### PR TITLE
[CMake] use source commit date as part of version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,9 @@ SET(KALMAR_VERSION_MINOR "10")
 
 # get date information based on UTC
 # use the last two digits of year + week number + day in the week as KALMAR_VERSION_PATCH
-execute_process(COMMAND date --utc +%y%W%w
+# use the commit date, instead of build date
+execute_process(COMMAND git show -s --format=@%ct
+                COMMAND date -f - --utc +%y%W%w
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                 OUTPUT_VARIABLE KALMAR_VERSION_PATCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
up until now we use hcc build date as part of version string, in this commit
we change to use source commit date