### PR TITLE
[GridLaunch] Fixes for anonymous namespace types

### DIFF
--- a/HC/DirectFuncCall/DirectFuncCall.cpp
+++ b/HC/DirectFuncCall/DirectFuncCall.cpp
@@ -31,6 +31,11 @@ namespace {
         {
           hasHCGridLaunchAttr = true;
 
+          // Anonymous arguments may cause clang to set the linkage to internal.
+          // This will interfere with clamp-link, causing a broken function.
+          // Force all GridLaunch kernels to use the default ExternalLinkage
+          F->setLinkage(GlobalValue::ExternalLinkage);
+
           // Attribute::NoInline is used to find the user of the function.
           // If inline is used, either forced or through optimziation, then this
           // pass will not be able to find a user to replace.

--- a/HC/WrapperGen/WrapperGen.cpp
+++ b/HC/WrapperGen/WrapperGen.cpp
@@ -390,8 +390,13 @@ struct StringFinder
       mArraySize = T->getArrayNumElements();
     }
 
-    if(str == "")
-      str.append("!UNKNOWN_TYPE_PLEASE_FIX!");
+    if(str == "") {
+      str.append("\'!UNKNOWN_TYPE: ");
+      llvm::raw_string_ostream rso(str);
+      T->print(rso);
+      rso.flush();
+      str.append("\'");
+    }
 
     return str;
 

--- a/HC/WrapperGen/WrapperGen.cpp
+++ b/HC/WrapperGen/WrapperGen.cpp
@@ -374,6 +374,9 @@ struct StringFinder
       // Remove other periods in the type name.
       std::replace(str.begin(), str.end(), '.', '_');
       std::replace(str.begin(), str.end(), ':', '_');
+      std::replace(str.begin(), str.end(), '(', '_');
+      std::replace(str.begin(), str.end(), ')', '_');
+      std::replace(str.begin(), str.end(), ' ', '_');
 
       // Rename struct so there won't be name conflicts during compilation
       // Linking should still resolve correctly as long as struct has POD members

--- a/tests/Unit/GridLaunch/customtype_byptr.cpp
+++ b/tests/Unit/GridLaunch/customtype_byptr.cpp
@@ -17,9 +17,11 @@ struct Bar {
   int x;
 };
 
-struct constStructconst {
-  int x;
-};
+namespace {
+  struct constStructconst {
+    int x;
+  };
+}
 
 #define GRID_SIZE 256
 #define TILE_SIZE 16


### PR DESCRIPTION
Types in anonymous namespaces are labeled with "(anonymous namespace)" string. This PR resolves the parenthesis and space characters when generating the GridLaunch wrapper.

Clang will sometimes mark the kernel function with InternalLinkage if the arguments contain types in anonymous namespaces. This will interfere with the opt passes in clamp-link. This PR also resolves that issue by forcing GridLaunch kernel functions to the default ExternalLinkage.

Finally, this PR adds some additional debugging information when a type is unknown.

***

Tests:

ROCK: master/b0b2dee
ROCR: master/de0d9b5
```
Failing Tests (4):                        
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp  
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp  
    CPPAMP :: Unit/HC/wg_size.cpp         
    CPPAMP :: Unit/HSAIL/shfl_xor.cpp     
                                          
  Expected Passes    : 663                
  Expected Failures  : 25                 
  Unsupported Tests  : 10                 
  Unexpected Failures: 4                  
```
master also seems to have the same failure rate.

***

HIP-privatestaging: privatestaging/31dc13d2
HIP-Examples-privatestaging: privatestaging/23c7882

All tests passed, except for hipHostRegister. Expected fail. 
All examples passed.
