### PR TITLE
[CMake] Autodetect HSA_AMDGPU_GPU_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,11 +276,12 @@ if (HSA_USE_AMDGPU_BACKEND)
   endif (NOT AMDPHDRS)
 endif ()
 
-set(HSA_AMDGPU_GPU_TARGET "kaveri" CACHE STRING "Target GPU device (kaveri,carrizo,fiji)")
+set(HSA_AMDGPU_GPU_TARGET "" CACHE STRING "Target GPU device (kaveri,carrizo,fiji)")
 
 if (NOT (HSA_AMDGPU_GPU_TARGET STREQUAL "kaveri" OR
          HSA_AMDGPU_GPU_TARGET STREQUAL "carrizo" OR
-         HSA_AMDGPU_GPU_TARGET STREQUAL "fiji"))
+         HSA_AMDGPU_GPU_TARGET STREQUAL "fiji" OR
+         HSA_AMDGPU_GPU_TARGET STREQUAL ""))
   MESSAGE(FATAL_ERROR "${HSA_AMDGPU_GPU_TARGET} is not a valid GPU")
 endif()
 

--- a/lib/clamp-hsatools.in
+++ b/lib/clamp-hsatools.in
@@ -71,13 +71,58 @@ if [ $KMDUMPLLVM == "1" ]; then
   cp $1.linked.bc ./dump.linked.bc
 fi
 
+TOPOLOGY_SYSFS_DIR=/sys/devices/virtual/kfd/kfd/topology/nodes
+
+# Prints GPU name for a given Device ID
+#   param - Device ID.
+deviceIdToGpuName() {
+    local deviceId=$1; shift;
+    local platformName=""
+    case $deviceId in
+        1304 | 1305 | 1306 | 1307 | 1309 | 130a | 130b | 130c | 130d | 130e | 130f | \
+        1310 | 1311 | 1312 | 1313 | 1315 | 1316 | 1317 | 1318 | 131b | 131c | 131d )
+            platformName="kaveri" ;;
+        9874 | 9875 | 9876 | 9877 )
+            platformName="carrizo" ;;
+        7300 )
+            platformName="fiji" ;;
+        * )
+            echo "Warning: failed to autodetect target, defaulting to fiji"
+            platformName="fiji" ;;
+    esac
+    echo "$platformName"
+}
+
+# Prints GPU Name for the given Node ID
+#   param - Node Path
+getNodeName() {
+    local nodePath=$1; shift;
+    local gpuIdInDec=$(cat $nodePath/properties | grep device_id | awk '{print $2}')
+    printf -v gpuIdInHex "%x" "$gpuIdInDec"
+    local gpuName=$(deviceIdToGpuName $gpuIdInHex)
+    echo "$gpuName"
+}
+
+# Prints the name of the first HSA node with a GPU associated with it
+getDefaultHsaNodeName() {
+    for i in $(find $TOPOLOGY_SYSFS_DIR  -maxdepth 1 -mindepth 1 -type d); do
+        local simdcount=$(cat $i/properties | grep simd_count | awk '{print $2}')
+        if [ $simdcount != 0 ]; then
+            echo "$(getNodeName $i)"
+            return
+        fi
+    done
+}
+
+HSA_AMDGPU_GPU_TARGET=@HSA_AMDGPU_GPU_TARGET@
+HSA_AMDGPU_GPU_TARGET="${HSA_AMDGPU_GPU_TARGET:-$(getDefaultHsaNodeName)}"
 
 # Optimization notes:
 #  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU 
 
 if [ $KM_USE_AMDGPU ]; then
   # KMOPTOPT can be used to pass last-minute options to opt in LC backend
-  $HLC_OPT $KMOPTOPT -O3 -mtriple amdgcn--amdhsa -mcpu=@HSA_AMDGPU_GPU_TARGET@ -disable-simplify-libcalls -verify $1.linked.bc -o $1.opt.bc
+  $HLC_OPT $KMOPTOPT -O3 -mtriple amdgcn--amdhsa -mcpu=$HSA_AMDGPU_GPU_TARGET -disable-simplify-libcalls -verify $1.linked.bc -o $1.opt.bc
 else
   $HLC_OPT -O3 -disable-simplify-libcalls -verify $1.linked.bc -o $1.opt.bc
 fi
@@ -93,9 +138,9 @@ if [ $KMDUMPLLVM == "1" ]; then
 fi
 
 if [ $KM_USE_AMDGPU  ]; then
-  $HLC_LLC -O2 -mtriple amdgcn--amdhsa -mcpu=@HSA_AMDGPU_GPU_TARGET@ -filetype=obj -o $1.hsail $1.opt.bc
+  $HLC_LLC -O2 -mtriple amdgcn--amdhsa -mcpu=$HSA_AMDGPU_GPU_TARGET -filetype=obj -o $1.hsail $1.opt.bc
   if [ $KMDUMPISA == "1" ]; then
-    $HLC_LLC -O2 -mtriple amdgcn--amdhsa -mcpu=@HSA_AMDGPU_GPU_TARGET@ -filetype=asm -o $1.isa $1.opt.bc
+    $HLC_LLC -O2 -mtriple amdgcn--amdhsa -mcpu=$HSA_AMDGPU_GPU_TARGET -filetype=asm -o $1.isa $1.opt.bc
     mv $1.isa ./dump.isa
   fi
 else


### PR DESCRIPTION
Instead of hardcoding the HSA_AMDGPU_GPU_TARGET at compile time,
autodetect it at runtime from the KFD topology.

Change-Id: I00af68084869ab4d439e70cf8816c1c8868f224d