### PR TITLE
Define const member function if needed

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -265,7 +265,7 @@ public:
      * Returns the maximum size of tile static area available on this
      * accelerator view.
      */
-    size_t get_max_tile_static_size() {
+    size_t get_max_tile_static_size() const {
         return pQueue.get()->getDev()->GetMaxTileStaticSize();
     }
 
@@ -276,7 +276,7 @@ public:
      * The number returned would be immediately obsolete. This functions shall
      * only be used for testing and debugging purpose.
      */
-    int get_pending_async_ops() {
+    int get_pending_async_ops() const {
         return pQueue->getPendingAsyncOps();
     }
 
@@ -286,7 +286,7 @@ public:
      * @return An opaque handle of the underlying HSA queue, if the accelerator
      *         view is based on HSA.  NULL if otherwise.
      */
-    void* get_hsa_queue() {
+    void* get_hsa_queue() const {
         return pQueue->getHSAQueue();
     }
 
@@ -296,7 +296,7 @@ public:
      * @return An opaque handle of the underlying HSA agent, if the accelerator
      *         view is based on HSA.  NULL otherwise.
      */
-    void* get_hsa_agent() {
+    void* get_hsa_agent() const {
         return pQueue->getHSAAgent();
     }
 
@@ -308,7 +308,7 @@ public:
      * @return An opaque handle of the region, if the accelerator is based
      *         on HSA.  NULL otherwise.
      */
-    void* get_hsa_am_region() {
+    void* get_hsa_am_region() const {
         return pQueue->getHSAAMRegion();
     }
 
@@ -321,7 +321,7 @@ public:
      * @return An opaque handle of the region, if the accelerator is based
      *         on HSA.  NULL otherwise.
      */
-    void* get_hsa_am_system_region() {
+    void* get_hsa_am_system_region() const {
         return pQueue->getHSAAMHostRegion();
     }
 
@@ -332,14 +332,14 @@ public:
      * @return An opaque handle of the region, if the accelerator view is based
      *         on HSA.  NULL otherwise.
      */
-    void* get_hsa_kernarg_region() {
+    void* get_hsa_kernarg_region() const {
         return pQueue->getHSAKernargRegion();
     }
 
     /**
      * Returns if the accelerator view is based on HSA.
      */
-    bool is_hsa_accelerator() {
+    bool is_hsa_accelerator() const {
         return pQueue->hasHSAInterOp();
     }
 
@@ -670,14 +670,14 @@ public:
      * Returns the maximum size of tile static area available on this
      * accelerator.
      */
-    size_t get_max_tile_static_size() {
+    size_t get_max_tile_static_size() const {
       return get_default_view().get_max_tile_static_size();
     }
   
     /**
      * Returns a vector of all accelerator_view associated with this accelerator.
      */
-    std::vector<accelerator_view> get_all_views() {
+    std::vector<accelerator_view> get_all_views() const {
         std::vector<accelerator_view> result;
         std::vector< std::shared_ptr<Kalmar::KalmarQueue> > queues = pDev->get_all_queues();
         for (auto q : queues) {
@@ -764,7 +764,7 @@ public:
      * Check if @p other is peer of this accelerator.
      *
      * @return true if other can access this accelerator's device memory pool or false if not.
-     * the acceleratos is its own peer.
+     * the accelerator is its own peer.
      */
     bool get_is_peer(const accelerator& other) const {
         return pDev->is_peer(other.pDev);
@@ -971,7 +971,7 @@ public:
      * this completion_future object. The method is mostly used for debugging
      * purpose.
      */
-    void* get_native_handle() {
+    void* get_native_handle() const {
       if (__asyncOp != nullptr) {
         return __asyncOp->getNativeHandle();
       } else {
@@ -1013,7 +1013,7 @@ public:
      * @return An implementation-defined frequency in Hz in case the instance is
      *         created by a kernel dispatch or a barrier packet. 0 otherwise.
      */
-    uint64_t get_tick_frequency() {
+    uint64_t get_tick_frequency() const {
       if (__asyncOp != nullptr) {
         return __asyncOp->getTimestampFrequency();
       } else {

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -65,7 +65,7 @@ struct rw_info;
 class KalmarAsyncOp {
 public:
   virtual ~KalmarAsyncOp() {} 
-  virtual std::shared_future<void>* getFuture() { return nullptr; }
+  virtual std::shared_future<void>* getFuture() const { return nullptr; }
   virtual void* getNativeHandle() { return nullptr;}
 
   /**
@@ -87,7 +87,7 @@ public:
    *
    * @return An implementation-defined frequency for the asynchronous operation.
    */
-  virtual uint64_t getTimestampFrequency() { return 0L; }
+  virtual uint64_t getTimestampFrequency() const { return 0L; }
 
   /**
    * Get if the async operations has been completed.
@@ -149,9 +149,9 @@ public:
   /// push device pointer to kernel argument list
   virtual void Push(void *kernel, int idx, void* device, bool modify) = 0;
 
-  virtual uint32_t GetGroupSegmentSize(void *kernel) { return 0; }
+  virtual uint32_t GetGroupSegmentSize(void *kernel) const { return 0; }
 
-  KalmarDevice* getDev() { return pDev; }
+  KalmarDevice* getDev() const { return pDev; }
   queuing_mode get_mode() const { return mode; }
   void set_mode(queuing_mode mod) { mode = mod; }
 
@@ -175,7 +175,7 @@ public:
   virtual void* getHSAKernargRegion() { return nullptr; }
 
   /// check if the queue is an HSA queue
-  virtual bool hasHSAInterOp() { return false; }
+  virtual bool hasHSAInterOp() const { return false; }
 
   /// enqueue marker
   virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarker() { return nullptr; }
@@ -278,7 +278,7 @@ public:
     }
 
     /// get max tile static area size
-    virtual size_t GetMaxTileStaticSize() { return 0; }
+    virtual size_t GetMaxTileStaticSize() const { return 0; }
 
     /// get all queues associated with this device
     virtual std::vector< std::shared_ptr<KalmarQueue> > get_all_queues() { return std::vector< std::shared_ptr<KalmarQueue> >(); }
@@ -287,13 +287,13 @@ public:
 
     virtual void memcpySymbol(void* symbolAddr, void* hostptr, size_t count, size_t offset = 0, hcMemcpyKind kind = hcMemcpyHostToDevice) {}
 
-    virtual void* getSymbolAddress(const char* symbolName) { return nullptr; }
+    virtual void* getSymbolAddress(const char* symbolName) const { return nullptr; }
 
     /// get underlying native agent handle
     virtual void* getHSAAgent() { return nullptr; }
 
     /// get the profile of the agent
-    virtual hcAgentProfile getProfile() { return hcAgentProfileNone; }
+    virtual hcAgentProfile getProfile() const { return hcAgentProfileNone; }
 
     /// check if @p other can access to this device's device memory, return true if so, false otherwise
     virtual bool is_peer(const KalmarDevice* other) {return false;}
@@ -376,7 +376,7 @@ protected:
 public:
     virtual ~KalmarContext() {}
 
-    std::vector<KalmarDevice*> getDevices() { return Devices; }
+    std::vector<KalmarDevice*> getDevices() const { return Devices; }
 
     /// set default device by path
     bool set_default(const std::wstring& path) {
@@ -410,10 +410,10 @@ public:
     }
 
     /// get system ticks
-    virtual uint64_t getSystemTicks() { return 0L; };
+    virtual uint64_t getSystemTicks() const { return 0L; };
 
     /// get tick frequency
-    virtual uint64_t getSystemTickFrequency() { return 0L; };
+    virtual uint64_t getSystemTickFrequency() const { return 0L; };
 };
 
 KalmarContext *getContext();
@@ -552,7 +552,7 @@ struct rw_info
     /// construct array
     /// According to AMP standard, array should be constructed with
     /// 1. one accelerator_view
-    /// 2. one acceleratir_view, with another staged one
+    /// 2. one accelerator_view, with another staged one
     ///    In this case, master should be cpu device
     ///    If it is not, ignore the stage one, fallback to case 1.
     rw_info(const std::shared_ptr<KalmarQueue>& Queue, const std::shared_ptr<KalmarQueue>& Stage,

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -215,7 +215,7 @@ private:
     Kalmar::HSAQueue* hsaQueue;
 
 public:
-    std::shared_future<void>* getFuture() override { return future; }
+    std::shared_future<void>* getFuture() const override { return future; }
 
     void* getNativeHandle() override { return &signal; }
 
@@ -257,7 +257,7 @@ public:
 
     void dispose();
 
-    uint64_t getTimestampFrequency() override {
+    uint64_t getTimestampFrequency() const override {
         // get system tick frequency
         uint64_t timestamp_frequency_hz = 0L;
         hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &timestamp_frequency_hz);
@@ -299,7 +299,7 @@ private:
     Kalmar::HSAQueue* hsaQueue;
 
 public:
-    std::shared_future<void>* getFuture() override { return future; }
+    std::shared_future<void>* getFuture() const override { return future; }
 
     void* getNativeHandle() override { return &signal; }
 
@@ -358,7 +358,7 @@ public:
 
     hsa_status_t dispatchKernelAsync(Kalmar::HSAQueue*);
 
-    uint32_t getGroupSegmentSize() {
+    uint32_t getGroupSegmentSize() const {
         hsa_status_t status = HSA_STATUS_SUCCESS;
         uint32_t group_segment_size = 0;
         status = hsa_executable_symbol_get_info(kernel->hsaExecutableSymbol,
@@ -376,7 +376,7 @@ public:
 
     void dispose();
 
-    uint64_t getTimestampFrequency() override {
+    uint64_t getTimestampFrequency() const override {
         // get system tick frequency
         uint64_t timestamp_frequency_hz = 0L;
         hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &timestamp_frequency_hz);
@@ -688,7 +688,7 @@ public:
         return sp_dispatch;
     }
 
-    uint32_t GetGroupSegmentSize(void *ker) override {
+    uint32_t GetGroupSegmentSize(void *ker) const override {
         HSADispatch *dispatch = reinterpret_cast<HSADispatch*>(ker);
         return dispatch->getGroupSegmentSize();
     }
@@ -886,7 +886,7 @@ public:
         }
     }
 
-    void* getHSAQueue() override {
+    void* getHSAQueue() const override {
         return static_cast<void*>(commandQueue);
     }
 
@@ -968,11 +968,11 @@ private:
 
 public:
  
-    uint32_t getWorkgroupMaxSize() {
+    uint32_t getWorkgroupMaxSize() const {
         return workgroup_max_size;
     }
 
-    const uint16_t* getWorkgroupMaxDim() {
+    const uint16_t* getWorkgroupMaxDim() const {
         return &workgroup_max_dim[0];
     }
 
@@ -1444,7 +1444,7 @@ public:
         return q;
     }
 
-    size_t GetMaxTileStaticSize() override {
+    size_t GetMaxTileStaticSize() const override {
         return max_tile_static_size;
     }
 
@@ -1491,7 +1491,7 @@ public:
       auto self_pool = getHSAAMRegion();
       hsa_amd_memory_pool_access_t access;
 
-      hsa_agent_t* agent = static_cast<hsa_agent_t*>( const_cast<KalmarDevice *> (other)->getHSAAgent());
+      hsa_agent_t* agent = static_cast<hsa_agent_t*>(const_cast<KalmarDevice*>(other)->getHSAAgent());
 
       //TODO: CPU acclerator will return NULL currently, return false.
       if(nullptr == agent)
@@ -1648,7 +1648,7 @@ public:
         return std::make_pair(ret, cursor);
     }
 
-    void* getSymbolAddress(const char* symbolName) override {
+    void* getSymbolAddress(const char* symbolName) const override {
         hsa_status_t status;
 
         unsigned long* symbol_ptr = nullptr;
@@ -2155,14 +2155,14 @@ public:
 #endif
     }
 
-    uint64_t getSystemTicks() override {
+    uint64_t getSystemTicks() const override {
         // get system tick
         uint64_t timestamp = 0L;
         hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP, &timestamp);
         return timestamp;
     }
 
-    uint64_t getSystemTickFrequency() override {
+    uint64_t getSystemTickFrequency() const override {
         // get system tick frequency
         uint64_t timestamp_frequency_hz = 0L;
         hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &timestamp_frequency_hz);


### PR DESCRIPTION
We define void* as the handle of i.e. queue, device, etc. And internally, it is a pointer to class member.

1. We will expose class member to outside, but good news is, we expose void*, and does not expose its  data type.

2. Make it hard to define getter method to const, because it also needs to declare the return value to be const too, then, cast from "a pointer to a constant member" to void*, which will also request const_cast.

In this change, only change what is easy, and for others, we may need to change the architect, which is not expected I believe.