### PR TITLE
clamp-hsatools: Use lld as the liner for AMDGPU

### DIFF
--- a/lib/clamp-hsatools.in
+++ b/lib/clamp-hsatools.in
@@ -47,7 +47,7 @@ fi
 HSA_USE_AMDGPU_BACKEND=@HSA_USE_AMDGPU_BACKEND@
 
 if [ $HSA_USE_AMDGPU_BACKEND == "ON" ]; then
-  LLD=@AMDPHDRS@
+  LLD=@HSA_LLVM_BIN_DIR@/ld.lld
   KM_USE_AMDGPU="${KM_USE_AMDGPU:=1}"
 fi
 
@@ -113,7 +113,7 @@ if [ $KMDUMPBRIG == "1" ]; then
 fi
 
 if [ $KM_USE_AMDGPU ]; then
-  $LLD  $1.hsail $1.brig
+  $LLD  -shared $1.hsail -o $1.brig
 else
   cat $NEWLIB/hsa_builtins.hsail >> $1.hsail
   $HLC_ASM -assemble -o $1.brig $1.hsail


### PR DESCRIPTION
We need to wait until co-v2 support lands in LLVM before merging this.