### PR TITLE
Fixes to unit tests for LC backend

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -77,9 +77,9 @@
 #define USE_MD5_HASH (0)
 
 // cutoff size used in FNV-1a hash function
-// default set as 512, this is a heuristic value
+// default set as 768, this is a heuristic value
 // which is larger than HSA BrigModuleHeader and AMD GCN ISA header (Elf64_Ehdr)
-#define FNV1A_CUTOFF_SIZE (512)
+#define FNV1A_CUTOFF_SIZE (768)
 
 static const char* getHSAErrorString(hsa_status_t s) {
 

--- a/tests/Unit/AmpMath/amp_math_erf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erf_precise_math.cpp
@@ -52,8 +52,13 @@ bool test() {
 int main(void) {
   bool ret = true;
 
+#if __hcc_backend__ == HCC_BACKEND_AMDGPU
+  // XXX the test will hang if compiled with LC backend
+  ret = false;
+#else
   ret &= test<float>();
   ret &= test<double>();
+#endif
 
   return !(ret == true);
 }

--- a/tests/Unit/AmpMath/amp_math_erfc_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erfc_precise_math.cpp
@@ -52,8 +52,13 @@ bool test() {
 int main(void) {
   bool ret = true;
 
+#if __hcc_backend__ == HCC_BACKEND_AMDGPU
+  // XXX the test will hang if compiled with LC backend
+  ret = false;
+#else
   ret &= test<float>();
   ret &= test<double>();
+#endif
 
   return !(ret == true);
 }


### PR DESCRIPTION
This pull request consists fixes in runtime and unit tests for LC backend.

Failing HCC unit tests with HSAIL backend
======================================
    CPPAMP :: Unit/HSAIL/shfl_xor.cpp

@scchan is working on getting this fixed


Failing HCC unit tests with LC backend
======================================

    CPPAMP :: Unit/AmpMath/amp_math_erf_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_erfc_precise_math.cpp

Binaries for these 2 tests would run indefinitely. They pass if compiled with HSAIL backend.
Temporary let them fail immediately if compiled with LC backend.


    CPPAMP :: Unit/AmpMath/amp_math_hypot_precise_math.cpp

Incorrect result with LC backend. It passes with HSAIL backend.

    
    CPPAMP :: Unit/DynamicTileStatic/test11.cpp
    CPPAMP :: Unit/DynamicTileStatic/test12.cpp
    CPPAMP :: Unit/DynamicTileStatic/test13.cpp
    CPPAMP :: Unit/DynamicTileStatic/test6.cpp
    CPPAMP :: Unit/HC/get_group_segment_sizes.cpp
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp
    CPPAMP :: Unit/HC/memcpy_symbol2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp
    CPPAMP :: Unit/HC/memcpy_symbol4.cpp

Tests related with dynamic LDS. Will get fix after getting dynamic LDS properly implemented. They all pass if compiled with HSAIL backend.


    CPPAMP :: Unit/HSAIL/activelaneid.cpp
    CPPAMP :: Unit/HSAIL/activelanepermute.cpp
    CPPAMP :: Unit/HSAIL/shfl.cpp
    CPPAMP :: Unit/HSAIL/shfl_down.cpp
    CPPAMP :: Unit/HSAIL/shfl_up.cpp
    CPPAMP :: Unit/HSAIL/shfl_xor.cpp
    CPPAMP :: Unit/HSAIL/wavesize.cpp

Compile error with LC backend. Other than shfl_xor, they all pass if compiled with HSAIL backend. @scchan is working on fixing these now.
    
    CPPAMP :: Unit/ParallelSTL/sort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdvector.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdvector.cpp

Compile error with LC backend. They all pass if compiled with HSAIL backend. Presumably codegen issue in LC backend.