### PR TITLE
various fixes for shfl unit tests, added  __wavesize for lc

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1903,7 +1903,7 @@ extern "C" unsigned int __wavesize() __HC__;
 
 
 #if __hcc_backend__==HCC_BACKEND_AMDGPU
-extern "C" unsigned int __wavesize() __HC__ {
+extern "C" inline unsigned int __wavesize() __HC__ {
   return __HSA_WAVEFRONT_SIZE__;
 }
 #endif

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1898,7 +1898,10 @@ tiled_extent<3> extent<N>::tile(int t0, int t1, int t2) const __CPU__ __HC__ {
  *
  * @return The size of a wavefront.
  */
-extern "C" unsigned int __wavesize() __HC__;
+#define __HSA_WAVEFRONT_SIZE__ (64)
+unsigned int __wavesize() __HC__ {
+  return __HSA_WAVEFRONT_SIZE__;
+}
 
 /**
  * Count number of 1 bits in the input
@@ -2330,8 +2333,6 @@ extern "C" inline uint64_t __ballot(int predicate) __HC__ {
 // ------------------------------------------------------------------------
 // Wavefront Shuffle Functions
 // ------------------------------------------------------------------------
-
-#define __HSA_WAVEFRONT_SIZE__ (64)
 
 // utility union type
 union __u {

--- a/include/hc_defines.h
+++ b/include/hc_defines.h
@@ -79,7 +79,7 @@ class auto_voidp {
 
 // Valid values for__hcc_backend__ to indicate the
 // compiler backend
-#define HCC_BACKEND_AMDGPU 1
-#define HCC_BACKEND_HSAIL  2
-#define HCC_BACKEND_CL     3
+#define HCC_BACKEND_AMDGPU (1)
+#define HCC_BACKEND_HSAIL  (2)
+#define HCC_BACKEND_CL     (3)
 

--- a/tests/Unit/HSAIL/activelaneid.cpp
+++ b/tests/Unit/HSAIL/activelaneid.cpp
@@ -1,4 +1,4 @@
-// XFAIL: Linux
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 
 #include <hc.hpp>

--- a/tests/Unit/HSAIL/activelanepermute.cpp
+++ b/tests/Unit/HSAIL/activelanepermute.cpp
@@ -1,4 +1,4 @@
-// XFAIL: Linux
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 
 #include <hc.hpp>

--- a/tests/Unit/HSAIL/shfl.cpp
+++ b/tests/Unit/HSAIL/shfl.cpp
@@ -26,7 +26,7 @@ bool test__shfl(int grid_size, T arg) {
   // broadcast of a single value across a wavefront
   parallel_for_each(ex, [&, arg](index<1>& idx) [[hc]] {
     T value = T();
-    if (__activelaneid_u32() == 0)
+    if (__lane_id() == 0)
       value = arg;
     value = __shfl(value, 0);
     table(idx) = value;
@@ -58,7 +58,7 @@ bool test__shfl2(int grid_size, int sub_wavefront_width, T arg) {
   // broadcast of a single value across a sub-wavefront
   parallel_for_each(ex, [&, arg, sub_wavefront_width](index<1>& idx) [[hc]] {
     T value = T();
-    unsigned int laneId = __activelaneid_u32();
+    unsigned int laneId = __lane_id();
     // each subsection of a wavefront would have a different test value
     if (laneId % sub_wavefront_width == 0)
       value = (arg + laneId / sub_wavefront_width);

--- a/tests/Unit/HSAIL/shfl_down.cpp
+++ b/tests/Unit/HSAIL/shfl_down.cpp
@@ -25,7 +25,7 @@ bool test__shfl_down(int grid_size, int offset, T init_value) {
 
   // shift values down in a wavefront
   parallel_for_each(ex, [&, offset, init_value](index<1>& idx) [[hc]] {
-    T value = init_value + __activelaneid_u32();
+    T value = init_value + __lane_id();
     value = __shfl_down(value, offset);
     table(idx) = value;
   }).wait();
@@ -58,7 +58,7 @@ bool test__shfl_down2(int grid_size, int sub_wavefront_width, int offset, T init
 
   // shift values down in a wavefront, divided into subsections
   parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](index<1>& idx) [[hc]] {
-    T value = init_value + (__activelaneid_u32() % sub_wavefront_width);
+    T value = init_value + (__lane_id() % sub_wavefront_width);
     value = __shfl_down(value, offset, sub_wavefront_width);
     table(idx) = value;
   }).wait();

--- a/tests/Unit/HSAIL/shfl_up.cpp
+++ b/tests/Unit/HSAIL/shfl_up.cpp
@@ -25,7 +25,7 @@ bool test__shfl_up(int grid_size, int offset, T init_value) {
 
   // shift values up in a wavefront
   parallel_for_each(ex, [&, offset, init_value](index<1>& idx) [[hc]] {
-    T value = init_value + __activelaneid_u32();
+    T value = init_value + __lane_id();
     value = __shfl_up(value, offset);
     table(idx) = value;
   }).wait();
@@ -56,7 +56,7 @@ bool test__shfl_up2(int grid_size, int sub_wavefront_width, int offset, T init_v
 
   // shift values up in a wavefront, divided into subsections
   parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](index<1>& idx) [[hc]] {
-    T value = init_value + (__activelaneid_u32() % sub_wavefront_width);
+    T value = init_value + (__lane_id() % sub_wavefront_width);
     value = __shfl_up(value, offset, sub_wavefront_width);
     table(idx) = value;
   }).wait();
@@ -84,7 +84,7 @@ bool test_scan(int grid_size, int sub_wavefront_width) {
   array<int, 1> table(grid_size);
 
   parallel_for_each(ex, [&, sub_wavefront_width](index<1>& idx) [[hc]] {
-    int laneId = __activelaneid_u32();
+    int laneId = __lane_id();
     int logicalLaneId = laneId % sub_wavefront_width;
     int value = (WAVEFRONT_SIZE - 1) - laneId;
 

--- a/tests/Unit/HSAIL/shfl_xor.cpp
+++ b/tests/Unit/HSAIL/shfl_xor.cpp
@@ -22,7 +22,7 @@ bool test_reduce(int grid_size) {
   array<int, 1> table(grid_size);
 
   parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
-    int laneId = __activelaneid_u32();
+    int laneId = __lane_id();
     int value = (WAVEFRONT_SIZE - 1) - laneId;
 
     // use xor mode to perform butterfly reduction


### PR DESCRIPTION
- added __lane_id() and changed a few unit tests to use lane_id
- added __wavesize() for LC
- fixed shfl_xor on hsail


********************
Testing Time: 193.42s
********************
Failing Tests (24):
    CPPAMP :: Unit/AmpMath/amp_math_erf_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_erfc_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_hypot_precise_math.cpp
    CPPAMP :: Unit/AmpShortVectors/hc_short_vector_device.cpp
    CPPAMP :: Unit/DynamicTileStatic/test11.cpp
    CPPAMP :: Unit/DynamicTileStatic/test12.cpp
    CPPAMP :: Unit/DynamicTileStatic/test13.cpp
    CPPAMP :: Unit/DynamicTileStatic/test6.cpp
    CPPAMP :: Unit/GridLaunch/linkobj.cpp
    CPPAMP :: Unit/HC/get_group_segment_sizes.cpp
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp
    CPPAMP :: Unit/HC/memcpy_symbol2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp
    CPPAMP :: Unit/HC/memcpy_symbol4.cpp
    CPPAMP :: Unit/HSAIL/activelaneid.cpp
    CPPAMP :: Unit/HSAIL/activelanepermute.cpp
    CPPAMP :: Unit/ParallelSTL/sort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdvector.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdvector.cpp
    CPPAMP :: Unit/SharedLibrary/shared_library2.cpp
    CPPAMP :: Unit/SharedLibrary/shared_library3.cpp

  Expected Passes    : 647
  Expected Failures  : 25
  Unsupported Tests  : 10
  Unexpected Failures: 24



HSAIL:

scchan@fd88c90d25ed:~/code/github/radeonopencompute/hcc.develop/build.hsail$ make test
[100%] Running HCC regression tests
llvm-lit: lit.cfg:115: note: using clang: '/home/scchan/code/github/radeonopencompute/hcc.develop/build.hsail/compiler/bin/clang'
Testing Time: 135.46s
  Expected Passes    : 671
  Expected Failures  : 25
  Unsupported Tests  : 10
[100%] Built target test
