### PR TITLE
Revert "[builtin][LC] use inline assembly for 32-bit FMA operation"

### DIFF
--- a/lib/hsail-amdgpu-wrapper.ll
+++ b/lib/hsail-amdgpu-wrapper.ll
@@ -146,12 +146,8 @@ declare double @llvm.floor.f64(double) #1
 
 ; Function Attrs: alwaysinline nounwind readnone
 define linkonce_odr spir_func float @__hsail_fma_f32(float, float, float) #2 {
-  ; Use inline assembly to leverage v_mad_f32 which offers better precision than @llvm.fma.f32()
-  %ret = tail call float asm "v_mad_f32 $0, $1, $2, $3", "=v,v,v,v"(float %0, float %1, float %2) #
-  ret float %ret
-
-  ;%4 = call float @llvm.fma.f32(float %0, float %1, float %2)
-  ;ret float %4
+  %4 = call float @llvm.fma.f32(float %0, float %1, float %2)
+  ret float %4
 }
 
 ; Function Attrs: nounwind readnone


### PR DESCRIPTION
This reverts commit 0213640450ee5af2a50643e5bf6e93c74c3bdd18.

This is entirely incorrect. v_mad_f32 is not equivalent to fma.
We also very much do not want to be using inline asm for common
operations.