### PR TITLE
Fix handling of invalid/missing tests

### DIFF
--- a/amp-conformance/output-to-junit.pl
+++ b/amp-conformance/output-to-junit.pl
@@ -57,6 +57,8 @@ while ( <STDIN> ) {
         $result = '<skipped/>';
       } elsif ($1 eq 'failed') {
         $result = '<failure/>';
+      } elsif ($1 eq 'invalid or cannot open') {
+        $result = '<failure/>';
       }
       next;
     }

--- a/amp-conformance/run_tests.pl.in
+++ b/amp-conformance/run_tests.pl.in
@@ -98,7 +98,9 @@ if (@ARGV[1]) {
     open(TESTLIST, @ARGV[1]) or &exit_message(1, "Cannot open test list: @ARGV[1]");
     while(<TESTLIST>) {
         chomp;
-        push @tests, abs_path($tests_root."/".$_);
+        if (-e $tests_root."/".$_) {
+            push @tests, abs_path($tests_root."/".$_);
+        }
     }
     close(TESTLIST);
     $has_test_list=1;
@@ -136,12 +138,13 @@ foreach my $test (@tests)
 sub run_test {
     my ($test) = @_;
 
-    log_message("Test: $test");
-
     if (not $test)
     {
+       log_message("Test: N/A");
        goto continue_ite;
     }
+
+    log_message("Test: $test");
     my $test_exec = "$tmpdir/test.out";
     if ($use_threads) {
         {lock($test_id); $test_exec.=$test_id; $test_id++;}


### PR DESCRIPTION
If a test list is passed in, and the test is not present, the system
will try to execute that test and return "Invalid or cannot open" .
This will cause the test_results.xml file to truncate at the invalid
test. Handle a non-existent test and ensure that the test is present
before adding it to the list of tests.

Change-Id: Ib9b368aa29f1c8de25b62760d771b05f8054a9a9