### PR TITLE
Add test cases for calling a member function with hc attribute inside a GridLaunch kernel

### DIFF
--- a/tests/Unit/GridLaunch/customtype_byval.cpp
+++ b/tests/Unit/GridLaunch/customtype_byval.cpp
@@ -22,8 +22,8 @@ public:
   int a;
   int b;
   Foo2 foo2;
-  int getX() { return x;}
-  int getY() { return y;}
+  [[hc]][[cpu]] int getX() { return x;}
+  [[hc]][[cpu]] int getY() { return y;}
 };
 
 struct Bar {

--- a/tests/Unit/GridLaunch/hc_attr_in_struct.cpp
+++ b/tests/Unit/GridLaunch/hc_attr_in_struct.cpp
@@ -1,0 +1,49 @@
+// XFAIL: Linux
+// RUN: %hc -lhc_am %s -o %t.out && %t.out
+
+#include "hc.hpp"
+#include "grid_launch.hpp"
+#include "hc_am.hpp"
+
+struct Foo
+{
+  int m_bar = 5;
+
+  __attribute__((hc)) int bar(int a)
+  {
+    return a+m_bar;
+  }
+};
+
+__attribute__((hc_grid_launch)) void kernel(const grid_launch_parm lp, const int a, int* data_d)
+{
+  Foo foo;
+  data_d[0] = foo.bar(a);
+}
+
+int main() {
+
+  auto acc = hc::accelerator();
+  int* data1_d = (int*)hc::am_alloc(sizeof(int), acc, 0);
+
+  grid_launch_parm lp;
+  grid_launch_init(&lp);
+  lp.gridDim = gl_dim3(1);
+  lp.groupDim = gl_dim3(1);
+  static hc::accelerator_view av = hc::accelerator().get_default_view();
+
+  lp.cf = NULL;
+  lp.av = &av;
+
+  const int a = 1;
+  kernel(lp, a, data1_d);
+
+  int data1 = 0;
+  hc::am_copy(&data1, data1_d, sizeof(int));
+
+  // Verify results
+  Foo foo;
+  return !(data1 == (a+foo.m_bar));
+
+}
+


### PR DESCRIPTION
This pull request tests the corresponding commit from hcc-clang repo.
The test case is adapted from [Issue #24](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP/issues/24).

make test:

```
Testing Time: 264.60s
  Expected Passes    : 676
  Expected Failures  : 25
  Unsupported Tests  : 10
[100%] Built target test
```

***
HIP-privatestaging/privatestaging/4d8e2d79 test cases:

```
37/37 Test #37: hipDynamicShared.tst ...................***Exception: Other  0.10 sec

97% tests passed, 1 tests failed out of 37

Total Test time (real) =  33.81 sec

The following tests FAILED:
         37 - hipDynamicShared.tst (OTHER_FAULT)
```

***
HIP-Examples-privatestaging/privatestaging/481050f4
Most tests pass with the following exceptions:
The following were skipped because they appear to break ssh sessions and in turn were not able to run pass the 2GB case. All the data sizes before the 2GB case have the correct output.
reduction
cuda-stream

Rodinia:
All pass except:
b+tree
heartwall
The above appears to fail in hcc/develop/1e82305 commit too.