### PR TITLE
[hcc rt] clear the dependent aysnc op vector correctly

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -759,7 +759,7 @@ public:
 
     // wait for dependent async operations to complete
     void waitForDependentAsyncOps(void* buffer) {
-        auto dependentAsyncOpVector = bufferKernelMap[buffer];
+        auto &dependentAsyncOpVector = bufferKernelMap[buffer];
         for (int i = 0; i < dependentAsyncOpVector.size(); ++i) {
           auto dependentAsyncOp = dependentAsyncOpVector[i];
           if (!dependentAsyncOp.expired()) {


### PR DESCRIPTION
clear the dependency vector instead of its copy