### PR TITLE
Fix performance problem when launching lots of kernels

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -755,7 +755,7 @@ public:
 
     // wait for dependent async operations to complete
     void waitForDependentAsyncOps(void* buffer) {
-        auto dependentAsyncOpVector = bufferKernelMap[buffer];
+        auto&& dependentAsyncOpVector = bufferKernelMap[buffer];
         for (int i = 0; i < dependentAsyncOpVector.size(); ++i) {
           auto dependentAsyncOp = dependentAsyncOpVector[i];
           if (!dependentAsyncOp.expired()) {


### PR DESCRIPTION
This fixes a problem where the `dependentAsyncOpVector` in the `bufferKernelMap` is never cleared, instead just a local copy is cleared. This drastically improves performances when the program launches a lot of kernels.