### PR TITLE
added fix for signal overflow for kernels

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2627,11 +2627,7 @@ HSADispatch::dispatchKernelAsync(Kalmar::HSAQueue* hsaQueue) {
 inline void
 HSADispatch::dispose() {
     hsa_status_t status;
-    if (kernargMemory != nullptr) {
-      device->releaseKernargBuffer(kernargMemory, kernargMemoryIndex);
-      kernargMemory = nullptr;
-    }
-
+    
     clearArgs();
     std::vector<uint8_t>().swap(arg_vec);
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -386,7 +386,10 @@ public:
             status = waitComplete();
             STATUS_CHECK(status, __LINE__);
         }
-        dispose();
+        if(future != nullptr){
+            delete future;
+            future = nullptr;
+        }
     }
 
     hsa_status_t setDynamicGroupSegment(size_t dynamicGroupSize) {
@@ -2557,7 +2560,7 @@ HSADispatch::waitComplete() {
         printf("Signal wait returned unexpected value\n");
         exit(0);
     }
-
+    dispose();
 #if KALMAR_DEBUG
     std::cerr << "complete!\n";
 #endif
@@ -2634,10 +2637,6 @@ HSADispatch::dispose() {
 
     Kalmar::ctx.releaseSignal(signal, signalIndex);
 
-    if (future != nullptr) {
-      delete future;
-      future = nullptr;
-    }
 }
 
 inline uint64_t


### PR DESCRIPTION
With this change, errors and bad dmesg errors generated by HIP samples which launch more than 32k kernels is fixed.