### PR TITLE
compile hcc-config and clamp-config in non-amp mode

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,16 +1,17 @@
 ####################
+# C++AMP config (clamp-config)
+####################
+add_config_executable(clamp-config mcwamp_main.cpp)
+add_config_executable(hcc-config mcwamp_main.cpp)
+
+####################
 # C++AMP runtime (mcwamp)
 ####################
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_mcwamp_library(mcwamp mcwamp.cpp)
 add_mcwamp_library(mcwamp_atomic mcwamp_atomic.cpp)
 
-####################
-# C++AMP config (clamp-config)
-####################
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-add_mcwamp_executable(clamp-config mcwamp_main.cpp)
-add_mcwamp_executable(hcc-config mcwamp_main.cpp)
-install(TARGETS mcwamp clamp-config hcc-config mcwamp_atomic
+install(TARGETS clamp-config hcc-config mcwamp mcwamp_atomic
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -72,6 +72,7 @@ endmacro(add_mcwamp_library_hsa name )
 ####################
 # C++AMP config (clamp-config)
 ####################
+
 macro(add_mcwamp_executable name )
   link_directories(${LIBCXX_LIB_DIR} ${LIBCXXRT_LIB_DIR})
   CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
@@ -86,4 +87,15 @@ macro(add_mcwamp_executable name )
   else (APPLE)
     target_link_libraries( ${name} mcwamp dl pthread c++abi)
   endif (APPLE)
+endmacro(add_mcwamp_executable name )
+
+
+macro(add_config_executable name )
+  CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  set(CMAKE_CXX_FLAGS "-std=c++11" )
+  add_executable( ${name} ${ARGN} )
+
+  # LLVM and Clang shall be compiled beforehand
+  add_dependencies(${name} llvm-link opt clang)
 endmacro(add_mcwamp_executable name )


### PR DESCRIPTION
This removes the dependency on hcc runtime