### PR TITLE
Fixed KALMAR_VERSION_PATCH computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ SET(KALMAR_VERSION_MINOR "10")
 # add xargs to remove strange trailing newline character
 execute_process(COMMAND git show -s --format=@%ct
                 COMMAND xargs
-                COMMAND date -f - --utc +%y%W%w
+                COMMAND date -f - --utc +%y%U%w
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                 OUTPUT_VARIABLE KALMAR_VERSION_PATCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
The computation for KALMAR_VERSION_PATCH was incorrectly using +%y%W%w for formatting the date whereas it should be +%y%U%w.