### PR TITLE
define __hcc_backend__ to HCC_BACKEND_AMDGPU in doxygen

### DIFF
--- a/lib/doxygen_config.in
+++ b/lib/doxygen_config.in
@@ -1935,7 +1935,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = restrict()=
+PREDEFINED             = restrict()= \
+                         __hcc_backend__=HCC_BACKEND_AMDGPU
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
this is needed for doxygen to generate docs for builtins that are only available to amdgpu backend