### PR TITLE
Replace hsa_memory_copy

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1073,6 +1073,38 @@ public:
         dependentAsyncOpVector.clear();
     }
 
+
+    void sync_copy(void* dst, hsa_agent_t dst_agent,
+                   const void* src, hsa_agent_t src_agent,
+                   size_t size) {
+
+#if KALMAR_DEBUG
+      dumpHSAAgentInfo(src_agent, "sync_copy source agent");
+      dumpHSAAgentInfo(dst_agent, "sync_copy destination agent");
+#endif
+
+      hsa_status_t status;
+
+      hsa_signal_t completion_signal = {0};
+      status = hsa_signal_create(0, 0, NULL, &completion_signal);
+      STATUS_CHECK(status, __LINE__);
+      hsa_signal_store_relaxed(completion_signal, 1);
+
+      status = hsa_amd_memory_async_copy(dst, dst_agent,
+                                          src, src_agent,
+                                          size, 0, nullptr, completion_signal);
+
+      
+      hsa_wait_state_t waitMode = HSA_WAIT_STATE_BLOCKED;
+      hsa_signal_wait_acquire(completion_signal, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, waitMode);
+
+
+      hsa_signal_destroy(completion_signal);
+      STATUS_CHECK(status, __LINE__);
+      
+      return;
+    }
+
     void read(void* device, void* dst, size_t count, size_t offset) override {
         waitForDependentAsyncOps(device);
 
@@ -1100,8 +1132,9 @@ public:
                     STATUS_CHECK(status, __LINE__);
                     va = dst;
                 }
-                status = hsa_memory_copy(va, (char*)device + offset, count);
-                STATUS_CHECK(status, __LINE__);
+
+                sync_copy(va, *static_cast<hsa_agent_t*>(getHostAgent()),  (char*)device + offset, *static_cast<hsa_agent_t*>(getHSAAgent()), count);
+
                 // Unlock the host memory
                 status = hsa_amd_memory_unlock(dst);
             } else {
@@ -1125,20 +1158,18 @@ public:
                 hsa_status_t status = HSA_STATUS_SUCCESS;
                 // Make sure host memory is accessible to gpu
                 // FIXME: host memory is allocated through OS allocator, if not, correct it.
-                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent());
-                void* va = nullptr;
-                status = hsa_amd_memory_lock(const_cast<void*>(src), count, agent, 1, &va);
-
+                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent()); 
+                const void* va = nullptr;
+                status = hsa_amd_memory_lock(const_cast<void*>(src), count, agent, 1, (void**)&va);
+                  
                 if(va == NULL || status != HSA_STATUS_SUCCESS)
                 {
                     status = hsa_amd_agents_allow_access(1, agent, NULL, src);
                     STATUS_CHECK(status, __LINE__);
-                    status = hsa_memory_copy((char*)device + offset, src, count);
-                    STATUS_CHECK(status, __LINE__);
-                    return;
+                    va = src;
                 }
+                sync_copy(((char*)device) + offset,  *agent, va,    *static_cast<hsa_agent_t*>(getHostAgent()), count);
 
-                status = hsa_memory_copy((char*)device + offset, va, count);
                 STATUS_CHECK(status, __LINE__);
                 // Unlock the host memory
                 status = hsa_amd_memory_unlock(const_cast<void*>(src));
@@ -1151,6 +1182,9 @@ public:
         }
     }
 
+
+
+    //FIXME: this API doesn't work in the P2P world because we don't who the source agent is!!!
     void copy(void* src, void* dst, size_t count, size_t src_offset, size_t dst_offset, bool blocking) override {
         waitForDependentAsyncOps(dst);
         waitForDependentAsyncOps(src);
@@ -1200,12 +1234,23 @@ public:
             status = hsa_amd_memory_pool_allocate(*am_host_region, count, 0, &data);
             STATUS_CHECK(status, __LINE__);
             if (data != nullptr) {
+#if KALMAR_DEBUG
+            std::wcerr << getDev()->get_path();
+            std::cerr << ": map() allow device access to mapped buffer\n";
+#endif
               // copy data from device buffer to host buffer
               hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent());
               status = hsa_amd_agents_allow_access(1, agent, NULL, data);
               STATUS_CHECK(status, __LINE__);
-              status = hsa_memory_copy(data, (char*)device + offset, count);
-              STATUS_CHECK(status, __LINE__);
+#if KALMAR_DEBUG
+                std::wcerr << getDev()->get_path();
+                std::cerr << ": map() copy device buffer to host buffer\n";
+#endif
+                sync_copy(data, *static_cast<hsa_agent_t*>(getHostAgent()), ((char*)device) + offset, *agent, count);
+#if KALMAR_DEBUG
+                std::wcerr << getDev()->get_path();
+                std::cerr << ": map() copy done\n";
+#endif
             } else {
 #if KALMAR_DEBUG
               std::cerr << "host buffer allocation failed!\n";
@@ -1244,12 +1289,18 @@ public:
 #endif
             if (modify) {
 #if KALMAR_DEBUG
-                std::cerr << "copy host buffer to device buffer\n";
+                std::wcerr << getDev()->get_path();
+                std::cerr << ": unmap() copy host buffer to device buffer\n";
 #endif
                 // copy data from host buffer to device buffer
                 hsa_status_t status = HSA_STATUS_SUCCESS;
-                status = hsa_memory_copy((char*)device + offset, addr, count);
-                STATUS_CHECK(status, __LINE__);
+
+                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent()); 
+                sync_copy(((char*)device) + offset, *agent, addr, *static_cast<hsa_agent_t*>(getHostAgent()), count);
+#if KALMAR_DEBUG
+                std::wcerr << getDev()->get_path();
+                std::cerr << ": unmap() copy done\n";
+#endif
             }
 
             // deallocate the host buffer
@@ -1279,6 +1330,8 @@ public:
     }
 
     void* getHSAAgent() override;
+
+    void* getHostAgent() override;
 
     void* getHSAAMRegion() override;
 
@@ -1482,13 +1535,19 @@ public:
     // we save the pools we care about into this structure.
     static hsa_status_t get_memory_pools(hsa_amd_memory_pool_t region, void* data)
     {
-
+        hsa_status_t status;
         hsa_amd_segment_t segment;
-        hsa_amd_memory_pool_get_info(region, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment);
+        status = hsa_amd_memory_pool_get_info(region, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment);
+        if (status != HSA_STATUS_SUCCESS) {
+          return status;
+        }
 
         if (segment == HSA_AMD_SEGMENT_GLOBAL) {
           size_t size = 0;
-          hsa_amd_memory_pool_get_info(region, HSA_AMD_MEMORY_POOL_INFO_SIZE, &size);
+          status = hsa_amd_memory_pool_get_info(region, HSA_AMD_MEMORY_POOL_INFO_SIZE, &size);
+          if (status != HSA_STATUS_SUCCESS) {
+            return status;
+          }
 #if KALMAR_DEBUG
           std::cerr << "found memory pool of GPU local memory, size(MB) = " << (size/(1024*1024)) << std::endl;
 #endif
@@ -2790,7 +2849,10 @@ inline void*
 HSAQueue::getHSAAgent() override {
     return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getAgent()));
 }
-
+inline void*
+HSAQueue::getHostAgent() override {
+    return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHostAgent()));
+}
 inline void*
 HSAQueue::getHSAAMRegion() override {
     return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHSAAMRegion()));

--- a/tests/Unit/HC/multi_acc.cpp
+++ b/tests/Unit/HC/multi_acc.cpp
@@ -1,0 +1,97 @@
+// XFAIL: Linux
+// RUN: %hc %s -o %t.out && %t.out
+#include <random>
+#include <algorithm>
+#include <vector>
+#include <iostream>
+#include <cmath>
+
+// header file for the hc API
+#include <hc.hpp>
+
+int main() {
+
+  constexpr int N = 1024 * 1024 * 256;
+  constexpr float a = 100.0f;
+
+  std::vector<float> host_x(N);
+  std::vector<float> host_y(N);
+
+  // initialize the input data
+  std::default_random_engine random_gen;
+  std::uniform_real_distribution<float> distribution(-N, N);
+  std::generate(host_x.begin(), host_x.end(), [&]() { return distribution(random_gen); });
+  std::generate(host_y.begin(), host_y.end(), [&]() { return distribution(random_gen); });
+
+  // CPU implementation of saxpy
+  std::vector<float> host_result_y(N);
+  for (int i = 0; i < N; i++) {
+    host_result_y[i] = a * host_x[i] + host_y[i];
+  }
+  
+  std::vector<hc::accelerator> all_accelerators = hc::accelerator::get_all();
+  std::vector<hc::accelerator> accelerators;
+  for (auto a = all_accelerators.begin(); a != all_accelerators.end(); a++) {
+
+    // only pick accelerators supported by the HSA runtime
+    if (a->is_hsa_accelerator()) {
+      accelerators.push_back(*a);
+    }
+  }
+
+  constexpr int numViewPerAcc = 2;
+  int numSaxpyPerView = N/(accelerators.size() * numViewPerAcc);
+
+  std::vector<hc::accelerator_view> acc_views;
+  std::vector<hc::array_view<float,1>> x_views;
+  std::vector<hc::array_view<float,1>> y_views;
+  std::vector<hc::completion_future> futures;
+
+  int dataCursor = 0;
+  for (auto acc = accelerators.begin(); acc != accelerators.end(); acc++) {
+    for (int i = 0; i < numViewPerAcc; i++) {
+
+      // create a new accelerator_view
+      acc_views.push_back(acc->create_view());
+
+      // create array_views that only covers the data portion needed by this accelerator_view
+      x_views.push_back(hc::array_view<float,1>(numSaxpyPerView, host_x.data() + dataCursor));
+      y_views.push_back(hc::array_view<float,1>(numSaxpyPerView, host_y.data() + dataCursor));
+      dataCursor+=numSaxpyPerView;
+
+
+      auto& x_av = x_views.back();
+      auto& y_av = y_views.back();
+      hc::completion_future f;
+      f = hc::parallel_for_each(acc_views.back(), x_av.get_extent()
+                            , [=](hc::index<1> i) [[hc]] {
+        y_av[i] = a * x_av[i] + y_av[i];
+      });
+      futures.push_back(f);
+
+
+      //printf("dataCursor: %d\n",dataCursor);
+    }
+  }
+
+  // If N is not a multiple of the number of acc_views,
+  // calculate the remaining saxpy on the host
+  for (; dataCursor!=N; dataCursor++) {
+    host_y[dataCursor] = a * host_x[dataCursor] + host_y[dataCursor];
+  }
+
+  // synchronize all the results back to the host
+  for(auto v = y_views.begin(); v != y_views.end(); v++) {
+    v->synchronize();
+  }
+  
+  // verify the results
+  int errors = 0;
+  for (int i = 0; i < N; i++) {
+    if (fabs(host_y[i] - host_result_y[i]) > fabs(host_result_y[i] * 0.0001f))
+      errors++;
+  }
+  //std::cout << errors << " errors" << std::endl;
+
+  return errors;
+}

--- a/tests/Unit/HC/multi_acc.cpp
+++ b/tests/Unit/HC/multi_acc.cpp
@@ -11,7 +11,7 @@
 
 int main() {
 
-  constexpr int N = 1024 * 1024 * 256;
+  constexpr int N = 1024 * 1024 * 64;
   constexpr float a = 100.0f;
 
   std::vector<float> host_x(N);

--- a/tests/Unit/HC/multi_acc_array.cpp
+++ b/tests/Unit/HC/multi_acc_array.cpp
@@ -1,0 +1,123 @@
+// XFAIL: Linux
+// RUN: %hc %s -o %t.out && %t.out
+#include <random>
+#include <algorithm>
+#include <vector>
+#include <iostream>
+#include <cmath>
+
+// header file for the hc API
+#include <hc.hpp>
+
+int main() {
+
+  constexpr int N = 1024 * 1024 * 256;
+  constexpr float a = 100.0f;
+
+  std::vector<float> host_x(N);
+  std::vector<float> host_y(N);
+
+  // initialize the input data
+  std::default_random_engine random_gen;
+  std::uniform_real_distribution<float> distribution(-N, N);
+  std::generate(host_x.begin(), host_x.end(), [&]() { return distribution(random_gen); });
+  std::generate(host_y.begin(), host_y.end(), [&]() { return distribution(random_gen); });
+
+  // CPU implementation of saxpy
+  
+  std::vector<float> host_result_y(N);
+  for (int i = 0; i < N; i++) {
+    host_result_y[i] = a * host_x[i] + host_y[i];
+  }
+  
+  std::vector<hc::accelerator> all_accelerators = hc::accelerator::get_all();
+  std::vector<hc::accelerator> accelerators;
+  for (auto a = all_accelerators.begin(); a != all_accelerators.end(); a++) {
+
+    // only pick accelerators supported by the HSA runtime
+    if (a->is_hsa_accelerator()) {
+      accelerators.push_back(*a);
+    }
+  }
+
+  constexpr int numViewPerAcc = 2;
+  int numSaxpyPerView = N/(accelerators.size() * numViewPerAcc);
+
+  std::vector<hc::accelerator_view> acc_views;
+
+  std::vector<hc::completion_future> futures;
+
+  std::vector<hc::array<float,1>> x_arrays;
+  std::vector<hc::array<float,1>> y_arrays;
+
+
+
+  int dataCursor = 0;
+  for (auto acc = accelerators.begin(); acc != accelerators.end(); acc++) {
+    for (int i = 0; i < numViewPerAcc; i++) {
+
+      // create a new accelerator_view
+      acc_views.push_back(acc->create_view());
+
+      int newDataCursor = dataCursor+numSaxpyPerView;
+
+      // create array_views that only covers the data portion needed by this accelerator_view
+      x_arrays.push_back(hc::array<float,1>(numSaxpyPerView, acc_views.back()));
+      auto& x_array = x_arrays.back();
+
+      hc::completion_future cpfuture_x = hc::copy_async(host_x.begin() + dataCursor
+                                                        , host_x.begin() + newDataCursor
+                                                        , x_array);
+
+      y_arrays.push_back(hc::array<float,1>(numSaxpyPerView, acc_views.back()));
+      auto& y_array = y_arrays.back();
+
+      hc::completion_future cpfuture_y = hc::copy_async(host_y.begin() + dataCursor
+                                                        , host_y.begin() + newDataCursor
+                                                        , y_array);
+      dataCursor = newDataCursor;
+      cpfuture_x.wait();
+      cpfuture_y.wait();
+      
+      hc::completion_future f;
+      f = hc::parallel_for_each(acc_views.back(), x_array.get_extent()
+                            , [&,a](hc::index<1> i) [[hc]] {
+        y_array[i] = a * x_array[i] + y_array[i];
+      });
+      futures.push_back(f);
+
+      //printf("dataCursor: %d\n",dataCursor);
+    }
+  }
+
+  // If N is not a multiple of the number of acc_views,
+  // calculate the remaining saxpy on the host
+  for (; dataCursor!=N; dataCursor++) {
+    host_y[dataCursor] = a * host_x[dataCursor] + host_y[dataCursor];
+  }
+
+  // synchronize all the results back to the host
+  auto kernel_future = futures.begin();
+  dataCursor = 0;
+  for(auto v = y_arrays.begin(); v != y_arrays.end(); v++) {
+    kernel_future->wait();
+    *kernel_future = hc::copy_async(*v, host_y.begin() + dataCursor);
+    dataCursor+=numSaxpyPerView;
+    kernel_future++;
+  }
+
+  // wait for the copies to complete
+  for(auto f = futures.begin(); f != futures.end(); f++) {
+    f->wait();
+  }
+ 
+  // verify the results
+  int errors = 0;
+  for (int i = 0; i < N; i++) {
+    if (fabs(host_y[i] - host_result_y[i]) > fabs(host_result_y[i] * 0.0001f))
+      errors++;
+  }
+  //std::cout << errors << " errors" << std::endl;
+
+  return errors;
+}

--- a/tests/Unit/HC/multi_acc_array.cpp
+++ b/tests/Unit/HC/multi_acc_array.cpp
@@ -11,7 +11,7 @@
 
 int main() {
 
-  constexpr int N = 1024 * 1024 * 256;
+  constexpr int N = 1024 * 1024 * 64;
   constexpr float a = 100.0f;
 
   std::vector<float> host_x(N);


### PR DESCRIPTION
replace hsa_memory_copy with memory pool async copy.

no regression found:

HCC_RUNTIME=HSA make test

********************
Testing Time: 128.52s
********************
Failing Tests (18):
    CPPAMP :: Unit/AmpMath/amp_math_erf_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_erfc_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_hypot_precise_math.cpp
    CPPAMP :: Unit/DynamicTileStatic/test11.cpp
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp
    CPPAMP :: Unit/HC/memcpy_symbol2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp
    CPPAMP :: Unit/HC/memcpy_symbol4.cpp
    CPPAMP :: Unit/HSAIL/activelaneid.cpp
    CPPAMP :: Unit/HSAIL/activelanepermute.cpp
    CPPAMP :: Unit/ParallelSTL/is_partitioned_carray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdvector.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdvector.cpp
    CPPAMP :: Unit/SharedLibrary/shared_library2.cpp
