### PR TITLE
Utilize all the cores when building and running tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ ENDIF (NOT CLANG_URL)
 set(CMAKE_MACOSX_RPATH 1)
 
 IF (NOT NUM_BUILD_THREADS)
-  SET(NUM_BUILD_THREADS 8)
+  include(ProcessorCount)
+  ProcessorCount(NUM_BUILD_THREADS)
 ENDIF(NOT NUM_BUILD_THREADS)
 
 include (EnsureLLVMisPresent)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,8 +78,11 @@ if(POLICY CMP0037)
   cmake_policy(SET CMP0037 OLD)
 endif()
 
+include(ProcessorCount)
+ProcessorCount(N)
+
 add_custom_target(test
-  COMMAND python ${LLVM_ROOT}/bin/llvm-lit -j 8 --path ${LLVM_TOOLS_DIR} -sv ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND python ${LLVM_ROOT}/bin/llvm-lit -j ${N} --path ${LLVM_TOOLS_DIR} -sv ${CMAKE_CURRENT_BINARY_DIR}
   # DEPENDS ${CPPAMP_GTEST_LIB}
   COMMENT "Running HCC regression tests")
 


### PR DESCRIPTION
This sets up the cmake to call the 'ProcessorCount' module to build and test with all the cores available, instead of just setting it to 8.