### PR TITLE
[LIGHTNING-306] Fix amp-conformance tests, on which Clang 4.0 reasonably reports error for ill-formed const object declaration.

### DIFF
--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_assign_op.01/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_assign_op.01/test.cpp
@@ -78,6 +78,7 @@ struct A7 : A7_base
 // Empty class with base classes having both defaulted and user-defined copy op=
 struct A8_base_1
 {
+	A8_base_1() {}
 	int i;
 };
 class A8_base_2
@@ -94,6 +95,7 @@ class A8 : A8_base_1, public A8_base_2
 // Classes with data members having both defaulted and user-defined copy op=
 struct A9_member_1
 {
+	A9_member_1() {}
 	int i;
 	A9_member_1& operator=(const A9_member_1&) restrict(cpu,amp) { return *this; }
 };
@@ -109,6 +111,7 @@ class A9
 
 class A10_member_1
 {
+	A10_member_1() {}
 	int i;
 };
 class A10_member_2

--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_ctor.01/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_ctor.01/test.cpp
@@ -91,6 +91,7 @@ struct A8 : A8_base
 // Empty class with base classes having both defaulted and user-defined copy ctors
 struct A9_base_1
 {
+	A9_base_1() {}
 	int i;
 };
 class A9_base_2
@@ -124,6 +125,7 @@ class A10
 
 class A11_member_1
 {
+	A11_member_1() {}
 	int i;
 };
 class A11_member_2


### PR DESCRIPTION
[Problem]
Clang 4.0 reports an error "default initialization of an object of const type 'const XXX' without a user-provided default constructor" on some of const declarations without explicit initialization. 

[Explanation]
All the problematic declarations are of the objects inherited from POD classes, which are not initialized by default. 
C++ spec says: "If a program calls for the default-initialization of an object of a const-qualified type T, T shall be a class type with user-provided default constructor" ... 7.1.7.1 The cv-qualifiers ... "the definition of an object or subobject of const-qualified type must specify an initializer or be subject to default initialization."

[Conclusion]
The error reported by Clang 4.0 is valid and conforms to C++ spec, because the reported const declarations are ill-formed in fact. Clang 3.5 allows such ill-formed declarations and thus is wrong (Bug in the compiler). 

[Solution]
Add default empty ctor to the base POD classes in order to make them non-POD. Fix doesn't change tests' logic.