### PR TITLE
Bench latency fix2

### DIFF
--- a/HC/WrapperGen/WrapperGen.cpp
+++ b/HC/WrapperGen/WrapperGen.cpp
@@ -7,7 +7,7 @@
 
 
 // Check the new launch-parm arguments to make sure they have sane default values.
-#define CHECK_LP_ARGS 1
+#define CHECK_LP_ARGS 0
 
 
 namespace
@@ -534,14 +534,21 @@ struct StringFinder
           out << "  static accelerator_view av = accelerator().get_default_view();\n";
           out << "  _lp.av = &av;\n";
           out << "}\n\n";
-          out << "completion_future cf = parallel_for_each(*(_lp.av),extent<3>(_lp.grid_dim.z*_lp.group_dim.z,_lp.grid_dim.y*_lp.group_dim.y,_lp.grid_dim.x*_lp.group_dim.x).tile_with_dynamic(_lp.group_dim.z, _lp.group_dim.y, _lp.group_dim.x, _lp.dynamic_group_mem_bytes), \n"
+          out << "completion_future cf;\n";
+          out << "completion_future* cf_ptr = _lp.cf ? _lp.cf : &cf;\n";
+
+          out << "*cf_ptr = parallel_for_each(*(_lp.av),extent<3>(_lp.grid_dim.z*_lp.group_dim.z,_lp.grid_dim.y*_lp.group_dim.y,_lp.grid_dim.x*_lp.group_dim.x).tile_with_dynamic(_lp.group_dim.z, _lp.group_dim.y, _lp.group_dim.x, _lp.dynamic_group_mem_bytes), \n"
+          //out << "cf = parallel_for_each(*(_lp.av),extent<3>(_lp.grid_dim.z*_lp.group_dim.z,_lp.grid_dim.y*_lp.group_dim.y,_lp.grid_dim.x*_lp.group_dim.x).tile_with_dynamic(_lp.group_dim.z, _lp.group_dim.y, _lp.group_dim.x, _lp.dynamic_group_mem_bytes), \n"
               << func->getFunctorName()
               << "(";
           func->printArgsAsArguments(out);
-          out << "));\n\n"
-              << "if(_lp.cf)\n"
-              << "  *(_lp.cf) = cf;\n"
-              << "}\n";
+          out << "));\n\n";
+
+          //out << "printf (\"==_lp.cf=%p USE_COUNT=%d isReady=%d%c\", _lp.cf, cf_ptr->use_count(), cf_ptr->is_ready(), 0xA);\n";
+          //out << "cf_ptr->wait();\n"; // bozo
+          
+
+          out << "}\n";
       }
         return false;
     }

--- a/HC/WrapperGen/WrapperGen.cpp
+++ b/HC/WrapperGen/WrapperGen.cpp
@@ -538,15 +538,10 @@ struct StringFinder
           out << "completion_future* cf_ptr = _lp.cf ? _lp.cf : &cf;\n";
 
           out << "*cf_ptr = parallel_for_each(*(_lp.av),extent<3>(_lp.grid_dim.z*_lp.group_dim.z,_lp.grid_dim.y*_lp.group_dim.y,_lp.grid_dim.x*_lp.group_dim.x).tile_with_dynamic(_lp.group_dim.z, _lp.group_dim.y, _lp.group_dim.x, _lp.dynamic_group_mem_bytes), \n"
-          //out << "cf = parallel_for_each(*(_lp.av),extent<3>(_lp.grid_dim.z*_lp.group_dim.z,_lp.grid_dim.y*_lp.group_dim.y,_lp.grid_dim.x*_lp.group_dim.x).tile_with_dynamic(_lp.group_dim.z, _lp.group_dim.y, _lp.group_dim.x, _lp.dynamic_group_mem_bytes), \n"
               << func->getFunctorName()
               << "(";
           func->printArgsAsArguments(out);
           out << "));\n\n";
-
-          //out << "printf (\"==_lp.cf=%p USE_COUNT=%d isReady=%d%c\", _lp.cf, cf_ptr->use_count(), cf_ptr->is_ready(), 0xA);\n";
-          //out << "cf_ptr->wait();\n"; // bozo
-          
 
           out << "}\n";
       }

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1147,6 +1147,8 @@ public:
       }
     }
 
+    int use_count() { return __asyncOp.use_count(); };
+
 private:
     std::shared_future<void> __amp_future;
     std::thread* __thread_then = nullptr;

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1147,7 +1147,11 @@ public:
       }
     }
 
-    int use_count() { return __asyncOp.use_count(); };
+
+    /**
+     * @return reference count for the completion future.  Primarily used for debug purposes.
+     */
+    int get_use_count() const { return __asyncOp.use_count(); };
 
 private:
     std::shared_future<void> __amp_future;

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -4,6 +4,7 @@
 
 # enable bash debugging
 KMDBSCRIPT="${KMDBSCRIPT:=0}"
+KMDBGRIDLAUNCH="${KMDBGRIDLAUNCH:=0}"
 
 # dump the LLVM bitcode
 KMDUMPLLVM="${KMDUMPLLVM:=0}"
@@ -25,6 +26,9 @@ CXXFLAGS="-std=c++amp -stdlib=libc++ -I$BINDIR/../../include -fPIC"
 # Set additional CXXFLAGS based on CMAKE_BUILD_TYPE
 shopt -s nocasematch
 CMAKE_BUILD_TYPE="@CMAKE_BUILD_TYPE@"
+if [ $KMDBGRIDLAUNCH == "1" ]; then
+    CMAKE_BUILD_TYPE="debug";
+fi
 case $CMAKE_BUILD_TYPE in
   release)
     CXXFLAGS=$CXXFLAGS" -O3"
@@ -93,5 +97,9 @@ else
   mv $TEMP_NAME.camp.o $2
 fi
 
-rm -f $TEMP_NAME.* $1.bc
-rmdir $TEMP_DIR
+if [ $KMDBGRIDLAUNCH == "1" ]; then
+  echo "db: KMDBGRIDLAUNCH=1 and temps saved in $TEMP_DIR"
+else
+  rm -f $TEMP_NAME.* $1.bc
+  rmdir $TEMP_DIR
+fi

--- a/tests/Unit/HC/get_use_count.cpp
+++ b/tests/Unit/HC/get_use_count.cpp
@@ -1,0 +1,46 @@
+// XFAIL: Linux
+// RUN: %hc %s -o %t.out && %t.out
+
+#include <hc.hpp>
+#include <assert.h>
+
+void checkPassByValue (hc::completion_future cf, int expectedCount)
+{
+    assert(cf.get_use_count() == expectedCount);
+}
+
+
+void checkPassByRef (const hc::completion_future &cf, int expectedCount)
+{
+    assert(cf.get_use_count() == expectedCount);
+}
+
+#define GRID_SIZE 1000
+
+int main() {
+  using namespace hc;
+  array<uint64_t, 1> table(GRID_SIZE);
+  extent<1> ex(GRID_SIZE);
+
+  // launch a kernel, log current hardware cycle count
+  completion_future cf = parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+    table(idx) = __cycle_u64();
+  });
+
+
+  // At this point the HCC queue structure has a reference the CF, and we have one here in CF:
+
+  assert(cf.get_use_count() == 2);
+
+  checkPassByValue(cf, 3);
+  checkPassByRef(cf, 2);
+
+  cf.wait();
+
+  // waiting removes the reference from the queue so we just have the one here in CF.
+  assert(cf.get_use_count() == 1);
+
+
+  return 0;
+}
+

--- a/tests/benchEmptyKernel/Makefile
+++ b/tests/benchEmptyKernel/Makefile
@@ -1,8 +1,11 @@
 # run kernel # of times
 N := 500000
 
+# TODO - should enable OPT=-O3 for benchmarking.
+OPT=
+
 bench: bench.cpp
-	hcc `hcc-config --build --cxxflags --ldflags` bench.cpp -o bench
+	hcc `hcc-config --build --cxxflags --ldflags` $(OPT) bench.cpp -o bench
 
 plot: bench
 	./bench ${N}

--- a/tests/benchEmptyKernel/Makefile
+++ b/tests/benchEmptyKernel/Makefile
@@ -2,7 +2,7 @@
 N := 500000
 
 # TODO - should enable OPT=-O3 for benchmarking.
-OPT=
+OPT=-O3
 
 bench: bench.cpp
 	hcc `hcc-config --build --cxxflags --ldflags` $(OPT) bench.cpp -o bench

--- a/tests/benchEmptyKernel/bench.cpp
+++ b/tests/benchEmptyKernel/bench.cpp
@@ -32,7 +32,10 @@
 #define TOL_HI 1e-4
 
 __attribute__((hc_grid_launch)) 
-void nullkernel(const grid_launch_parm lp) {
+void nullkernel(const grid_launch_parm lp, float* A) {
+    if (A) {
+        A[0] = 0x13;
+    }
 }
 
 
@@ -158,8 +161,8 @@ int main(int argc, char* argv[]) {
     lp.cf = &cf;
     lp.av = &av;
 
-    nullkernel(lp);
-    //std::cout << "CF use_count=" << cf.use_count() << "is_ready=" << cf.is_ready()<< "\n";
+    nullkernel(lp, 0x0);
+    //std::cout << "CF get_use_count=" << cf.get_use_count() << "is_ready=" << cf.is_ready()<< "\n";
     cf.wait();
 
     end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Optimize dispatch latency, cleanup benchmark, add completion_future::get_use_count.

--

********************
Testing Time: 309.57s
********************
Failing Tests (23):
    CPPAMP :: Unit/AmpMath/amp_math_erf_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_erfc_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_hypot_precise_math.cpp
    CPPAMP :: Unit/DynamicTileStatic/test11.cpp
    CPPAMP :: Unit/HC/amdgcn_ds_swizzle_bitmode.cpp
    CPPAMP :: Unit/HC/amdgcn_ds_swizzle_qdmode.cpp
    CPPAMP :: Unit/HC/create_blocking_marker.cpp
    CPPAMP :: Unit/HC/create_blocking_marker2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp
    CPPAMP :: Unit/HC/memcpy_symbol2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp
    CPPAMP :: Unit/HC/memcpy_symbol4.cpp
    CPPAMP :: Unit/HSAIL/activelaneid.cpp
    CPPAMP :: Unit/HSAIL/activelanepermute.cpp
    CPPAMP :: Unit/HSAIL/ballot.cpp
    CPPAMP :: Unit/HSAIL/shfl.cpp
    CPPAMP :: Unit/ParallelSTL/sort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/sort_stdvector.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_carray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdarray.cpp
    CPPAMP :: Unit/ParallelSTL/stablesort_stdvector.cpp
    CPPAMP :: Unit/SharedLibrary/shared_library2.cpp

  Expected Passes    : 681
  Expected Failures  : 22
  Unsupported Tests  : 10
  Unexpected Failures: 23
