### PR TITLE
[LIGHTNING-306] [2nd commit] Fix amp-conformance tests with ill-formed const object declaration. Perform initialization instead of default user-defined constructor (1st commit).

### DIFF
--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_assign_op.01/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_assign_op.01/test.cpp
@@ -78,7 +78,6 @@ struct A7 : A7_base
 // Empty class with base classes having both defaulted and user-defined copy op=
 struct A8_base_1
 {
-	A8_base_1() {}
 	int i;
 };
 class A8_base_2
@@ -95,7 +94,6 @@ class A8 : A8_base_1, public A8_base_2
 // Classes with data members having both defaulted and user-defined copy op=
 struct A9_member_1
 {
-	A9_member_1() {}
 	int i;
 	A9_member_1& operator=(const A9_member_1&) restrict(cpu,amp) { return *this; }
 };
@@ -111,7 +109,6 @@ class A9
 
 class A10_member_1
 {
-	A10_member_1() {}
 	int i;
 };
 class A10_member_2
@@ -173,11 +170,11 @@ bool test() restrict(cpu,amp)
 	a7l = a7r;
 
 	A8 a8l;
-	const A8 a8r;
+	const A8 a8r = {};
 	a8l = a8r;
 
 	A9 a9l;
-	const A9 a9r;
+	const A9 a9r = {};
 	a9l = a9r;
 
 	A11 a11l, a11r;
@@ -193,7 +190,7 @@ bool test_cpu() restrict(cpu)
 	a6l = a6r;
 
 	A10 a10l;
-	const A10 a10r;
+	const A10 a10r = {};
 	a10l = a10r;
 	
 	return true; // Compile-time tests

--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_ctor.01/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_3_Expr_Invo_Rest_Func/2_3_2_Func_Over/Special_member_functions/defaulted_copy_ctor.01/test.cpp
@@ -91,7 +91,6 @@ struct A8 : A8_base
 // Empty class with base classes having both defaulted and user-defined copy ctors
 struct A9_base_1
 {
-	A9_base_1() {}
 	int i;
 };
 class A9_base_2
@@ -125,7 +124,6 @@ class A10
 
 class A11_member_1
 {
-	A11_member_1() {}
 	int i;
 };
 class A11_member_2
@@ -202,7 +200,7 @@ bool test() restrict(cpu,amp)
 	A8 a8;
 	A8 a8c(a8);
 
-	const A9 a9;
+	const A9 a9 = {};
 	A9 a9c(a9);
 
 	const A10 a10;
@@ -222,7 +220,7 @@ bool test_cpu() restrict(cpu)
 	const A7 a7;
 	A7 a7c(a7);
 
-	const A11 a11;
+	const A11 a11 = {};
 	A11 a11c(a11);
 
 	return true; // Compile-time tests


### PR DESCRIPTION
First commit for bug 306 was in adding default user-defined ctor. After discussion agreed on explcit initialization instead of ctor in order to avoid all possible changes in tests' logic.