### PR TITLE
[LIGHTNING-308] Fix - Clang 4.0 reports linker error 'undefined reference to' ctor

### DIFF
--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_1_Synt/Contextual_restrict/test.05/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_1_Synt/Contextual_restrict/test.05/test.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 class restrict
 {
-   int size;
+   unsigned int size;
 
 public:
     restrict() __GPU

--- a/amp-conformance/Tests/2_Cxx_Lang_Exte/2_1_Synt/Contextual_restrict/test.06/test.cpp
+++ b/amp-conformance/Tests/2_Cxx_Lang_Exte/2_1_Synt/Contextual_restrict/test.06/test.cpp
@@ -41,7 +41,7 @@ struct restrict
     }
 
 private:
-   int size;
+   unsigned int size;
 };
 
 


### PR DESCRIPTION
_[Code snippet]_

```
class restrict {
  int size;
  …
public:
  restrict(unsigned int _size) __GPU {
    this->size = _size;
  }
  …
private:
  int size;
};
…
restrict *y = new restrict(20); // error: undefined reference to `restrict::restrict(int)'
```
_[Analysis]_
The error is reported for conversion constructor only, neither for class virtual functions, nor for non-virtual functions. The restriction specifier is not the case. Constructor call for stack variable leads to the same error:
```
restrict y(20);
restrict y = 20;
restrict y = restrict(20);
```
But changing the type of member "size" from int to unsigned int eliminates the issue. It is very strange. Looks like a bug in Clang 4.0 compiler. MSVC doesn’t emit even a warning on the same code.

_[Conclusion]_
Anyway, either it is a Clang 4.0 itself bug or a correct behavior with conversion constructors (evidence in C++ Spec is not found), the variable size type in the code is unsigned semantically, and there is no need for test in implicit type casting from unsigned int to int and vice versa, as the "test checks that a function qualifier can be used as a class/struct name".

2 alternative options:
1) `restrict(int _size) __GPU`
2) `restrict *y = new restrict(20U);`