### PR TITLE
fix array copy on multi-gpu system

### DIFF
--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -528,12 +528,11 @@ static inline void copy_helper(std::shared_ptr<KalmarQueue>& srcQueue, void* src
     /// If device pointer comes from cpu, let the device queue to handle the copy
     /// For example, if src is on cpu and dst is on device,
     /// in OpenCL, clEnqueueWrtieBuffer to write data from src to device
-    if (is_cpu_queue(srcQueue))
-        dstQueue->write(dst, (char*)src + src_offset, cnt, dst_offset, block);
-    else if (is_cpu_queue(dstQueue))
+    
+    if (is_cpu_queue(dstQueue))
         srcQueue->read(src, (char*)dst + dst_offset, cnt, src_offset);
     else
-        dstQueue->copy(src, dst, cnt, src_offset, dst_offset, block);
+        dstQueue->write(dst, (char*)src + src_offset, cnt, dst_offset, block);
 }
 
 /// software MSI protocol


### PR DESCRIPTION
The issue is that KalmarQueue::copy() doesn't work on a multi-gpu system since the hsa version is implemented with hsa_memory_copy.  The fallback on read() or write() fixes that and the test hcc/tests/Unit/HC/multi_acc_array.cpp, which contains array copies of cpu->device and device ->cpu in a multi-gpu env, is passing now

No new regressions:

HCC_RUNTIME=HSA make test
********************
Testing Time: 543.92s
********************
Failing Tests (14):
    CPPAMP :: Unit/AmpMath/amp_math_erf_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_erfc_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_hypot_precise_math.cpp
    CPPAMP :: Unit/AmpMath/amp_math_log.cpp
    CPPAMP :: Unit/DynamicTileStatic/test11.cpp
    CPPAMP :: Unit/HC/create_blocking_marker.cpp
    CPPAMP :: Unit/HC/create_blocking_marker2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol1.cpp
    CPPAMP :: Unit/HC/memcpy_symbol2.cpp
    CPPAMP :: Unit/HC/memcpy_symbol3.cpp
    CPPAMP :: Unit/HC/memcpy_symbol4.cpp
    CPPAMP :: Unit/HSAIL/activelaneid.cpp
    CPPAMP :: Unit/HSAIL/activelanepermute.cpp
    CPPAMP :: Unit/SharedLibrary/shared_library2.cpp

  Expected Passes    : 690
  Expected Failures  : 22
  Unsupported Tests  : 10
  Unexpected Failures: 14
