### PR TITLE
[HCC Runtime] Performance tuning for dispatch speed.

### DIFF
--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -316,7 +316,7 @@ public:
     virtual void BuildProgram(void* size, void* source) {}
 
     /// create kernel
-    virtual void* CreateKernel(const char* fun, void* size, void* source) { return nullptr; }
+    virtual void* CreateKernel(const char* fun) { return nullptr; }
 
     /// check if a given kernel is compatible with the device
     virtual bool IsCompatibleKernel(void* size, void* source) { return true; }
@@ -420,7 +420,7 @@ public:
     std::shared_ptr<KalmarQueue> createQueue(execute_order order = execute_in_order) override { return std::shared_ptr<KalmarQueue>(new CPUQueue(this)); }
     void* create(size_t count, struct rw_info* /* not used */ ) override { return kalmar_aligned_alloc(0x1000, count); }
     void release(void* ptr, struct rw_info* /* nout used */) override { kalmar_aligned_free(ptr); }
-    void* CreateKernel(const char* fun, void* size, void* source) { return nullptr; }
+    void* CreateKernel(const char* fun) { return nullptr; }
 };
 
 /// KalmarContext

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -354,13 +354,7 @@ void BuildProgram(KalmarQueue* pQueue) {
 
 // used in parallel_for_each.h
 void *CreateKernel(std::string s, KalmarQueue* pQueue) {
-  size_t kernel_size = 0;
-  void* kernel_source = nullptr;
-  bool needs_compilation = true;
-
-  DetermineAndGetProgram(pQueue, &kernel_size, &kernel_source);
-
-  return pQueue->getDev()->CreateKernel(s.c_str(), (void *)kernel_size, kernel_source);
+  return pQueue->getDev()->CreateKernel(s.c_str());
 }
 
 void PushArg(void *k_, int idx, size_t sz, const void *s) {


### PR DESCRIPTION
The hotspot is the function DetermineAndGetProgram() which is called by function CreateKernel. The following changes are made.
- include/kalmar_runtime.h : change KalmarDevice::CreateKernel() to remove void\* size, void \* source from the function signature, so raw kernel bytes won't be used in parallel_for_each().
- lib/has/mcwamp_has.cpp : change HSADevice::CreateKernel() to honor the new interface, and change its logic as below:
  a. Don't call kernel_checksum() anymore, as the raw kernel bytes won't be passed to HSADevice::CreateKernel() anymore.
  b. Walks through the map of HSAExecutables to find the instance of HSAExecutable which has the symbol. If not found, create create HSAKernel instance.
  c. Create HSADispatch.

With the change above, the dispatch latencey measured on my system by app emptyKernelBench can be dramatically decreased from 144 micro-seconds to 10.6 micro-seconds.
