### PR TITLE
patch for Fedora 23 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,15 @@ MESSAGE("HSA_LIBRARY_DIR = ${HSA_LIBRARY_DIR}, actually found at: ${HSA_LIBRARY}
 MESSAGE("HSA_HOF_DIR = ${HSA_HOF_DIR}, actually found at: ${HSA_HOF}")
 MESSAGE("")
 
+
+#################
+# Detect libc++
+#################
+
+find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 NO_DEFAULT_PATH)
+MESSAGE("libc++ headers found at ${LIBCXX_HEADER}")
+
+
 #################
 # Set up version information
 #################
@@ -655,7 +664,7 @@ else (OFFICIAL_RELEASE_BUILD)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_GENERAL_DEBIAN_DEP}")
 endif (OFFICIAL_RELEASE_BUILD)
 
-set(CPACK_GENERATOR "DEB;TGZ")
+set(CPACK_GENERATOR "DEB;RPM;TGZ")
 set(CPACK_SOURCE_GENERATOR "TGZ")
 set(CPACK_BINARY_DEB "ON")
 set(CPACK_BINARY_STGZ "OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,18 +195,11 @@ MESSAGE("HSA_LIBRARY_DIR = ${HSA_LIBRARY_DIR}, actually found at: ${HSA_LIBRARY}
 MESSAGE("HSA_HOF_DIR = ${HSA_HOF_DIR}, actually found at: ${HSA_HOF}")
 MESSAGE("")
 
-
-if ("${DISTRO}" STREQUAL "fedora") 
-
-  #################
-  # Detect libc++
-  #################
-
-  find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 NO_DEFAULT_PATH)
-  MESSAGE("libc++ headers found at ${LIBCXX_HEADER}")
-
-endif ("${DISTRO}" STREQUAL "fedora") 
-
+#################
+# Detect libc++
+#################
+find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 /usr/include/c++/v1 NO_DEFAULT_PATH)
+MESSAGE("libc++ headers found at ${LIBCXX_HEADER}")
 
 #################
 # Set up version information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,13 @@ IF (NOT NUM_BUILD_THREADS)
   ProcessorCount(NUM_BUILD_THREADS)
 ENDIF(NOT NUM_BUILD_THREADS)
 
+
+# Accepted values for DISTRO: ubuntu, fedora
+IF (NOT DISTRO)
+  SET(DISTRO "ubuntu")
+ENDIF(NOT DISTRO)
+MESSAGE("Distro: ${DISTRO}")
+
 include (EnsureLLVMisPresent)
 include (EnsureCLANGisPresent)
 include (EnsureHLCisPresent)
@@ -189,12 +196,16 @@ MESSAGE("HSA_HOF_DIR = ${HSA_HOF_DIR}, actually found at: ${HSA_HOF}")
 MESSAGE("")
 
 
-#################
-# Detect libc++
-#################
+if ("${DISTRO}" STREQUAL "fedora") 
 
-find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 NO_DEFAULT_PATH)
-MESSAGE("libc++ headers found at ${LIBCXX_HEADER}")
+  #################
+  # Detect libc++
+  #################
+
+  find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 NO_DEFAULT_PATH)
+  MESSAGE("libc++ headers found at ${LIBCXX_HEADER}")
+
+endif ("${DISTRO}" STREQUAL "fedora") 
 
 
 #################
@@ -664,7 +675,16 @@ else (OFFICIAL_RELEASE_BUILD)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_GENERAL_DEBIAN_DEP}")
 endif (OFFICIAL_RELEASE_BUILD)
 
-set(CPACK_GENERATOR "DEB;RPM;TGZ")
+
+
+if ("${DISTRO}" STREQUAL "fedora") 
+  set(CPACK_GENERATOR "RPM;TGZ")
+else (DISTRO)
+  # default to Ubuntu
+  set(CPACK_GENERATOR "DEB;TGZ")
+endif(DISTRO)
+
+
 set(CPACK_SOURCE_GENERATOR "TGZ")
 set(CPACK_BINARY_DEB "ON")
 set(CPACK_BINARY_STGZ "OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,26 +655,32 @@ set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
   "${PROJECT_BINARY_DIR}/packaging/debian/postinst;${PROJECT_BINARY_DIR}/packaging/debian/prerm")
 
-set(HCC_GENERAL_DEBIAN_DEP "libstdc++-4.8-dev, libc++1, libc++-dev, libc++abi1, libc++abi-dev, elfutils")
-
-# control the list of package dependency depending on whether this is an official release build.
-# for non-official release build, we want to relax the dependency on rocr runtime
 set(OFFICIAL_RELEASE_BUILD 0)
-if (OFFICIAL_RELEASE_BUILD)
-  set(HCC_ROCR_DEBIAN_DEP "hsa-rocr-dev, hsa-ext-rocr-dev")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_ROCR_DEBIAN_DEP}, ${HCC_GENERAL_DEBIAN_DEP}")
-else (OFFICIAL_RELEASE_BUILD)
-  # dependencies for any local build
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_GENERAL_DEBIAN_DEP}")
-endif (OFFICIAL_RELEASE_BUILD)
 
+if ("${DISTRO}" STREQUAL "ubuntu")
 
+  set(HCC_GENERAL_DEBIAN_DEP "libstdc++-4.8-dev, libc++1, libc++-dev, libc++abi1, libc++abi-dev, elfutils")
 
-if ("${DISTRO}" STREQUAL "fedora") 
-  set(CPACK_GENERATOR "RPM;TGZ")
-else (DISTRO)
-  # default to Ubuntu
+  # control the list of package dependency depending on whether this is an official release build.
+  # for non-official release build, we want to relax the dependency on rocr runtime
+  if (OFFICIAL_RELEASE_BUILD)
+    set(HCC_ROCR_DEBIAN_DEP "hsa-rocr-dev, hsa-ext-rocr-dev")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_ROCR_DEBIAN_DEP}, ${HCC_GENERAL_DEBIAN_DEP}")
+  else (OFFICIAL_RELEASE_BUILD)
+    # dependencies for any local build
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "${HCC_GENERAL_DEBIAN_DEP}")
+  endif (OFFICIAL_RELEASE_BUILD)
+
   set(CPACK_GENERATOR "DEB;TGZ")
+
+elseif ("${DISTRO}" STREQUAL "fedora")
+
+  # disable automatic shared libraries dependency detection
+  set(CPACK_RPM_PACKAGE_AUTOREQ 0)
+
+  set(CPACK_RPM_PACKAGE_REQUIRES "")
+  set(CPACK_GENERATOR "RPM;TGZ")
+
 endif(DISTRO)
 
 

--- a/amp-conformance/CMakeLists.txt
+++ b/amp-conformance/CMakeLists.txt
@@ -1,10 +1,12 @@
 #OpenCL
-include_directories(${OPENCL_HEADER}/../ ${CMAKE_CURRENT_SOURCE_DIR}/amp_test_lib/inc)
+include_directories(${OPENCL_HEADER}/../ ${CMAKE_CURRENT_SOURCE_DIR}/amp_test_lib/inc ${LIBCXX_HEADER} )
 
 add_mcwamp_library(amptest
 amp_test_lib/src/context.cpp amp_test_lib/src/device.cpp amp_test_lib/src/logging.cpp
 amp_test_lib/src/main.cpp amp_test_lib/src/runall.cpp amp_test_lib/src/string_utils.cpp
 )
+
+target_link_libraries(amptest c++)
 
 set(AMP_CONFORMANCE_NUM_THREADS 1 CACHE INT "The number of threads to use when running amp conformance")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ endif (HCC_RUNTIME_DEBUG)
 ####################
 # C++AMP config (clamp-config)
 ####################
+add_definitions(-DLIBCXX_HEADER=${LIBCXX_HEADER}) 
 add_config_executable(clamp-config mcwamp_main.cpp)
 add_config_executable(hcc-config mcwamp_main.cpp)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,10 +12,13 @@ endif (HCC_RUNTIME_DEBUG)
 add_config_executable(clamp-config mcwamp_main.cpp)
 add_config_executable(hcc-config mcwamp_main.cpp)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${LIBCXX_HEADER} )
+target_link_libraries(clamp-config c++)
+target_link_libraries(hcc-config c++)
+
 ####################
 # C++AMP runtime (mcwamp)
 ####################
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_mcwamp_library(mcwamp mcwamp.cpp)
 add_mcwamp_library(mcwamp_atomic mcwamp_atomic.cpp)
 

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -22,7 +22,7 @@ LLVM_AS=$BINDIR/llvm-as
 LLVM_DIS=$BINDIR/llvm-dis
 CLAMP_ASM=$BINDIR/clamp-assemble
 LIBPATH=$BINDIR/../lib
-CXXFLAGS="-std=c++amp -stdlib=libc++ -I$BINDIR/../../include -fPIC"
+CXXFLAGS="-std=c++amp -stdlib=libc++ -I@LIBCXX_HEADER@ -I$BINDIR/../../include -fPIC"
 # Set additional CXXFLAGS based on CMAKE_BUILD_TYPE
 shopt -s nocasematch
 CMAKE_BUILD_TYPE="@CMAKE_BUILD_TYPE@"

--- a/lib/hsa/CMakeLists.txt
+++ b/lib/hsa/CMakeLists.txt
@@ -2,7 +2,7 @@
 # HSA headers
 ####################
 if (HAS_HSA EQUAL 1)
-  include_directories(${HSA_HEADER} ${LIBHSAIL_HEADER_DIR} ${LIBHSAIL_HEADER_DIR}/generated)
+  include_directories(${HSA_HEADER} ${LIBHSAIL_HEADER_DIR} ${LIBHSAIL_HEADER_DIR}/generated ${LIBCXX_HEADER} )
 endif (HAS_HSA EQUAL 1)
 
 ####################

--- a/lib/mcwamp_main.cpp
+++ b/lib/mcwamp_main.cpp
@@ -38,6 +38,8 @@ void cxxflags(void) {
         std::cout << " -hc";
     }
 
+    std::cout << " -I /usr/local/include/c++/v1/";
+
     // Common options
     std::cout << " -std=c++amp -stdlib=libc++";
 

--- a/lib/mcwamp_main.cpp
+++ b/lib/mcwamp_main.cpp
@@ -11,6 +11,11 @@
 #include <iostream>
 #include <cassert>
 #include "clamp-config.hxx"
+
+// macro for stringification 
+#define XSTR(S) STR(S)
+#define STR(S) #S
+
 /* Flag set by ‘--verbose’. */
 static int verbose_flag;
 static bool build_mode = false, install_mode = true; // use install mode by default
@@ -38,7 +43,8 @@ void cxxflags(void) {
         std::cout << " -hc";
     }
 
-    std::cout << " -I /usr/local/include/c++/v1/";
+    // Add include path to the libcxx headers
+    std::cout << " -I " XSTR(LIBCXX_HEADER) ;
 
     // Common options
     std::cout << " -std=c++amp -stdlib=libc++";

--- a/utils/gtest/CMakeLists.txt
+++ b/utils/gtest/CMakeLists.txt
@@ -1,2 +1,10 @@
 include_directories(${GMAC_SRC_DIR})
+
+
+
 add_mcwamp_library(mcwamp_gtest gtest_main.cc gtest-all.cc)
+
+
+include_directories( ${LIBCXX_HEADER} )
+target_link_libraries(mcwamp_gtest c++)
+


### PR DESCRIPTION
These are patches for building hcc with 3.5 clang on Fedora 23.  One of the main purposes of this is to workaround the broken libc++ rpm in FD23 and instead having hcc to use a libc++ built from source (release_36).  Patch already tested on roc-1.3.x
