### PR TITLE
Include -lm in output of `hcc-config --ldflags`

### DIFF
--- a/lib/mcwamp_main.cpp
+++ b/lib/mcwamp_main.cpp
@@ -78,7 +78,7 @@ void ldflags(void) {
         }
     }
 
-    std::cout << " -lc++ -lc++abi -ldl -lpthread ";
+    std::cout << " -lc++ -lc++abi -ldl -lm -lpthread ";
     if (const char *p = getenv("TEST_CPU"))
         if (p == std::string("ON"))
         std::cout << " -lmcwamp_atomic ";


### PR DESCRIPTION
See issue https://github.com/RadeonOpenCompute/hcc/issues/144

Not sure which branch is best to base this PR on, hope the default one is fine.
