### PR TITLE
-Worder and -Wpessimizing-move

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -564,7 +564,7 @@ public:
         std::vector<accelerator> ret(Devices.size());
         for (int i = 0; i < ret.size(); ++i)
             ret[i] = Devices[i];
-        return std::move(ret);
+        return ret;
     }
 
     /**

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -89,7 +89,7 @@ struct rw_info;
 /// This is an abstraction of all asynchronous operations within Kalmar
 class KalmarAsyncOp {
 public:
-  KalmarAsyncOp(hcCommandKind xCommandKind) : seqNum(0), commandKind(xCommandKind) {} 
+  KalmarAsyncOp(hcCommandKind xCommandKind) : commandKind(xCommandKind), seqNum(0) {} 
 
   virtual ~KalmarAsyncOp() {} 
   virtual std::shared_future<void>* getFuture() { return nullptr; }


### PR DESCRIPTION
```
hc.hpp:567:16: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
        return std::move(ret);
```

Pretty sure RVO takes care of the return and [std::(move) is unnecessary](http://stackoverflow.com/a/19267500/795574)