### PR TITLE
Add options to alloc HSA Coherent system memory

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -403,6 +403,18 @@ public:
     }
 
     /**
+     * Returns an opaque handle which points to the AM system region on the HSA agent.
+     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * specified accelerator.
+     *
+     * @return An opaque handle of the region, if the accelerator is based
+     *         on HSA.  NULL otherwise.
+     */
+    void* get_hsa_am_finegrained_system_region() {
+        return pQueue->getHSACoherentAMHostRegion();
+    }
+
+    /**
      * Returns an opaque handle which points to the Kernarg region on the HSA
      * agent.
      *
@@ -874,6 +886,18 @@ public:
      */
     void* get_hsa_am_system_region() const {
         return get_default_view().get_hsa_am_system_region();
+    }
+
+    /**
+     * Returns an opaque handle which points to the AM system region on the HSA agent.
+     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * specified accelerator.
+     *
+     * @return An opaque handle of the region, if the accelerator is based
+     *         on HSA.  NULL otherwise.
+     */
+    void* get_hsa_am_finegrained_system_region() const {
+        return get_default_view().get_hsa_am_finegrained_system_region();
     }
 
     /**

--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -10,6 +10,7 @@ typedef int am_status_t;
 
 // Flags for am_alloc API:
 #define amHostPinned 0x1
+#define amHostCoherent 0x2
 
 
 namespace hc {

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -216,6 +216,8 @@ public:
   virtual void* getHSAAMRegion() { return nullptr; }
 
   virtual void* getHSAAMHostRegion() { return nullptr; }
+  
+  virtual void* getHSACoherentAMHostRegion() { return nullptr; }
 
   /// get kernarg region handle
   virtual void* getHSAKernargRegion() { return nullptr; }

--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -196,7 +196,9 @@ auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
             hsa_amd_memory_pool_t *alloc_region;
             if (flags & amHostPinned) {
                alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_system_region());
-            } else {
+            } else if (flags & amHostCoherent) {
+               alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_finegrained_system_region());
+            }else {
                alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_region());
             }
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -694,6 +694,7 @@ struct pool_iterator
 {
     hsa_amd_memory_pool_t _am_memory_pool;
     hsa_amd_memory_pool_t _am_host_memory_pool;
+    hsa_amd_memory_pool_t _am_host_coherent_memory_pool;
 
     hsa_amd_memory_pool_t _kernarg_memory_pool;
     hsa_amd_memory_pool_t _finegrained_system_memory_pool;
@@ -1368,6 +1369,8 @@ public:
     void* getHostAgent() override;
 
     void* getHSAAMRegion() override;
+    
+    void* getHSACoherentHostRegion() override;
 
     void* getHSAAMHostRegion() override;
 
@@ -1847,6 +1850,10 @@ public:
         ri._am_host_memory_pool = (ri._found_coarsegrained_system_memory_pool)
                                       ? ri._coarsegrained_system_memory_pool
                                       : ri._finegrained_system_memory_pool;
+        
+        ri._am_host_coherent_memory_pool = (ri._found_finegrained_system_memory_pool)
+                                      ? ri._finegrained_system_memory_pool
+                                      : ri._coarsegrained_system_memory_pool;
 
         /// Query the maximum number of work-items in a workgroup
         status = hsa_agent_get_info(agent, HSA_AGENT_INFO_WORKGROUP_MAX_SIZE, &workgroup_max_size);
@@ -2208,6 +2215,10 @@ public:
 
     hsa_amd_memory_pool_t& getHSAAMHostRegion() {
         return ri._am_host_memory_pool;
+    }
+
+    hsa_amd_memory_pool_t& getHSACoherentHostRegion() {
+        return ri._am_host_coherent_memory_pool;
     }
 
     hsa_amd_memory_pool_t& getHSAAMRegion() {
@@ -2969,7 +2980,10 @@ inline void*
 HSAQueue::getHSAAMRegion() override {
     return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHSAAMRegion()));
 }
-
+inline void*
+HSAQueue::getHSACoherentHostRegion() override {
+    return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHSACoherentHostRegion()));
+}
 inline void*
 HSAQueue::getHSAAMHostRegion() override {
     return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHSAAMHostRegion()));


### PR DESCRIPTION
This PR adds options to allocate finegrained system memory by using the flag of "amHostCoherent" with hc::am_alloc() api.
