### PR TITLE
Revert: Revert "[modules] PR28752: Do not instantiate variable declarations which are not visible."

### DIFF
--- a/amp-conformance/amp_test_lib/inc/amptest/device.h
+++ b/amp-conformance/amp_test_lib/inc/amptest/device.h
@@ -69,7 +69,7 @@ namespace Concurrency {
 		/// with a single separator character (default is a pipe ('|') character).
 		/// Note, whitespace is not allowed unless it's the separator character.
 		/// If a value isn't recognized (or UNKNOWN) an amptest_cascade_failure exception will be thrown.
-		device_flags AMP_TEST_API parse_device_flags(const std::string& src_desc, const std::string& src, char separator = '|', device_flags valid_flags = all_valid_device_flags);
+		device_flags AMP_TEST_API parse_device_flags(const std::string& src_desc, const std::string& src, char separator, device_flags valid_flags);
 		inline device_flags parse_device_flags(const std::string& src, char separator = '|', device_flags valid_flags = all_valid_device_flags) {
 			return parse_device_flags("", src, separator, valid_flags);
 		}
@@ -81,7 +81,7 @@ namespace Concurrency {
 		/// meant to support.
 		/// This method may only be called before any DMR API that retrieves a device or set
 		/// of devices, otherwise an exception will be thrown.
-		void AMP_TEST_API set_amptest_supported_devices(device_flags required_flags = device_flags::NOT_SPECIFIED);
+		void AMP_TEST_API set_amptest_supported_devices(device_flags required_flags);
 
 
 		/// Gets a prioritized list of the available devices for the current amptest.
@@ -95,15 +95,15 @@ namespace Concurrency {
 		///       by using the set_amptest_supported_devices function before this.
 		/// Exceptions:
 		/// invalid_argument - If device_flags has the AMP_DEFAULT flag set.
-		std::vector<accelerator> AMP_TEST_API get_available_devices(device_flags required_flags = device_flags::NOT_SPECIFIED);
+		std::vector<accelerator> AMP_TEST_API get_available_devices(device_flags required_flags);
 
-		
+
 		/// Retrieves a device from the DMF that has the required_flags.
 		/// The DMF will return its first prioritized choice.
 		/// If no device is available:
 		///   - if amptest_main.h is used an amptest_skip exception is thrown.
 		///   - if amptest_main.h IS NOT used, then exit() is called with an exit code of runall_skip.
-        accelerator AMP_TEST_API require_device(device_flags required_flags = device_flags::NOT_SPECIFIED);
+        accelerator AMP_TEST_API require_device(device_flags required_flags);
 
 		/// Retrieves a device from the DMF that has the required_flags and excludes the specified device.
 		/// The DMF will return its first prioritized choice which is not excluded.
@@ -111,7 +111,7 @@ namespace Concurrency {
 		/// If no device is available:
 		///   - if amptest_main.h is used an amptest_skip exception is thrown.
 		///   - if amptest_main.h IS NOT used, then exit() is called with an exit code of runall_skip.
-        accelerator AMP_TEST_API require_device(const accelerator& excluded_device, device_flags required_flags = device_flags::NOT_SPECIFIED);
+        accelerator AMP_TEST_API require_device(const accelerator& excluded_device, device_flags required_flags);
 
 		/// Requires a device and when T is 'double' will also verify the device has double support.
 		/// The type of double support requested is determined by the parameter full_double_support:
@@ -119,7 +119,7 @@ namespace Concurrency {
 		///    false => device_flags::LIMITED_DOUBLE
 		/// The default value of full_double_support if false.
 		template <typename T>
-		inline accelerator require_device_for(device_flags required_flags = device_flags::NOT_SPECIFIED, bool full_double_support = false) {
+		inline accelerator require_device_for(device_flags required_flags, bool full_double_support) {
 			static_assert(0 == (sizeof(T) % sizeof(int)), "only value types whose size is a multiple of the size of an integer are allowed on accelerator");
 
 			(void)(full_double_support);	// only used for double support
@@ -148,7 +148,7 @@ namespace Concurrency {
 		///    false => device_flags::LIMITED_DOUBLE
 		/// The default value of full_double_support if false.
 		template <typename T>
-		inline accelerator require_device_for(const accelerator& excluded_device, device_flags required_flags = device_flags::NOT_SPECIFIED, bool full_double_support = false) {
+		inline accelerator require_device_for(const accelerator& excluded_device, device_flags required_flags, bool full_double_support) {
 			static_assert(0 == (sizeof(T) % sizeof(int)), "only value types whose size is a multiple of the size of an integer are allowed on accelerator");
 
 			(void)(full_double_support);	// only used for double support
@@ -189,7 +189,7 @@ namespace Concurrency {
 		}
 
 		/// Attempts to retrieve a device and returns a value indicating whether the retrieval was successful.
-        bool AMP_TEST_API get_device(accelerator &device, device_flags required_flags = device_flags::NOT_SPECIFIED);
+        bool AMP_TEST_API get_device(accelerator &device, device_flags required_flags);
 
 		// TODO: After the above APIs have solidified, the uses off these should be replaced.
         inline bool get_device(Test::Device required_device, accelerator &device) {

--- a/amp-conformance/amp_test_lib/inc/amptest/logging.h
+++ b/amp-conformance/amp_test_lib/inc/amptest/logging.h
@@ -40,7 +40,7 @@ namespace Concurrency
 
 		/// Gets the current timestamp from the system and formats it to a string
 		/// The format used has the timestamp surrounded with square brackets (e.g. "[...]").
-		std::string AMP_TEST_API get_timestamp(bool include_date = false);
+		std::string AMP_TEST_API get_timestamp(bool include_date);
 
 		/// C++-style streaming operators.  Convert output to a UTF-8 encoded byte stream.
 		std::ostream& operator<<(std::ostream& os, const wchar_t* str);
@@ -49,16 +49,16 @@ namespace Concurrency
 		std::ostream& operator<<(std::ostream& os, const std::wstring& str);
 
         ///<summary>Logs the "logtype" and returns an ostream for further logging</summary>
-        std::ostream& AMP_TEST_API Log(LogType type = LogType::Info, bool print_line_prefix = true);
+        std::ostream& AMP_TEST_API Log(LogType type, bool print_line_prefix);
         std::ostream& AMP_TEST_API LogStream();
 
         inline std::ostream& Log(runall_result result) {
 			if(result.get_is_pass() || result.get_is_no_value()) {
-				return Log(LogType::Info);
+				return Log(LogType::Info, true);
 			} else if(result.get_is_skip()) {
-				return Log(LogType::Warning);
+				return Log(LogType::Warning, true);
 			} else { // Any of the fail states
-				return Log(LogType::Error);
+				return Log(LogType::Error, true);
 			}
 		}
 
@@ -69,14 +69,14 @@ namespace Concurrency
         void AMP_TEST_API Log_writeline(const char *msg, ...);
 
 		// Prints a new line character to the specified log.
-        void AMP_TEST_API Log_writeline(LogType type = LogType::Info);
+        void AMP_TEST_API Log_writeline(LogType type);
 
         void AMP_TEST_API SetVerbosity(LogType level);
         LogType AMP_TEST_API GetVerbosity();
 
 		/// Reports a pass/fail result.
 		inline bool report_result(const std::string& description, const bool& passed) {
-			Log(passed ? LogType::Info : LogType::Error)
+			Log(passed ? LogType::Info : LogType::Error, true)
 				<< description << ": " << runall_result_name(passed) << std::endl << std::flush;
 			return passed;
 		}
@@ -96,7 +96,7 @@ namespace Concurrency
 		/// calling exit(runall_skip) if contition is false.
 		inline void skip_if(const std::string& description, bool condition) {
 			if(condition) {
-				Log() << description << ": Skipping..." << std::endl << std::flush;
+				Log(LogType::Info, true) << description << ": Skipping..." << std::endl << std::flush;
 				exit(runall_skip);
 			}
 		}

--- a/amp-conformance/amp_test_lib/src/context.cpp
+++ b/amp-conformance/amp_test_lib/src/context.cpp
@@ -77,7 +77,7 @@ namespace Concurrency
 				// First determine if the new filestream already exists for stdout.
 				// If so, just copy it.
 				if (_cout_logfile_path == stderr_filename)
-				{	
+				{
 					_cerr_logfile_override = _cout_logfile_override;
 				}
 				else
@@ -101,7 +101,7 @@ namespace Concurrency
 				// First determine if the new filestream already exists for stderr.
 				// If so, just copy it.
 				if (_cerr_logfile_path == stdout_filename)
-				{	
+				{
 					_cout_logfile_override = _cerr_logfile_override;
 				}
 				else
@@ -178,8 +178,8 @@ namespace Concurrency
 		}
 
 		bool amptest_context_t::is_buffer_aliasing_forced() const {
-		
-			return get_environment_variable("CPPAMP_FORCE_ALIASED_SHADER", false);			
+
+			return get_environment_variable("CPPAMP_FORCE_ALIASED_SHADER", false);
 		}
 
 		int amptest_context_t::load_environment_variable_cache_from_file(const std::string& file_path)
@@ -192,7 +192,7 @@ namespace Concurrency
 
 			if (infile.fail() == 1)
 			{
-				Log(LogType::Error) << "environment variable cache file not found" << std::endl;
+				Log(LogType::Error, true) << "environment variable cache file not found" << std::endl;
 				return count;
 			}
 
@@ -259,15 +259,15 @@ namespace Concurrency
 		{
 			if (!_using_env_cache)
 			{
-				Log() << "Environment Variable Cache is not being used" << std::endl;
+				Log(LogType::Info, true) << "Environment Variable Cache is not being used" << std::endl;
 				return 0;
 			}
 
 			int count = 0;
-			Log() << "Environment Variable Cache: dumping entries" << std::endl;
+			Log(LogType::Info, true) << "Environment Variable Cache: dumping entries" << std::endl;
 			std::for_each(_env_cache.begin(), _env_cache.end(), [&](std::pair<std::string, std::string> value)
 			{
-				Log() << "    " << value.first << "=" << value.second <<std::endl;
+				Log(LogType::Info, true) << "    " << value.first << "=" << value.second <<std::endl;
 				++count;
 			});
 

--- a/amp-conformance/amp_test_lib/src/device.cpp
+++ b/amp-conformance/amp_test_lib/src/device.cpp
@@ -215,7 +215,7 @@ namespace Concurrency {
 
 				// Split by ' ' in case of RUNALL_CROSSLIST usages
 				auto parts = split_string(env_var_val, ' ', true);
-				for_each(parts.begin(), parts.end(), [](const string& part) {
+				for (auto&& part : parts) {
 						// 'RESET' is only valid when it's surrounded by spaces
 						if(part == "RESET") {
 							// Reset to the default value
@@ -234,7 +234,7 @@ namespace Concurrency {
 						device_flags flags = parse_device_flags(string("environment variable ") + env_var_name_allowed_devices, part, ',', valid_flags);
 
 						dmf_allowed_device_flags |= flags;
-					});
+					}
 			}
 
 			void parse_allowed_gpu_device_paths() {
@@ -244,7 +244,7 @@ namespace Concurrency {
 
 				// Split by ' ' in case of RUNALL_CROSSLIST usages
 				auto parts1 = split_string(env_var_val, ' ', true);
-				for_each(parts1.begin(), parts1.end(), [](const string& part1) {
+				for (auto&& part1 : parts1) {
 						auto parts2 = split_string(part1, ',', true);
 						for_each(parts2.begin(), parts2.end(), [](const string& part2) {
 								// Detect whether 'NOT_SPECIFIED' is used, because this would cause the prev flags to be cleared
@@ -255,7 +255,7 @@ namespace Concurrency {
 									//dmf_allowed_gpu_device_paths.push_back(part);
 								}
 							});
-					});
+					}
 			}
 
 			void parse_supported_devices() {
@@ -265,7 +265,7 @@ namespace Concurrency {
 
 				// Split by ' ' in case of RUNALL_CROSSLIST usages
 				auto parts = split_string(env_var_val, ' ', true);
-				for_each(parts.begin(), parts.end(), [](const string& part) {
+				for (auto&& part : parts) {
 						// Detect whether 'NOT_SPECIFIED' is used, because it doesn't have any meaning.
 						if(part.find("NOT_SPECIFIED") != string::npos) {
 							stringstream ss;
@@ -276,7 +276,7 @@ namespace Concurrency {
 						device_flags flags = parse_device_flags(string("environment variable ") + env_var_name_supported_devices, part, ',', valid_supported_device_flags);
 
 						dmf_supported_device_flags |= flags;
-					});
+					}
 			}
 
 			void parse_TARGET_DEVICE() {
@@ -290,7 +290,7 @@ namespace Concurrency {
 
 				// Handle when they use ALL_DEVICES, as it's the same as NOT_SPECIFIED.
 				if(env_var_val == "ALL_DEVICES") {
-					Log(LogType::Warning) << env_var_name_TARGET_DEVICE << " has unsupported value of 'ALL_DEVICES'. This is the same as saying NOT_SPECIFIED." << std::endl;
+					Log(LogType::Warning, true) << env_var_name_TARGET_DEVICE << " has unsupported value of 'ALL_DEVICES'. This is the same as saying NOT_SPECIFIED." << std::endl;
 					return;
 				}
 
@@ -385,7 +385,7 @@ namespace Concurrency {
 
 			void parse_IHV_failure_behavior() {
 				dmf_known_IHV_failure_behavior = known_IHV_failure_behavior::EXCLUDE_DEVICE;
-				
+
 				string env_var_val = trim(amptest_context.get_environment_variable(env_var_name_known_IHV_failure_behavior));
 
 				// Split by ' ' in case of RUNALL_CROSSLIST usages, we take the last one specified
@@ -415,7 +415,7 @@ namespace Concurrency {
 					throw amptest_cascade_failure("The DMF is already initialized.");
 				}
 
-				Log() << "DMF: Initializing the AMPTest Device Management Framework..." << std::endl;
+				Log(LogType::Info, true) << "DMF: Initializing the AMPTest Device Management Framework..." << std::endl;
 
 				// Look for common typos in the environment variable name
 				if(amptest_context.get_environment_variable("AMPTEST_AVAILABLE_DEVICES").length() > 0) {
@@ -428,14 +428,14 @@ namespace Concurrency {
 					ss << "Typo: Environment variable IHV_FAILURE is not supported. Use " << env_var_name_known_IHV_failures << " instead.";
 					throw amptest_cascade_failure(ss.str());
 				}
-				
+
 				// Allowed Devices
 				parse_allowed_devices();
-				Log() << "DMF:    Allowed device types: " << device_flags_to_string(dmf_allowed_device_flags) << std::endl;
+				Log(LogType::Info, true) << "DMF:    Allowed device types: " << device_flags_to_string(dmf_allowed_device_flags) << std::endl;
 
 				parse_allowed_gpu_device_paths();
 				if(dmf_allowed_gpu_device_paths.size() > 0) {
-					Log() << "DMF:    Allowed GPU device paths: " << std::endl;
+					Log(LogType::Info, true) << "DMF:    Allowed GPU device paths: " << std::endl;
 					std::for_each(dmf_allowed_gpu_device_paths.begin(), dmf_allowed_gpu_device_paths.end(), [](const wstring& dpath) {
 							WLog() << "DMF:       " << dpath << std::endl;
 						});
@@ -445,12 +445,12 @@ namespace Concurrency {
 				if(!dmf_supported_device_flags_set_in_code) {
 					parse_supported_devices();
 				}
-				Log() << "DMF:    Supported devices for this test: " << device_flags_to_string(dmf_supported_device_flags) << std::endl;
+				Log(LogType::Info, true) << "DMF:    Supported devices for this test: " << device_flags_to_string(dmf_supported_device_flags) << std::endl;
 
 				// BACKWARD COMPATABILITY
 				parse_TARGET_DEVICE();
 				if(dmf_TARGET_DEVICE_flags != device_flags::NOT_SPECIFIED) {
-					Log() << "DMF:    TARGET_DEVICE (deprecated!!!): " << device_flags_to_string(dmf_TARGET_DEVICE_flags) << std::endl;
+					Log(LogType::Info, true) << "DMF:    TARGET_DEVICE (deprecated!!!): " << device_flags_to_string(dmf_TARGET_DEVICE_flags) << std::endl;
 				}
 
 				// Detect IHV failures
@@ -458,11 +458,11 @@ namespace Concurrency {
 				parse_IHV_failure_behavior();
 				if(dmf_known_IHV_failures.size() > 0) {
 					// Only bother reporting the IHV failure behavior setting if the test has some specified.
-					Log() << "DMF:    Known IHV failures have been marked for this test. count = " << dmf_known_IHV_failures.size() << std::endl;
-					Log() << "DMF:    IHV failure behavior: " << get_known_IHV_failure_behavior_name() << std::endl;
+					Log(LogType::Info, true) << "DMF:    Known IHV failures have been marked for this test. count = " << dmf_known_IHV_failures.size() << std::endl;
+					Log(LogType::Info, true) << "DMF:    IHV failure behavior: " << get_known_IHV_failure_behavior_name() << std::endl;
 				}
 
-				Log() << "DMF: Finished Initializing." << std::endl << std::endl;
+				Log(LogType::Info, true) << "DMF: Finished Initializing." << std::endl << std::endl;
 				is_dmf_initialized = true;
 			}
 
@@ -603,7 +603,7 @@ namespace Concurrency {
 					// The CPU device is always ALLOWED
 					return true;
 				}
-				
+
 				if(!is_compute_device_type_match(dinfo.first, dmf_allowed_device_flags)) {
 					return false;
 				}
@@ -627,7 +627,7 @@ namespace Concurrency {
 				if(!has_bits_set(dinfo.first, device_bit_flags::IS_CPU)) {
 					is_supported &= is_compute_device_type_match(dinfo.first, dmf_supported_device_flags);
 				}   // The CPU is always a SUPPORTED device type
-				
+
 				// Check the device capabilities flags
 				is_supported &= is_device_capabilities_match(dinfo.first, dmf_supported_device_flags);
 
@@ -649,7 +649,7 @@ namespace Concurrency {
 				} else {
 					is_supported &= is_compute_device_type_match(dinfo.first, required_flags);
 				}
-				
+
 				// Check the device capabilities flags
 				is_supported &= is_device_capabilities_match(dinfo.first, required_flags);
 
@@ -669,12 +669,12 @@ namespace Concurrency {
 
 					// Check against the test context
 					bool matches_context = true;
-					
+
 					// context - Build Flavor
 					if(has_any_bits_set(failure, known_IHV_failure::FLAV_MASK)) {
-						Log(LogType::Warning) << "DMF: amptest_context.is_chk_build and is_ret_build functions are not implemented yet. Ignoring IHV_FAILURE context specifying build flavor." << std::endl;
+						Log(LogType::Warning, true) << "DMF: amptest_context.is_chk_build and is_ret_build functions are not implemented yet. Ignoring IHV_FAILURE context specifying build flavor." << std::endl;
 					}
-					
+
 					// context - AMP buffer aliasing
 					if(has_any_bits_set(failure, known_IHV_failure::ALIASING_MASK)) {
 						if(has_bits_set(failure, known_IHV_failure::ALIASING_FORCED)) {
@@ -684,7 +684,7 @@ namespace Concurrency {
 						} else {
 							throw amptest_exception("is_device_known_IHV_failure_impl: Unhandled aliasing flag.");
 						}
-					}					
+					}
 
 					return matches_context;
 				});
@@ -804,9 +804,9 @@ namespace Concurrency {
 
 			accelerator require_device_core(device_flags required_flags, vector<wstring> excluded_device_paths = vector<wstring>(0)) {
 				// Report what we're doing
-				Log() << "DMF: Getting required device: " << device_flags_to_string(required_flags) << std::endl;
+				Log(LogType::Info, true) << "DMF: Getting required device: " << device_flags_to_string(required_flags) << std::endl;
 				if(excluded_device_paths.size() > 0) {
-					Log() << "DMF:    excluding:" << std::endl;
+					Log(LogType::Info, true) << "DMF:    excluding:" << std::endl;
 					std::for_each(excluded_device_paths.begin(), excluded_device_paths.end(), [](const wstring& dpath) {
 						WLog() << "DMF:        " << dpath << std::endl;
 					});
@@ -846,7 +846,7 @@ namespace Concurrency {
 				}
 
 				// Make sure we have one to return
-				if(newLast - avail_infos.begin() == 0) {
+				if(newLast == avail_infos.begin()) {
 					throw amptest_skip("The required device could not be retrieved.");
 				}
 
@@ -855,7 +855,7 @@ namespace Concurrency {
 				// Log what we are returning
 				auto device_type = retrieved_device_type_to_string(device);
 				auto device_caps = retrieved_device_caps_to_string(device);
-				Log() << "DMF:    Returning " << device_type << " (" << device_caps << ")"
+				Log(LogType::Info, true) << "DMF:    Returning " << device_type << " (" << device_caps << ")"
 					<< " accelerator: " << device.get_description() << " (" << device.get_device_path() << ")" << std::endl;
 
 				// Handle IHV failures
@@ -865,7 +865,7 @@ namespace Concurrency {
 					static const char* err_msg = "The retrieved device is marked as a known IHV device failure.";
 					switch(dmf_known_IHV_failure_behavior) {
 					case known_IHV_failure_behavior::IGNORE_FAILURE:
-						Log(LogType::Warning) << "DMF: " << err_msg << std::endl;
+						Log(LogType::Warning, true) << "DMF: " << err_msg << std::endl;
 						break;
 					case known_IHV_failure_behavior::SKIP_TEST:
 						throw amptest_skip(err_msg);
@@ -876,7 +876,7 @@ namespace Concurrency {
 					}
 				}
 
-				Log() << std::endl;
+				Log(LogType::Info, true) << std::endl;
 				return device;
 			}
 
@@ -886,7 +886,7 @@ namespace Concurrency {
 					try {
 						return func();
 					} catch(amptest_skip& ex) {
-						Log(LogType::Warning) << ex.what() << std::endl;
+						Log(LogType::Warning, true) << ex.what() << std::endl;
 						exit(runall_skip);
 					}
 				} else {
@@ -924,7 +924,7 @@ namespace Concurrency {
 
 			// Parse the list
 			auto parts = split_string(trim(str), separator, true);
-			for_each(parts.begin(), parts.end(), [&flags, &src_desc](const string& prt) {
+			for (auto&& prt : parts) {
 				string part = trim(prt);
 				if(part.length() > 0) {
 					device_flags flg = parse_device_flag(part);
@@ -938,7 +938,7 @@ namespace Concurrency {
 
 					flags |= flg;
 				}
-			});
+			}
 
 			// Detect invalid flags
 			if(valid_flags != device_flags::NOT_SPECIFIED) {
@@ -987,7 +987,7 @@ namespace Concurrency {
 			if(parts.size() == 0) {
 				return "NOT_SPECIFIED";
 			}
-				
+
 			// Loop thru the parts and add a seperator
 			stringstream ss;
 			ss << parts[0];
@@ -1032,7 +1032,7 @@ namespace Concurrency {
 
 			details::ensure_dmf_initialized();
 
-			Log() << "DMF: Getting available devices: " << device_flags_to_string(required_flags) << std::endl;
+			Log(LogType::Info, true) << "DMF: Getting available devices: " << device_flags_to_string(required_flags) << std::endl;
 			vector<details::device_info> avail_infos = details::get_available_device_infos(required_flags);
 			auto newLast = avail_infos.end();
 
@@ -1077,7 +1077,7 @@ namespace Concurrency {
 				devices.push_back(dinfo.second);
 			});
 
-            Log() << "DMF:    Found " << devices.size() << " available devices." << std::endl;
+            Log(LogType::Info, true) << "DMF:    Found " << devices.size() << " available devices." << std::endl;
 			return devices;
 		}
 
@@ -1106,7 +1106,7 @@ namespace Concurrency {
 			// Note, since we'll be using the new device_flags features we could possibly get more coverage than the previous implementation
 
 			details::ensure_dmf_initialized();
-			
+
 			try {
 				device = details::require_device_core(required_flags);
 				return true;
@@ -1123,7 +1123,7 @@ namespace Concurrency {
 		// parts of the DMF.
 		// Note, these functions aren't marked with AMP_TEST_API as the tests in which they are used don't need it.
 		namespace dmf_testing {
-			
+
 			/// Ensures that the DMF is initialized without calling any of the public APIs.
 			/// This will cause all environment variables related to the DMF to be parsed.
 			void ensure_dmf_initialized() {
@@ -1140,7 +1140,7 @@ namespace Concurrency {
 			// Tells the DMF whether to throw an exception when the TARGET_DEVICE env var is used.
 			void set_TARGET_DEVICE_behavior(bool throw_failure) {
 				details::dmf_TARGET_DEVICE_throws_failure = throw_failure;
-				Log() << "DMF Testing: The TARGET_DEVICE behavior has been changed to: " << (throw_failure ? "throws amptest_failure" : "is supported") << std::endl;
+				Log(LogType::Info, true) << "DMF Testing: The TARGET_DEVICE behavior has been changed to: " << (throw_failure ? "throws amptest_failure" : "is supported") << std::endl;
 			}
 
 			/// Gets the parsed setting for the AMPTEST_ALLOWED_DEVICES environment variable.

--- a/amp-conformance/amp_test_lib/src/logging.cpp
+++ b/amp-conformance/amp_test_lib/src/logging.cpp
@@ -63,7 +63,7 @@ namespace Concurrency
             LogType g_verbose = LogType::Info;
 
 			static inline std::ostream& get_raw_log_stream(LogType type) {
-	
+
 				switch (type)
 				{
 				case LogType::Info:
@@ -82,7 +82,7 @@ namespace Concurrency
 
 				// Compose the prefix as a string so it won't get broken up
 				std::stringstream ss;
-				ss << get_timestamp() << " AMPTest: ";
+				ss << get_timestamp(false) << " AMPTest: ";
 				if(type == LogType::Warning) {
 					ss << "Warning: ";
 				} else if(type == LogType::Error) {
@@ -201,7 +201,7 @@ namespace Concurrency
 #pragma warning(disable:4996)
 			int actual_len = vsnprintf(c_msg.get(), len+1, msg, args);
 #pragma warning(default:4996)
-			Log(type) << c_msg.get() << std::endl;
+			Log(type, true) << c_msg.get() << std::endl;
 
             va_end(args);
 
@@ -209,7 +209,7 @@ namespace Concurrency
 			{
 				// The code above should ensure this doesn't happen.  However, I'd prefer to fail fast if we
 				// do ever see it.
-				Log(LogType::Warning) << "The previous message was unexpectedly truncated" << std::endl;
+				Log(LogType::Warning, true) << "The previous message was unexpectedly truncated" << std::endl;
 				throw amptest_exception("Log_Writeline() message was unexpectedly truncated");
 			}
         }
@@ -226,10 +226,10 @@ namespace Concurrency
                 return; // message does not have required verbosity
             }
 
-			Log(type) << std::endl;
+			Log(type, true) << std::endl;
 		}
-		
-		std::string AMP_TEST_API get_type_name(const std::type_info& ti) {			
+
+		std::string AMP_TEST_API get_type_name(const std::type_info& ti) {
 
 			if(ti == typeid(std::string)) {
 				return "string";
@@ -256,7 +256,7 @@ namespace Concurrency
 
 			return tname;
 		}
-		
+
 		std::ostream& AMP_TEST_API LogStream()
         {
 			return amptest_context.get_raw_stdout_stream();

--- a/amp-conformance/amp_test_lib/src/main.cpp
+++ b/amp-conformance/amp_test_lib/src/main.cpp
@@ -40,7 +40,7 @@ namespace Concurrency {
 				try {
 					amptest_context_enable_debugging = amptest_context.get_environment_variable("AMPTEST_ENABLE_DEBUGGING", false);
 				} catch(std::exception& ex) {
-					Log(LogType::Error) << "Error loading AMPTest context: " << ex.what() << std::endl;
+					Log(LogType::Error, true) << "Error loading AMPTest context: " << ex.what() << std::endl;
 					exit(runall_fail);
 				}
 			}
@@ -53,19 +53,19 @@ namespace Concurrency {
 
 					result = test_main();
 				} catch(amptest_skip e) {
-					Log(LogType::Warning) << e.what() << std::endl;
+					Log(LogType::Warning, true) << e.what() << std::endl;
 					result = runall_skip;
 				} catch(amptest_cascade_failure e) {
-					Log(LogType::Error) << e.what() << std::endl;
+					Log(LogType::Error, true) << e.what() << std::endl;
 					result = runall_cascade_fail;
 				} catch(amptest_failure e) {
-					Log(LogType::Error) << e.what() << std::endl;
+					Log(LogType::Error, true) << e.what() << std::endl;
 					result = runall_fail;
 				} catch(const amptest_exception& e) {
-					Log(LogType::Error) << "test_main() threw unhandled " << get_type_name(e) << " exception: " << e.what() << std::endl;
+					Log(LogType::Error, true) << "test_main() threw unhandled " << get_type_name(e) << " exception: " << e.what() << std::endl;
 					result = runall_fail;
 				}
-				Log() << "test_main(): Returned " << result << std::endl;
+				Log(LogType::Info, true) << "test_main(): Returned " << result << std::endl;
 				return result;
 			}
 
@@ -75,27 +75,27 @@ namespace Concurrency {
 					return invoke_test_main();
 				} catch(concurrency::accelerator_view_removed& ex) {
 					// If we catch a TDR, then lets be sure to print out the reason too
-					Log(LogType::Error) << "test_main() threw unhandled " << get_type_name(ex) << " exception "
+					Log(LogType::Error, true) << "test_main() threw unhandled " << get_type_name(ex) << " exception "
 						<< "(error code: 0x" << std::hex << ex.get_error_code() << std::dec
 						<< ", reason code: 0x" << std::hex << ex.get_view_removed_reason() << std::dec
 						<< "): "
 						<< ex.what() << std::endl;
 					return runall_fail;
 				} catch(concurrency::runtime_exception& ex) {
-					Log(LogType::Error) << "test_main() threw unhandled " << get_type_name(ex) << " exception "
+					Log(LogType::Error, true) << "test_main() threw unhandled " << get_type_name(ex) << " exception "
 						<< "(error code: 0x" << std::hex << ex.get_error_code() << std::dec << "): "
 						<< ex.what() << std::endl;
 					return runall_fail;
 				} catch(const std::exception& ex) {
-					Log(LogType::Error) << "test_main() threw unhandled " << get_type_name(ex) << " exception: " << ex.what() << std::endl;
+					Log(LogType::Error, true) << "test_main() threw unhandled " << get_type_name(ex) << " exception: " << ex.what() << std::endl;
 					return runall_fail;
 				} catch(const char* exmsg) {
-					Log(LogType::Error) << "test_main() threw unhandled exception: " << exmsg << std::endl;
+					Log(LogType::Error, true) << "test_main() threw unhandled exception: " << exmsg << std::endl;
 					return runall_fail;
 				}
-				catch(...)	
+				catch(...)
 				{
-					Log(LogType::Error) << "test_main() threw unhandled unknown exception caught." << std::endl;
+					Log(LogType::Error, true) << "test_main() threw unhandled unknown exception caught." << std::endl;
 					return runall_fail;
 				}
 			}
@@ -112,7 +112,7 @@ namespace Concurrency {
 			} else {
 				test_result = details::invoke_test_main_with_exception_handling();
 			}
-			
+
 			return test_result.get_exit_code();
 		}
 	} // namespace Test


### PR DESCRIPTION
This re-enables the upstream patch, after fixing the issues it was spawning:
    - upstream did not include our C++ AMP / HC specific bits - this was corrected via merging;
    - the new behaviour brought to the fore some dubious behaviour in the conformance suite we inherited - this was corrected by small edits in some of the helper functions; ideally, we will end up fully refactoring the conformance suite.
Thank you.