### PR TITLE
Added CodeXL Activity Logger header file and library to the CMake files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,20 @@ dpkg -i libc++-dev_3.9.0-3_amd64.deb
 ```
 
 This replaces previous version of libc++.
+
+CodeXL Activity Logger
+======================
+To enable the [CodeXL Activity Logger](https://github.com/RadeonOpenCompute/ROCm-Profiler/tree/master/CXLActivityLogger), use `USE_CODEXL_ACTIVITY_LOGGER` env var.
+
+Configure the build like: 
+
+```
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DHSA_AMDGPU_GPU_TARGET=<AMD GPU ISA version string> \
+    -DROCM_DEVICE_LIB_DIR=<where bitcodes of ROCm-Device-Libs are> \
+    -DUSE_CODEXL_ACTIVITY_LOGGER=1 \
+    <ToT HCC checkout directory>
+```
+
+For the usage of the Activity Logger for profiling, please refer to its [documentation](https://github.com/RadeonOpenCompute/ROCm-Profiler/blob/master/CXLActivityLogger/doc/AMDTActivityLogger.pdf).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,6 +47,41 @@ install(PROGRAMS ${PROJECT_BINARY_DIR}/bin/extractkernel
     DESTINATION bin)
 
 ####################
+# CodeXL Activity Logger
+####################
+if (USE_CODEXL_ACTIVITY_LOGGER EQUAL 1)
+MESSAGE("")
+MESSAGE("CodeXL INFORMATION")
+
+####################
+# CodeXL Activity Logger header
+####################
+find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES include/CXLActivityLogger.h PATHS ${CODEXL_ACTIVITY_LOGGER_HEADER_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger NO_DEFAULT_PATH)
+find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES include/CXLActivityLogger.h)
+
+if (NOT CODEXL_ACTIVITY_LOGGER_HEADER)
+  MESSAGE("ERROR: CodeXL header not found. use -DCODEXL_ACTIVITY_LOGGER_HEADER_DIR=<path_to_CXLActivityLogger.h>.")
+else (NOT CODEXL_ACTIVITY_LOGGER_HEADER)
+  MESSAGE("CODEXL_ACTIVITY_LOGGER_HEADER_DIR = ${CODEXL_ACTIVITY_LOGGER_HEADER_DIR}, actually found at: ${CODEXL_ACTIVITY_LOGGER_HEADER}")
+  include_directories(${CODEXL_ACTIVITY_LOGGER_HEADER})
+endif (NOT CODEXL_ACTIVITY_LOGGER_HEADER)
+
+####################
+# CodeXL Activity Logger Library
+####################
+find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES x86_64/libCXLActivityLogger.so PATHS ${CODEXL_ACTIVITY_LOGGER_LIBRARY_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger/bin NO_DEFAULT_PATH)
+find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES x86_64/libCXLActivityLogger.so)
+
+if (NOT CODEXL_ACTIVITY_LOGGER_LIBRARY)
+  MESSAGE("ERROR: CodeXL Activity Logger library not found. Use -DCODEXL_ACTIVITY_LOGGER_LIBRARY_DIR=<path_to_libCXLActivityLogger.so>.")
+else (NOT CODEXL_ACTIVITY_LOGGER_LIBRARY)
+  MESSAGE("CODEXL_ACTIVITY_LOGGER_LIBRARY_DIR = ${CODEXL_ACTIVITY_LOGGER_LIBRARY_DIR}, actually found at: ${CODEXL_ACTIVITY_LOGGER_LIBRARY}")
+endif (NOT CODEXL_ACTIVITY_LOGGER_LIBRARY)
+
+MESSAGE("")
+endif (USE_CODEXL_ACTIVITY_LOGGER EQUAL 1)
+
+####################
 # add subdirectories
 ####################
 add_subdirectory(hsa)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,8 +56,8 @@ MESSAGE("CodeXL INFORMATION")
 ####################
 # CodeXL Activity Logger header
 ####################
-find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES include/CXLActivityLogger.h PATHS ${CODEXL_ACTIVITY_LOGGER_HEADER_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger NO_DEFAULT_PATH)
-find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES include/CXLActivityLogger.h)
+find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES CXLActivityLogger.h PATHS ${CODEXL_ACTIVITY_LOGGER_HEADER_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger/include NO_DEFAULT_PATH)
+find_path(CODEXL_ACTIVITY_LOGGER_HEADER NAMES CXLActivityLogger.h)
 
 if (NOT CODEXL_ACTIVITY_LOGGER_HEADER)
   MESSAGE("ERROR: CodeXL header not found. use -DCODEXL_ACTIVITY_LOGGER_HEADER_DIR=<path_to_CXLActivityLogger.h>.")
@@ -69,8 +69,8 @@ endif (NOT CODEXL_ACTIVITY_LOGGER_HEADER)
 ####################
 # CodeXL Activity Logger Library
 ####################
-find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES x86_64/libCXLActivityLogger.so PATHS ${CODEXL_ACTIVITY_LOGGER_LIBRARY_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger/bin NO_DEFAULT_PATH)
-find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES x86_64/libCXLActivityLogger.so)
+find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES libCXLActivityLogger.so PATHS ${CODEXL_ACTIVITY_LOGGER_LIBRARY_DIR} ${ROCM_ROOT}/profiler/CXLActivityLogger/bin/x86_64 NO_DEFAULT_PATH)
+find_path(CODEXL_ACTIVITY_LOGGER_LIBRARY NAMES libCXLActivityLogger.so)
 
 if (NOT CODEXL_ACTIVITY_LOGGER_LIBRARY)
   MESSAGE("ERROR: CodeXL Activity Logger library not found. Use -DCODEXL_ACTIVITY_LOGGER_LIBRARY_DIR=<path_to_libCXLActivityLogger.so>.")

--- a/lib/hsa/CMakeLists.txt
+++ b/lib/hsa/CMakeLists.txt
@@ -12,3 +12,15 @@ MESSAGE(STATUS "ROCm available, going to build HSA HCC Runtime")
 else (HAS_ROCM EQUAL 1)
 MESSAGE(STATUS "ROCm NOT available, NOT going to build HSA HCC Runtime")
 endif (HAS_ROCM EQUAL 1)
+
+####################
+# CodeXL Activity Logger Library
+####################
+if (USE_CODEXL_ACTIVITY_LOGGER EQUAL 1)
+if (CODEXL_ACTIVITY_LOGGER_LIBRARY)
+  include_directories(${CODEXL_ACTIVITY_LOGGER_LIBRARY})
+  target_link_libraries(mcwamp_hsa ${CODEXL_ACTIVITY_LOGGER_LIBRARY}/libCXLActivityLogger.so)
+  target_link_libraries(hc_am ${CODEXL_ACTIVITY_LOGGER_LIBRARY}/libCXLActivityLogger.so)
+endif (CODEXL_ACTIVITY_LOGGER_LIBRARY)
+endif (USE_CODEXL_ACTIVITY_LOGGER EQUAL 1)
+


### PR DESCRIPTION
Allows CodeXL Activity Logger to be used in HCC.
To enable set the environment variable USE_CODEXL_ACTIVITY_LOGGER to 1 when building HCC