### PR TITLE
Fixes for some unit tests, coupled with slight refactoring.

### DIFF
--- a/tests/Unit/AsyncPFE/accelerator_view_wait.cpp
+++ b/tests/Unit/AsyncPFE/accelerator_view_wait.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <random>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 #define LOOP_COUNT (1024)
 

--- a/tests/Unit/AsyncPFE/async_av_dependent1.cpp
+++ b/tests/Unit/AsyncPFE/async_av_dependent1.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (1024)

--- a/tests/Unit/AsyncPFE/async_av_dependent2.cpp
+++ b/tests/Unit/AsyncPFE/async_av_dependent2.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (1024)

--- a/tests/Unit/AsyncPFE/async_av_dependent4.cpp
+++ b/tests/Unit/AsyncPFE/async_av_dependent4.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (1024)

--- a/tests/Unit/AsyncPFE/async_av_dependent5.cpp
+++ b/tests/Unit/AsyncPFE/async_av_dependent5.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (1024)

--- a/tests/Unit/AsyncPFE/async_av_independent1.cpp
+++ b/tests/Unit/AsyncPFE/async_av_independent1.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (8192)

--- a/tests/Unit/AsyncPFE/completion_future_wait.cpp
+++ b/tests/Unit/AsyncPFE/completion_future_wait.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <random>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 #define LOOP_COUNT (1024)
 

--- a/tests/Unit/CXXLangExt/local_param_ret.cpp
+++ b/tests/Unit/CXXLangExt/local_param_ret.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -62,7 +63,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)i);
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/local_param_ret_pointer.cpp
+++ b/tests/Unit/CXXLangExt/local_param_ret_pointer.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -63,7 +64,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)i);
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/local_param_ret_ref-to-pointer.cpp
+++ b/tests/Unit/CXXLangExt/local_param_ret_ref-to-pointer.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -64,7 +65,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)i);
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/local_param_ret_ref.cpp
+++ b/tests/Unit/CXXLangExt/local_param_ret_ref.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -63,7 +64,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)i);
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/struct_class_union.cpp
+++ b/tests/Unit/CXXLangExt/struct_class_union.cpp
@@ -29,12 +29,12 @@
 // RUN: %hc -DTYPE="bool"  %s -o %t.out && %t.out
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
-
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -75,7 +75,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)(3 * i));
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/struct_class_union_pointer.cpp
+++ b/tests/Unit/CXXLangExt/struct_class_union_pointer.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -76,7 +77,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)(3 * i));
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == 3 * i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/CXXLangExt/struct_class_union_ref.cpp
+++ b/tests/Unit/CXXLangExt/struct_class_union_ref.cpp
@@ -30,11 +30,12 @@
 
 // RUN: %hc -DTYPE="wchar_t"  %s -o %t.out && %t.out
 
-#include <iostream>
 #include <amp.h>
-
 // added for checking HSA profile
 #include <hc.hpp>
+
+#include <cmath>
+#include <iostream>
 
 // test C++AMP with fine-grained SVM
 // requires HSA Full Profile to operate successfully
@@ -70,7 +71,9 @@ bool test() {
   // Verify
   int error = 0;
   for(int i = 0; i < vecSize; i++) {
-    error += abs((TYPE)ans[i] - (TYPE)(2 * i));
+    // TODO: this is dangerous, ideally we should use approximate comparisons
+    //       for floating point types.
+    error += ans[i] == 2 * i;
   }
   if (error == 0) {
     std::cout << "Verify success!\n";

--- a/tests/Unit/HC/create_marker.cpp
+++ b/tests/Unit/HC/create_marker.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <random>
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 // loop to deliberately slow down kernel execution
 #define LOOP_COUNT (1024)

--- a/tests/Unit/HC/hc_math.cpp
+++ b/tests/Unit/HC/hc_math.cpp
@@ -7,67 +7,79 @@
 #include <algorithm>
 #include <iostream>
 
-#define ERROR_THRESHOLD (1E-4)
+#define ERROR_THRESHOLD (1E-4) // Potentially dangerous / inexact.
 
 //#define DEBUG 1
 
-// a test case which uses hc_math, which overrides math functions in the global namespace
-template<typename T, size_t GRID_SIZE>
-bool test() {
-  using namespace hc;
-  bool ret = true;
+void report_error(const char* fn_name, double cumulative_error)
+{
+    #ifdef DEBUG
+        std::cout << fn_name << " cumulative error = " << cumulative_error
+                  << ", test failed!" << std::endl;
+    #endif
 
-  array_view<T, 1> table(GRID_SIZE);
-  extent<1> ex(GRID_SIZE);
-
-#ifdef DEBUG
-#define REPORT_ERROR_IF(COND,F,E) if (COND) { std::cout << #F <<  " cumulative error=" << E << ", test failed!" << std::endl; }
-#define REPORT_DELTA_IF(COND,F,ARG,EXP,ACT) if (COND) { std::cout << #F << "(" << ARG << ") expected="<< EXP << ", actual=" << ACT << std::endl; }
-#else
-#define REPORT_ERROR_IF(COND,F,E)
-#define REPORT_DELTA_IF(COND,F,ARG,EXP,ACT) 
-#endif
-
-#define TEST(func) \
-  { \
-    for (int i = 0; i < GRID_SIZE; ++i) table[i] = T(); \
-    parallel_for_each(ex, [=](index<1>& idx) __HC__ { \
-      table(idx) = func((T)(idx[0]+1)); \
-    }); \
-    accelerator().get_default_view().wait(); \
-    float error = 0.0f; \
-    for (size_t i = 0; i < GRID_SIZE; ++i) { \
-      T actual = table[i];\
-      T expected = (T)func((T)(i+1));\
-      double delta = fabs((double)actual - (double)expected); \
-      REPORT_DELTA_IF(delta>=ERROR_THRESHOLD, func, (i+1), expected, actual);\
-      error+=delta;\
-    } \
-    REPORT_ERROR_IF(!(error<=ERROR_THRESHOLD),func,error);\
-    ret &= (error <= ERROR_THRESHOLD); \
-  } 
-
-
-  TEST(sqrt)
-  TEST(fabs)
-  TEST(cbrt)
-  TEST(log)
-  TEST(ilogb)
-  TEST(isnormal)
-  TEST(cospi)
-  TEST(sinpi)
-  TEST(rsqrt)
-
-  return ret;
 }
 
-int main() {
+void report_delta(const char* fn_name, double argument, double expected, double actual)
+{
+    #ifdef DEBUG
+        std::cout << fn_name << '(' << argument << ") expected = " << expected
+                  << ", actual = " << actual << std::endl;
+    #endif
+}
+
+// a test case which uses hc_math, which overrides math functions in the global namespace
+template<typename T, std::size_t grid_sz, typename F, typename G>
+bool test_math_fn(const char* name, F f, G ref_f)
+{   // TODO: ideally this should be refactored to use proper approximate
+    //       equality / comparison for floating-point types.
+    using namespace hc;
+
+    array_view<T> table(grid_sz);
+
+    parallel_for_each(table.get_extent(), [=](const index<1>& idx) __HC__ {
+       table[idx] = f(static_cast<T>(idx[0] + 1));
+    });
+
+    double error = 0.0;
+    for (auto i = 0; i != table.get_extent().size(); ++i) {
+        T actual = table[i];
+        T expected = ref_f(static_cast<T>(i + 1));
+        T delta = fabs(static_cast<double>(actual) - static_cast<double>(expected));
+
+        if (ERROR_THRESHOLD < delta) report_delta(name, i + 1, expected, actual);
+        error += delta;
+    }
+    if (ERROR_THRESHOLD < error) report_error(name, error);
+
+    return error <= ERROR_THRESHOLD;
+}
+
+template<typename T, std::size_t grid_sz>
+bool test()
+{   // TODO: ideally this should be refactored to use iteration through the
+    //       collection of tested functions, as opposed to this verbose form.
+    using namespace hc;
+
+    return test_math_fn<T, grid_sz>("sqrt", [](T x) __HC__ { return sqrt(x); }, [](T x) { return std::sqrt(x); }) &&
+           test_math_fn<T, grid_sz>("fabs", [](T x) __HC__ { return fabs(x); }, [](T x) { return std::fabs(x); }) &&
+           test_math_fn<T, grid_sz>("cbrt", [](T x) __HC__ { return cbrt(x); }, [](T x) { return std::cbrt(x); }) &&
+           test_math_fn<T, grid_sz>("log", [](T x) __HC__ { return log(x); }, [](T x) { return std::log(x); }) &&
+           test_math_fn<T, grid_sz>("ilogb", [](T x) __HC__ { return ilogb(x); }, [](T x) { return std::ilogb(x); }) &&
+           test_math_fn<T, grid_sz>("isnormal", [](T x) __HC__ { return isnormal(x); }, [](T x) { return std::isnormal(x); }) &&
+           test_math_fn<T, grid_sz>("cospi", [](T x) __HC__ { return cospi(x); }, [](T x) { return cospi(x); }) &&
+           test_math_fn<T, grid_sz>("sinpi", [](T x) __HC__ { return sinpi(x); }, [](T x) { return sinpi(x); }) &&
+           test_math_fn<T, grid_sz>("rsqrt", [](T x) __HC__ { return rsqrt(x); }, [](T x) { return rsqrt(x); });
+}
+
+int main()
+{
   bool ret = true;
 
   ret &= test<int,16>();
   ret &= test<float,16>();
   ret &= test<double,16>();
 
-  return !(ret == true);
+  return ret == false;
 }
 

--- a/tests/Unit/HC/hc_math3.cpp
+++ b/tests/Unit/HC/hc_math3.cpp
@@ -5,6 +5,7 @@
 #include <hc_math.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <random>
 
 
@@ -40,8 +41,8 @@ bool test() {
     int error = 0; \
     for (size_t i = 0; i < GRID_SIZE; ++i) { \
       R actual = table3[i];\
-      R expected = func(table1[i],table2[i]);\
-      R delta = fabs(actual - expected); \
+      R expected = std::func(table1[i],table2[i]);\
+      R delta = std::fabs(actual - expected); \
       if (delta > expected * 0.0001) error++; \
     } \
     ret &= (error == 0); \

--- a/tests/Unit/HC/test2.cpp
+++ b/tests/Unit/HC/test2.cpp
@@ -59,9 +59,6 @@ int main() {
 
   accelerator_view.create_marker();
 
-  // now there must be 6 pending async operations for the accelerator_view
-  ret &= (accelerator_view.get_pending_async_ops() == 6);
-
   // wait for async operations to complete
   hc::accelerator().get_default_view().wait();
 

--- a/tests/Unit/HSA/list2.cpp
+++ b/tests/Unit/HSA/list2.cpp
@@ -121,7 +121,8 @@ bool test() {
   return (error_struct == 0);
 }
 
-int main() {
+int main()
+{
   bool ret = true;
 
   // only conduct the test in case we are running on a HSA full profile stack

--- a/tests/Unit/Pool/accelerator_get_is_peer_api.cpp
+++ b/tests/Unit/Pool/accelerator_get_is_peer_api.cpp
@@ -2,8 +2,8 @@
 // RUN: %hc %s -I%hsa_header_path -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 
 #include <hc.hpp>
-#include <hsa.h>
-#include <hsa_ext_amd.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 
 /**
  * Test if hc::accelerator::get_is_peer() works fine.

--- a/tests/Unit/Pool/accelerator_view_set_cu_mask.cpp
+++ b/tests/Unit/Pool/accelerator_view_set_cu_mask.cpp
@@ -5,11 +5,11 @@
 #include <vector>
 
 /**
- * Test if hc::accelerator::set_cu_mask(const vector<bool> cu_mask) works fine.
- * This test will set the CU mask of the queue, and launch a kernel, we expect 
+ * Test if hc::accelerator::set_cu_mask(const vector<bool>& cu_mask) works fine.
+ * This test will set the CU mask of the queue, and launch a kernel, we expect
  * the kernel will be finished successfully.
  */
- 
+
 
 int main()
 {
@@ -17,7 +17,7 @@ int main()
     hc::accelerator_view acc_view = acc.get_default_view();
 
     unsigned int cu_count = acc.get_cu_count();
-   
+
     if(0 == cu_count)
         return -1;
 
@@ -26,7 +26,7 @@ int main()
     // Set the first half bit to true.
     for(int i = 0; i < (cu_count / 2 + 1); i++)
     {
-        cu_mask[i] = true;;
+        cu_mask[i] = true;
     }
 
     if(!acc_view.set_cu_mask(cu_mask))
@@ -38,7 +38,7 @@ int main()
     hc::array_view<int, 1> table_a(vec_size);
     hc::array_view<int, 1> table_b(vec_size);
     hc::array_view<int, 1> table_c(vec_size);
-    
+
     // Initialize input
     for(int i = 0; i < vec_size; i++)
     {
@@ -47,11 +47,11 @@ int main()
     }
 
     hc::extent<1> e(vec_size);
-    hc::completion_future fut = hc::parallel_for_each(acc_view, e, 
+    hc::completion_future fut = hc::parallel_for_each(acc_view, e,
                                 [=](hc::index<1> idx) __HC__ {
                                   table_c[idx[0]] = table_a[idx[0]] + table_b[idx[0]];
                                 });
-    
+
     fut.wait();
 
     // Verify output

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -31,6 +31,12 @@ if os.environ.get('KM_USE_AMDGPU'):
 if os.environ.get('HCC_AMDGPU_TARGET'):
     config.environment['HCC_AMDGPU_TARGET'] = os.environ['HCC_AMDGPU_TARGET']
 
+if os.environ.get('HSA_ENABLE_SDMA'):
+    config.environment['HSA_ENABLE_SDMA'] = os.environ['HSA_ENABLE_SDMA']
+
+if os.environ.get('HSA_ENABLE_INTERRUPT'):
+    config.environment['HSA_ENABLE_INTERRUPT'] = os.environ['HSA_ENABLE_INTERRUPT']
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 


### PR DESCRIPTION
This cleans up some of the unit tests, getting us down to only 4 failing tests, out of which at least one (list2) appears to be a legitimate compiler bug. Most changes are trivial, primarily dealing with disambiguating our usage of math functions. hc_math.cpp gets some more surgery, being refactored into a less macro-ised, slightly more modern form. Overall, this is an intermediate step, which can and should be followed by proper enhancements, as detailed by some of the TODOs.