### PR TITLE
remove trailing newline generated by hcc_config

### DIFF
--- a/hcc_config/hcc_config.cpp
+++ b/hcc_config/hcc_config.cpp
@@ -64,8 +64,6 @@ void cxxflags(void) {
     // CodeXL Activity Logger
     std::cout << " -I" XSTR(CODEXL_ACTIVITY_LOGGER_HEADER);
 #endif
-
-    std::cout << std::endl;
 }
 
 void ldflags(void) {
@@ -102,8 +100,6 @@ void ldflags(void) {
     std::cout << " -L" XSTR(CODEXL_ACTIVITY_LOGGER_LIBRARY);
     std::cout << " -lCXLActivityLogger";
 #endif
-
-    std::cout << std::endl;
 }
 
 void prefix(void) {


### PR DESCRIPTION
remove the trailing \n from hcc_config which occasionally causes the link step of applications to fail 