### PR TITLE
replace std::align to posix_memalign

### DIFF
--- a/include/kalmar_aligned_alloc.h
+++ b/include/kalmar_aligned_alloc.h
@@ -26,7 +26,7 @@ inline void* kalmar_aligned_alloc(std::size_t alignment, std::size_t size) noexc
     }
     std::size_t n = size + alignment - N;
     void* p1 = 0;
-    void* p2 = std::malloc(n + sizeof p1);
+    void* p2 = std::malloc(n + sizeof(p1));
     if (p2) {
         p1 = static_cast<char*>(p2) + sizeof(p1);
         posix_memalign(&p1,alignment,size);

--- a/include/kalmar_aligned_alloc.h
+++ b/include/kalmar_aligned_alloc.h
@@ -28,8 +28,8 @@ inline void* kalmar_aligned_alloc(std::size_t alignment, std::size_t size) noexc
     void* p1 = 0;
     void* p2 = std::malloc(n + sizeof p1);
     if (p2) {
-        p1 = static_cast<char*>(p2) + sizeof p1;
-        (void)std::align(alignment, size, p1, n);
+        p1 = static_cast<char*>(p2) + sizeof(p1);
+        posix_memalign(&p1,alignment,size);
         *(static_cast<void**>(p1) - 1) = p2;
     }
     return p1;


### PR DESCRIPTION
This commit replaces std::align to posix_memalign, and fix the missing parenthesis of "sizeof(p1)".