### PR TITLE
Revert "replace std::align to posix_memalign"

### DIFF
--- a/include/kalmar_aligned_alloc.h
+++ b/include/kalmar_aligned_alloc.h
@@ -26,10 +26,10 @@ inline void* kalmar_aligned_alloc(std::size_t alignment, std::size_t size) noexc
     }
     std::size_t n = size + alignment - N;
     void* p1 = 0;
-    void* p2 = std::malloc(n + sizeof(p1));
+    void* p2 = std::malloc(n + sizeof p1);
     if (p2) {
-        p1 = static_cast<char*>(p2) + sizeof(p1);
-        posix_memalign(&p1,alignment,size);
+        p1 = static_cast<char*>(p2) + sizeof p1;
+        (void)std::align(alignment, size, p1, n);
         *(static_cast<void**>(p1) - 1) = p2;
     }
     return p1;


### PR DESCRIPTION
Reverts RadeonOpenCompute/hcc#221

This patch is causing a lot of regressions in hcc's "make test".  Replace investigate and fix the problems before re-submitting this patch