### PR TITLE
Feature finish opt flush2

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -242,6 +242,11 @@ public:
      * commands that were submitted prior to the marker event creation have
      * completed, the future is ready.
      *
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * the marker always ensures older commands complete before the returned completion_future
+     * is marked ready.   Thus, markers provide a mechanism to enforce order between
+     * commands in an execute_any_order accelerator_view.
+     *
      * @return A future which can be waited on, and will block until the
      *         current batch of commands has completed.
      */
@@ -255,6 +260,11 @@ public:
      * dependent event and all commands submitted prior to the marker event
      * creation have been completed, the future is ready.
      *
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * the marker always ensures older commands complete before the returned completion_future
+     * is marked ready.   Thus, markers provide a mechanism to enforce order between
+     * commands in an execute_any_order accelerator_view.
+     *
      * @return A future which can be waited on, and will block until the
      *         current batch of commands, plus the dependent event have
      *         been completed.
@@ -266,8 +276,13 @@ public:
      * queue with arbitrary number of dependent asynchronous events.
      *
      * This marker is returned as a completion_future object. When its
-     * dependent event and all commands submitted prior to the marker event
-     * creation have been completed, the future is ready.
+     * dependent events and all commands submitted prior to the marker event
+     * creation have been completed, the completion_future is ready.
+     *
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * the marker always ensures older commands complete before the returned completion_future
+     * is marked ready.   Thus, markers provide a mechanism to enforce order between
+     * commands in an execute_any_order accelerator_view.
      *
      * @return A future which can be waited on, and will block until the
      *         current batch of commands, plus the dependent event have
@@ -310,10 +325,13 @@ public:
      * Src and dst must not overlap.  
      * Note the src is the first parameter and dst is second, following C++ convention.  
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
+     * If the source or dest is host memory, the memory must be pinned or a runtime exception will be thrown.
+     * Pinned memory can be created with am_alloc with flag=amHostPinned flag.
      *
      * The copy command will be implicitly ordered with respect to commands previously equeued to this accelerator_view:
-     * - If the queue execute_order is execute_in_order (the default), then the copy will execute after all previously sent commands finish execution.
-     * - If the queue execute_order is execute_any_order, then the copy will start after all previously send commands start but can execute in any order.
+     * - If the accelerator_view execute_order is execute_in_order (the default), then the copy will execute after all previously sent commands finish execution.
+     * - If the accelerator_view execute_order is execute_any_order, then the copy will start after all previously send commands start but can execute in any order.
+     *
      *
      */
     completion_future copy_async(const void *src, void *dst, size_t size_bytes);
@@ -324,10 +342,12 @@ public:
      * Src and dst must not overlap.  
      * Note the src is the first parameter and dst is second, following C++ convention.  
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
+     * If the source or dest is host memory, the memory must be pinned or a runtime exception will be thrown.
+     * Pinned memory can be created with am_alloc with flag=amHostPinned flag.
      *
      * The copy command will be implicitly ordered with respect to commands previously enqueued to this accelerator_view:
-     * - If the queue execute_order is execute_in_order (the default), then the copy will execute after all previously sent commands finish execution.
-     * - If the queue execute_order is execute_any_order, then the copy will start after all previously send commands start but can execute in any order.
+     * - If the accelerator_view execute_order is execute_in_order (the default), then the copy will execute after all previously sent commands finish execution.
+     * - If the accelerator_view execute_order is execute_any_order, then the copy will start after all previously send commands start but can execute in any order.
      *   The copyAcc determines where the copy is executed and does not affect the ordering.
      *
      * The copy_async_ext flavor allows caller to provide additional information about each pointer, which can improve performance by eliminating replicated lookups,

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -399,11 +399,21 @@ public:
      * Returns the number of pending asynchronous operations on this
      * accelerator view.
      *
-     * The number returned would be immediately obsolete. This functions shall
-     * only be used for testing and debugging purpose.
+     * Care must be taken to use this API in a thread-safe manner,
      */
     int get_pending_async_ops() {
         return pQueue->getPendingAsyncOps();
+    }
+
+    /**
+     * Returns true if the accelerator_view is currently empty.
+     *
+     * Care must be taken to use this API in a thread-safe manner.
+     * As the accelerator completes work, the queue may become empty
+     * after this function returns false;
+     */
+    int get_is_empty() {
+        return pQueue->isEmpty();
     }
 
     /**

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -290,6 +290,27 @@ public:
      */
     completion_future create_blocking_marker(std::initializer_list<completion_future> dependent_future_list, memory_scope scope=system_scope) const;
 
+
+    /**
+     * This command inserts a marker event into the accelerator_view's command
+     * queue with arbitrary number of dependent asynchronous events.
+     *
+     * This marker is returned as a completion_future object. When its
+     * dependent events and all commands submitted prior to the marker event
+     * creation have been completed, the completion_future is ready.
+     *
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * the marker always ensures older commands complete before the returned completion_future
+     * is marked ready.   Thus, markers provide a mechanism to enforce order between
+     * commands in an execute_any_order accelerator_view.
+     *
+     * @return A future which can be waited on, and will block until the
+     *         current batch of commands, plus the dependent event have
+     *         been completed.
+     */
+    template<typename InputIterator>
+    completion_future create_blocking_marker(InputIterator first, InputIterator last, memory_scope scope) const;
+
     /**
      * Copies size_bytes bytes from src to dst.  
      * Src and dst must not overlap.  
@@ -630,9 +651,6 @@ private:
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<1>&, const Kernel&);
 
-    // private member function template to create a marker from iterators
-    template<typename InputIterator>
-    completion_future create_blocking_marker(InputIterator first, InputIterator last, memory_scope scope) const;
 
 #if __KALMAR_ACCELERATOR__ == 2 || __KALMAR_CPU__ == 2
 public:

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -433,7 +433,7 @@ public:
      * As the accelerator completes work, the queue may become empty
      * after this function returns false;
      */
-    int get_is_empty() {
+    bool get_is_empty() {
         return pQueue->isEmpty();
     }
 

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -37,6 +37,15 @@ enum execute_order
     execute_any_order
 };
 
+
+// Flags to specify visibility of previous commands after a marker is executed.
+enum memory_scope
+{
+    accelerator_scope,  // One accelerator scope 
+    system_scope,       // CPU + All accelerators
+};
+
+
 enum hcCommandKind {
     hcCommandInvalid= -1,
 
@@ -47,6 +56,7 @@ enum hcCommandKind {
     hcCommandKernel = 4,
     hcCommandMarker = 5,
 };
+
 
 static inline bool isCopyCommand(hcCommandKind k) 
 {
@@ -226,11 +236,11 @@ public:
   virtual bool hasHSAInterOp() { return false; }
 
   /// enqueue marker
-  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarker() { return nullptr; }
+  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarker(memory_scope) { return nullptr; }
 
   /// enqueue marker with prior dependency
-  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(int count, std::shared_ptr <KalmarAsyncOp> *depOps) { return nullptr; }
-  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(std::shared_ptr <KalmarAsyncOp> depOp) { return EnqueueMarkerWithDependency(1, &depOp); };
+  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(int count, std::shared_ptr <KalmarAsyncOp> *depOps, memory_scope scope) { return nullptr; }
+  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(std::shared_ptr <KalmarAsyncOp> depOp, memory_scope scope) { return EnqueueMarkerWithDependency(1, &depOp, scope); };
 
 
   /// copy src to dst asynchronously

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -217,7 +217,7 @@ public:
   virtual int getPendingAsyncOps() { return 0; }
 
   /// Is the queue empty?  Same as getPendingAsyncOps but may be faster.
-  virtual int isEmpty() { return 0; }
+  virtual bool isEmpty() { return 0; }
 
   /// get underlying native queue handle
   virtual void* getHSAQueue() { return nullptr; }

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -216,6 +216,9 @@ public:
   /// get number of pending async operations in the queue
   virtual int getPendingAsyncOps() { return 0; }
 
+  /// Is the queue empty?  Same as getPendingAsyncOps but may be faster.
+  virtual int isEmpty() { return 0; }
+
   /// get underlying native queue handle
   virtual void* getHSAQueue() { return nullptr; }
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -813,7 +813,7 @@ struct RocrQueue {
         assert(queue_size != 0);
 
         /// Create a queue using the maximum size.
-        status = hsa_queue_create(agent, queue_size, HSA_QUEUE_TYPE_SINGLE, NULL, NULL,
+        hsa_status_t status = hsa_queue_create(agent, queue_size, HSA_QUEUE_TYPE_SINGLE, NULL, NULL,
                                   UINT32_MAX, UINT32_MAX, &_hwQueue);
         DBOUT(DB_QUEUE, "  " <<  __func__ << ": created an HSA command queue: " << _hwQueue << "\n");
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -48,6 +48,11 @@
 #endif
 
 
+// Used to mark pieces of HCC runtime which may be specific to AMD's HSA implementation.
+// Intended to help identify this code when porting to another HSA impl.
+#define AMD_HSA
+
+
 /////////////////////////////////////////////////
 // kernel dispatch speed optimization flags
 /////////////////////////////////////////////////
@@ -3812,7 +3817,10 @@ HSABarrier::enqueueAsync(Kalmar::HSAQueue* hsaQueue, hc::memory_scope scope) {
 
         // setup header
         uint16_t header = HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE;
+#ifndef AMD_HSA
+        // AMD implementation does not require barrier bit on barrier packet and executes a little faster without it set.
         header |= 1 << HSA_PACKET_HEADER_BARRIER;
+#endif
         header |= fenceBits;
         barrier->header = header;
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -39,7 +39,6 @@
 #include <time.h>
 #include <iomanip>
 
-#define KALMAR_DEBUG (0)
 #ifndef KALMAR_DEBUG
 #define KALMAR_DEBUG (0)
 #endif
@@ -1076,7 +1075,7 @@ public:
     }
 
 
-    int isEmpty() override {
+    bool isEmpty() override {
         // Have to walk asyncOps since it can contain null pointers.
         for (int i = 0; i < asyncOps.size(); ++i) {
             if (asyncOps[i] != nullptr) {

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3826,11 +3826,11 @@ HSABarrier::enqueueAsync(Kalmar::HSAQueue* hsaQueue, hc::memory_scope scope) {
     unsigned fenceBits;
     if (scope == hc::accelerator_scope) {
         fenceBits =
-            ((HSA_FENCE_SCOPE_AGENT) << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
+            ((HSA_FENCE_SCOPE_NONE) << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
             ((HSA_FENCE_SCOPE_AGENT) << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
     } else if (scope == hc::system_scope) {
         fenceBits =
-            ((HSA_FENCE_SCOPE_SYSTEM) << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
+            ((HSA_FENCE_SCOPE_NONE) << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
             ((HSA_FENCE_SCOPE_SYSTEM) << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
     } else {
         STATUS_CHECK(HSA_STATUS_ERROR_INVALID_ARGUMENT, __LINE__);

--- a/tests/benchEmptyKernel/bench.cpp
+++ b/tests/benchEmptyKernel/bench.cpp
@@ -49,8 +49,8 @@
 #define DISPATCH_HSA_KERNEL_CF    0x10
 #define DISPATCH_HSA_KERNEL_NOCF  0x20
 
-//int p_tests = 0xff;
-int p_tests = DISPATCH_HSA_KERNEL_CF+DISPATCH_HSA_KERNEL_NOCF;
+int p_tests = 0xff;
+//int p_tests = DISPATCH_HSA_KERNEL_CF+DISPATCH_HSA_KERNEL_NOCF;
 //
 int p_useSystemScope = false;
 
@@ -144,6 +144,12 @@ int parseString(const char *str, const char **output)
     printf (__VA_ARGS__);\
     printf ("\n");\
     exit(EXIT_FAILURE);
+
+void usage() {
+    printf (" --dispatch_count, -d      : Set dispatch count\n");
+    printf (" --burst_count, -b         : Set burst count (commands before sync) \n");
+    printf (" --hsaco_dir, -h           : Directory to look for nullkernel hsaco file\n");
+};
 
 int main(int argc, char* argv[]) {
 

--- a/tests/benchEmptyKernel/hsacodelib.CPP
+++ b/tests/benchEmptyKernel/hsacodelib.CPP
@@ -102,8 +102,9 @@ void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args
     aql.kernarg_address = 0;
     aql.kernel_object = k._kernelCodeHandle;
 
-    aql.header =   (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE) |
-                        (1 << HSA_PACKET_HEADER_BARRIER);
+    aql.header =   (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE);
+
+    //aql.header |=   (1 << HSA_PACKET_HEADER_BARRIER);
  
     if (systemScope) {
       aql.header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |

--- a/tests/benchEmptyKernel/hsacodelib.CPP
+++ b/tests/benchEmptyKernel/hsacodelib.CPP
@@ -83,7 +83,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 
 // Dispatch a GL packet - 
 // Convert to AQL and call dispatch_hsa_kernel
-void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize)
+void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize, bool systemScope)
 {
     hsa_kernel_dispatch_packet_t aql;
     memset(&aql, 0, sizeof(aql));
@@ -103,9 +103,15 @@ void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args
     aql.kernel_object = k._kernelCodeHandle;
 
     aql.header =   (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE) |
-                        (1 << HSA_PACKET_HEADER_BARRIER) |
-                        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
-                        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
+                        (1 << HSA_PACKET_HEADER_BARRIER);
+ 
+    if (systemScope) {
+      aql.header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
+                    (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
+    } else {
+      aql.header |= (HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
+                    (HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
+    }
 
     aql.setup = 1 << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
 

--- a/tests/benchEmptyKernel/hsacodelib.h
+++ b/tests/benchEmptyKernel/hsacodelib.h
@@ -7,4 +7,4 @@ struct Kernel {
 };
 
 extern Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *kernelName);
-void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize);
+void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize, bool systemScope);


### PR DESCRIPTION
Add new parm to create_marker and friends to allow specifying scope of release fence.  (Accelerator scope is smaller and offers performance advantage over system, this new flag allows users to choose scope appropriate for the marker).

Finish implementation of HCC_OPT_FLUSH, which defers flush operations to host sync points (accelerator_view::wait and markers) rather than after each kernel.  Disabled by default pending additional performance optimization.

Test results below.  benchempty kernel should work but finds wrong extractkernel (/opt/rocm/bin/) not the clang40 version.

********************
Testing Time: 383.29s
********************
Unexpected Passing Tests (4):
    HCC :: Unit/FilePath/file path_test2.cpp
    HCC :: Unit/FilePath/file_path_test1.cpp
    HCC :: Unit/FilePath/file_path_test3.cpp
    HCC :: Unit/FilePath/file_path_test4.cpp

********************
Failing Tests (3):
    HCC :: Unit/HC/multi_acc_array2.cpp
    HCC :: Unit/HSA/list2.cpp
    HCC :: benchEmptyKernel/bench.cpp

  Expected Passes    : 691
  Expected Failures  : 21
  Unexpected Passes  : 4
  Unexpected Failures: 3

