### PR TITLE
Mark atomic add/sub tests with fp as invalid (with XFAIL) 

### DIFF
--- a/tests/Unit/Atomic/atomic_add_float_global.cpp
+++ b/tests/Unit/Atomic/atomic_add_float_global.cpp
@@ -1,3 +1,5 @@
+// NOTE: This is an invalid test.  C++ atomic_fetch_add does not support floating point types.
+// XFAIL: *
 // RUN: %cxxamp %s -o %t.out && %t.out
 #include <amp.h>
 #include <stdlib.h>

--- a/tests/Unit/Atomic/atomic_add_float_local.cpp
+++ b/tests/Unit/Atomic/atomic_add_float_local.cpp
@@ -1,3 +1,5 @@
+// NOTE: This is an invalid test.  C++ atomic_fetch_add does not support floating point types.
+// XFAIL: *
 // RUN: %cxxamp %s -o %t.out && %t.out
 #include <amp.h>
 #include <stdlib.h>

--- a/tests/Unit/Atomic/atomic_sub_float_global.cpp
+++ b/tests/Unit/Atomic/atomic_sub_float_global.cpp
@@ -1,3 +1,5 @@
+// NOTE: This is an invalid test.  C++ atomic_fetch_sub does not support floating point types.
+// XFAIL: *
 // RUN: %cxxamp %s -o %t.out && %t.out
 #include <amp.h>
 #include <stdlib.h>

--- a/tests/Unit/Atomic/atomic_sub_float_local.cpp
+++ b/tests/Unit/Atomic/atomic_sub_float_local.cpp
@@ -1,3 +1,5 @@
+// NOTE: This is an invalid test.  C++ atomic_fetch_sub does not support floating point types.
+// XFAIL: *
 // RUN: %cxxamp %s -o %t.out && %t.out
 #include <amp.h>
 #include <stdlib.h>

--- a/tests/Unit/HC/hc_atomic_add_float_global.cpp
+++ b/tests/Unit/HC/hc_atomic_add_float_global.cpp
@@ -1,4 +1,5 @@
-
+// NOTE: This is an invalid test.  C++ atomic_fetch_add does not support floating point types.
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 #include <hc.hpp>
 #include <stdlib.h>

--- a/tests/Unit/HC/hc_atomic_add_float_local.cpp
+++ b/tests/Unit/HC/hc_atomic_add_float_local.cpp
@@ -1,4 +1,5 @@
-
+// NOTE: This is an invalid test.  C++ atomic_fetch_add does not support floating point types.
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 #include <hc.hpp>
 #include <stdlib.h>

--- a/tests/Unit/HC/hc_atomic_sub_float_global.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_float_global.cpp
@@ -1,4 +1,5 @@
-
+// NOTE: This is an invalid test.  C++ atomic_fetch_sub does not support floating point types.
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 #include <hc.hpp>
 #include <stdlib.h>

--- a/tests/Unit/HC/hc_atomic_sub_float_local.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_float_local.cpp
@@ -1,4 +1,5 @@
-
+// NOTE: This is an invalid test.  C++ atomic_fetch_sub does not support floating point types.
+// XFAIL: *
 // RUN: %hc %s -o %t.out && %t.out
 #include <hc.hpp>
 #include <stdlib.h>


### PR DESCRIPTION
C++ atomic_fetch_add/sub only support integers.  
These tests apply atomic_fetch_add/sub on floating-point types and the clang FE would do implicit conversion into integral types, which cause the tests to fail.  
We should change these tests to use compare-and-swap instead in the future