### PR TITLE
Increase checksum cutoff

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -150,7 +150,7 @@ if (COMPILE_HCC_DB && (HCC_DB & (1<<(db_flag)))) { \
 // cutoff size used in FNV-1a hash function
 // default set as 768, this is a heuristic value
 // which is larger than HSA BrigModuleHeader and AMD GCN ISA header (Elf64_Ehdr)
-#define FNV1A_CUTOFF_SIZE (768)
+#define FNV1A_CUTOFF_SIZE (2048)
 
 #define CASE_STRING(X)  case X: case_string = #X ;break;
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -148,7 +148,7 @@ if (COMPILE_HCC_DB && (HCC_DB & (1<<(db_flag)))) { \
 #define FORCE_SIGNAL_DEP_BETWEEN_COPIES (0)
 
 // cutoff size used in FNV-1a hash function
-// default set as 768, this is a heuristic value
+// default set as 2048, this is a heuristic value
 // which is larger than HSA BrigModuleHeader and AMD GCN ISA header (Elf64_Ehdr)
 #define FNV1A_CUTOFF_SIZE (2048)
 


### PR DESCRIPTION
shared_library2 and shared_library3 tests started to fail after recent clang and llvm update.  

It turns out the checksum value for the GPU binary blobs in these tests collide and therefore, one of the GPU blobs didn't get loaded.

Increase the cutoff size to avoid the collision.