### PR TITLE
Enable passing generic lambdas as argument to p_f_e v2

### DIFF
--- a/include/amp.h
+++ b/include/amp.h
@@ -21,6 +21,8 @@
 #include "kalmar_launch.h"
 #include "kalmar_cpu_launch.h"
 
+#include <utility> // For std::declval.
+
 // forward declaration
 namespace Concurrency {
 class completion_future;
@@ -95,7 +97,7 @@ public:
         pQueue = other.pQueue;
         return *this;
     }
-  
+
     /**
      * Returns the queuing mode that this accelerator_view was created with.
      * See "Queuing Mode".
@@ -143,7 +145,7 @@ public:
      */
     // FIXME: dummy implementation now
     bool get_is_debug() const { return 0; }
-  
+
     /**
      * Performs a blocking wait for completion of all commands submitted to the
      * accelerator view prior to calling wait().
@@ -159,8 +161,8 @@ public:
      * invocations (parallel_for_each calls). This member function sends the
      * commands to the device for processing. Normally, these commands are sent
      * to the GPU automatically whenever the runtime determines that they need
-     * to be, such as when the command buffer is full or when waiting for 
-     * transfer of data from the device buffers to host memory. The flush 
+     * to be, such as when the command buffer is full or when waiting for
+     * transfer of data from the device buffers to host memory. The flush
      * member function will send the commands manually to the device.
      *
      * Calling this member function incurs an overhead and must be used with
@@ -192,7 +194,7 @@ public:
      */
     // FIXME: dummy implementation now
     completion_future create_marker();
-  
+
     /**
      * Compares "this" accelerator_view with the passed accelerator_view object
      * to determine if they represent the same underlying object.
@@ -219,7 +221,7 @@ private:
     accelerator_view(std::shared_ptr<Kalmar::KalmarQueue> pQueue) : pQueue(pQueue) {}
     std::shared_ptr<Kalmar::KalmarQueue> pQueue;
     friend class accelerator;
-  
+
     template<typename Kernel, int dim_ext> friend
         void Kalmar::mcw_cxxamp_launch_kernel(const std::shared_ptr<Kalmar::KalmarQueue>&, size_t *, size_t *, const Kernel&);
     template<typename Kernel, int dim_ext> friend
@@ -232,7 +234,7 @@ private:
 
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template <int N, typename Kernel> friend
         void parallel_for_each(Concurrency::extent<N>, const Kernel&);
     template <int N, typename Kernel> friend
@@ -243,17 +245,17 @@ private:
         void parallel_for_each(const accelerator_view&, Concurrency::extent<2>, const Kernel&);
     template <typename Kernel> friend
         void parallel_for_each(const accelerator_view&, Concurrency::extent<3>, const Kernel&);
-  
+
     template <int D0, typename Kernel> friend
         void parallel_for_each(tiled_extent<D0>, const Kernel&);
     template <int D0, typename Kernel> friend
         void parallel_for_each(const accelerator_view&, tiled_extent<D0>, const Kernel&);
-  
+
     template <int D0, int D1, typename Kernel> friend
         void parallel_for_each(tiled_extent<D0,D1>, const Kernel&);
     template <int D0, int D1, typename Kernel> friend
         void parallel_for_each(const accelerator_view&, tiled_extent<D0, D1>, const Kernel&);
-  
+
     template <int D0, int D1, int D2, typename Kernel> friend
         void parallel_for_each(tiled_extent<D0,D1,D2>, const Kernel&);
     template <int D0, int D1, int D2, typename Kernel> friend
@@ -282,9 +284,9 @@ public:
 class accelerator
 {
 public:
-  
+
     /** @{ */
-    /** 
+    /**
      * These are static constant string literals that represent device paths for
      * known accelerators, or in the case of "default_accelerator", direct the
      * runtime to choose an accelerator automatically.
@@ -301,12 +303,12 @@ public:
      */
     static const wchar_t default_accelerator[];   // = L"default"
     static const wchar_t cpu_accelerator[];       // = L"cpu"
-  
+
     /** @} */
-  
+
     /**
      * Constructs a new accelerator object that represents the default
-     * accelerator. This is equivalent to calling the constructor 
+     * accelerator. This is equivalent to calling the constructor
      * @code{.cpp}
      * accelerator(accelerator::default_accelerator)
      * @endcode
@@ -315,7 +317,7 @@ public:
      * accelerator::set_default().
      */
     accelerator() : accelerator(default_accelerator) {}
-  
+
     /**
      * Constructs a new accelerator object that represents the physical device
      * named by the "path" argument. If the path represents an unknown or
@@ -333,7 +335,7 @@ public:
      */
     explicit accelerator(const std::wstring& path)
         : pDev(Kalmar::getContext()->getDevice(path)) {}
-  
+
     /**
      * Copy constructs an accelerator object. This function does a shallow copy
      * with the newly created accelerator object pointing to the same underlying
@@ -342,7 +344,7 @@ public:
      * @param[in] other The accelerator object to be copied.
      */
     accelerator(const accelerator& other) : pDev(other.pDev) {}
-  
+
     /**
      * Returns a std::vector of accelerator objects (in no specific
      * order) representing all accelerators that are available, including
@@ -357,7 +359,7 @@ public:
             ret[i] = Devices[i];
         return std::move(ret);
     }
-  
+
     /**
      * Sets the default accelerator to the device path identified by the "path"
      * argument. See the constructor accelerator(const std::wstring& path)
@@ -458,9 +460,9 @@ public:
      * this this accelerator.
      *
      * This method only succeeds if the default_cpu_access_type for the
-     * accelerator has not already been overriden by a previous call to this 
-     * method and the runtime selected default_cpu_access_type for this 
-     * accelerator has not yet been used for allocating an array or for an 
+     * accelerator has not already been overriden by a previous call to this
+     * method and the runtime selected default_cpu_access_type for this
+     * accelerator has not yet been used for allocating an array or for an
      * implicit array_view memory allocation on this accelerator.
      *
      * @param[in] default_cpu_access_type The default cpu access_type to be used
@@ -484,7 +486,7 @@ public:
      * Returns a short textual description of the accelerator device.
      */
     std::wstring get_description() const { return pDev->get_description(); }
-  
+
     /**
      * Returns a 32-bit unsigned integer representing the version number of this
      * accelerator. The format of the integer is major.minor, where the major
@@ -867,7 +869,7 @@ public:
         base_.operator=(other.base_);
         return *this;
     }
-    
+
     /** @{ */
     /**
      * Returns the extent component value at position c.
@@ -1779,7 +1781,7 @@ public:
         trunc[2] = (trunc[2]/D2) * D2;
         return trunc;
     }
-  
+
     /**
      * Returns an instance of an extent<N> that captures the values of the
      * tiled_extent template arguments D0, D1, and D2. For example:
@@ -2561,7 +2563,7 @@ public:
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
-     * @param[in] srcBegin A beginning iterator into the source container. 
+     * @param[in] srcBegin A beginning iterator into the source container.
      * @param[in] srcEnd An ending iterator into the source container.
      */
     template <typename InputIter>
@@ -2632,7 +2634,7 @@ public:
     /** @{ */
     /**
      * Equivalent to construction using
-     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".   
+     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
@@ -2700,7 +2702,7 @@ public:
      *
      * Users can optionally specify the type of CPU access desired for "this"
      * array thus requesting creation of an array that is accessible both on
-     * the specified accelerator_view "av" as well as the CPU (with the 
+     * the specified accelerator_view "av" as well as the CPU (with the
      * specified CPU access_type). If a value other than access_type_auto or
      * access_type_none is specified for the cpu_access_type parameter and the
      * accelerator corresponding to the accelerator_view “av” does not support
@@ -2775,7 +2777,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to construction using 
+     * Equivalent to construction using
      * "array(extent<N>(e0 [, e1 [, e2 ]]), av, associated_av)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
@@ -3869,7 +3871,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -3988,7 +3990,7 @@ private:
                const Concurrency::extent<N>& ext_b,
                const Concurrency::index<N>& idx_b, int off) restrict(amp,cpu)
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b), offset(off) {}
-  
+
     acc_buffer_t cache;
     Concurrency::extent<N> extent;
     Concurrency::extent<N> extent_base;
@@ -4184,7 +4186,7 @@ public:
         }
         return *this;
     }
- 
+
     /** @} */
 
     /**
@@ -4280,7 +4282,7 @@ public:
         std::future<void> fut = std::async([&]() mutable { synchronize(); });
         return completion_future(fut.share());
     }
-  
+
     /**
      * Calling this member function synchronizes any modifications made to the
      * data underlying "this" array_view to the specified accelerator_view
@@ -4350,7 +4352,7 @@ public:
      */
     // FIXME: this method is not implemented
     const T& get_ref(const index<N>& idx) const restrict(amp,cpu);
-  
+
     /** @{ */
     /**
      * Equivalent to
@@ -4363,7 +4365,7 @@ public:
         static_assert(N == 1, "const T& array_view::operator()(int) is only permissible on array_view<T, 1>");
         return (*this)[index<1>(i0)];
     }
-  
+
     const T& operator() (int i0, int i1) const restrict(amp,cpu) {
         static_assert(N == 2, "const T& array_view::operator()(int,int) is only permissible on array_view<T, 2>");
         return (*this)[index<2>(i0, i1)];
@@ -4374,7 +4376,7 @@ public:
     }
 
     /** @} */
-  
+
     /** @{ */
     /**
      * This overload is defined for array_view<T,N> where @f$N \ge 2@f$.
@@ -4404,7 +4406,7 @@ public:
     // is not implemented
 
     /** @} */
-  
+
     /**
      * Returns a subsection of the source array view at the origin specified by
      * "idx" and with the extent specified by "ext".
@@ -4437,7 +4439,7 @@ public:
         Kalmar::amp_helper<N, Concurrency::index<N>, Concurrency::extent<N>>::minus(idx, ext);
         return section(idx, ext);
     }
-  
+
     /**
      * Equivalent to "section(index<N>(), ext)".
      */
@@ -4448,7 +4450,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -4472,7 +4474,7 @@ public:
     }
 
     /** @} */
-  
+
     /**
      * This member function is similar to "array<T,N>::reinterpret_as",
      * although it only supports array_views of rank 1 (only those guarantee
@@ -4517,7 +4519,7 @@ public:
             array_view<const T, K> av(cache, viewExtent, offset + index_base[0]);
             return av;
         }
-  
+
     ~array_view() restrict(amp,cpu) {}
 
     // FIXME: functions below are not defined in C++ AMP specification
@@ -4532,7 +4534,7 @@ private:
     template <typename K, int Q> friend struct array_projection_helper;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Q, int K> friend
         bool is_flat(const array_view<Q, K>&) noexcept;
     template <typename Q, int K> friend
@@ -4545,18 +4547,18 @@ private:
         void copy(const array_view<Q, K>&, OutputIter);
     template <typename Q, int K> friend
         void copy(const array_view<const Q, K>& src, const array_view<Q, K>& dest);
-  
+
     // used by view_as and reinterpret_as
     array_view(const acc_buffer_t& cache, const Concurrency::extent<N>& ext,
                int offset) restrict(amp,cpu)
         : cache(cache), extent(ext), extent_base(ext), offset(offset) {}
-  
+
     // used by section and projection
     array_view(const acc_buffer_t& cache, const Concurrency::extent<N>& ext_now,
                const Concurrency::extent<N>& ext_b,
                const Concurrency::index<N>& idx_b, int off) restrict(amp,cpu)
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b), offset(off) {}
-  
+
     acc_buffer_t cache;
     Concurrency::extent<N> extent;
     Concurrency::extent<N> extent_base;
@@ -5899,7 +5901,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<1>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -5932,7 +5934,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<2>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -5972,7 +5974,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<3>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -6009,7 +6011,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<D0>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -6048,7 +6050,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<D0, D1>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -6095,7 +6097,7 @@ __attribute__((noinline,used)) void parallel_for_each(const accelerator_view& av
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<D0, D1, D2>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -193,7 +193,7 @@ public:
      * the parent accelerator.
      */
     // FIXME: dummy implementation now
-    bool get_is_debug() const { return 0; } 
+    bool get_is_debug() const { return 0; }
 
     /**
      * Performs a blocking wait for completion of all commands submitted to the
@@ -213,10 +213,10 @@ public:
      * An accelerator_view internally maintains a buffer of commands such as
      * data transfers between the host memory and device buffers, and kernel
      * invocations (parallel_for_each calls). This member function sends the
-     * commands to the device for processing. Normally, these commands 
+     * commands to the device for processing. Normally, these commands
      * to the GPU automatically whenever the runtime determines that they need
-     * to be, such as when the command buffer is full or when waiting for 
-     * transfer of data from the device buffers to host memory. The flush 
+     * to be, such as when the command buffer is full or when waiting for
+     * transfer of data from the device buffers to host memory. The flush
      * member function will send the commands manually to the device.
      *
      * Calling this member function incurs an overhead and must be used with
@@ -276,8 +276,8 @@ public:
     completion_future create_blocking_marker(std::initializer_list<completion_future> dependent_future_list) const;
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
      * Note the src is the first parameter and dst is second, following C++ convention.
      * The copy command will execute after any commands already inserted into the accelerator_view finish.
      * This is a synchronous copy command, and the copy operation complete before this call returns.
@@ -288,15 +288,15 @@ public:
 
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
      * Note the src is the first parameter and dst is second, following C++ convention.
      * The copy command will execute after any commands already inserted into the accelerator_view finish.
      * This is a synchronous copy command, and the copy operation complete before this call returns.
      * The copy_ext flavor allows caller to provide additional information about each pointer, which can improve performance by eliminating replicated lookups.
      * This interface is intended for language runtimes such as HIP.
-    
-     @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice. 
+
+     @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice.
      @p forceUnpinnedCopy : Force copy to be performed with host involvement rather than with accelerator copy engines.
      */
     void copy_ext(const void *src, void *dst, size_t size_bytes, hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, const hc::accelerator *copyAcc, bool forceUnpinnedCopy);
@@ -306,9 +306,9 @@ public:
     void copy_ext(const void *src, void *dst, size_t size_bytes, hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, bool forceUnpinnedCopy) ;
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
-     * Note the src is the first parameter and dst is second, following C++ convention.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
+     * Note the src is the first parameter and dst is second, following C++ convention.
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
      *
      * The copy command will be implicitly ordered with respect to commands previously equeued to this accelerator_view:
@@ -320,9 +320,9 @@ public:
 
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
-     * Note the src is the first parameter and dst is second, following C++ convention.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
+     * Note the src is the first parameter and dst is second, following C++ convention.
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
      *
      * The copy command will be implicitly ordered with respect to commands previously enqueued to this accelerator_view:
@@ -331,18 +331,18 @@ public:
      *   The copyAcc determines where the copy is executed and does not affect the ordering.
      *
      * The copy_async_ext flavor allows caller to provide additional information about each pointer, which can improve performance by eliminating replicated lookups,
-     * and also allow control over which device performs the copy.  
+     * and also allow control over which device performs the copy.
      * This interface is intended for language runtimes such as HIP.
      *
-     *  @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice. 
+     *  @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice.
      *  @p copyAcc : Specify which accelerator performs the copy operation.  The specified accelerator must have access to the source and dest pointers - either
      *               because the memory is allocated on those devices or because the accelerator has peer access to the memory.
      *               If copyAcc is nullptr, then the copy will be performed by the host.  In this case, the host accelerator must have access to both pointers.
-     *               The copy operation will be performed by the specified engine but is not synchronized with respect to any operations on that device.  
+     *               The copy operation will be performed by the specified engine but is not synchronized with respect to any operations on that device.
      *
      */
-    completion_future copy_async_ext(const void *src, void *dst, size_t size_bytes, 
-                                     hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, 
+    completion_future copy_async_ext(const void *src, void *dst, size_t size_bytes,
+                                     hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo,
                                      const hc::accelerator *copyAcc);
 
     /**
@@ -408,7 +408,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM region on the HSA agent.
-     * This region can be used to allocate accelerator memory which is accessible from the 
+     * This region can be used to allocate accelerator memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -421,7 +421,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate system memory which is accessible from the 
+     * This region can be used to allocate system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -433,7 +433,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * This region can be used to allocate finegrained system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -464,34 +464,34 @@ public:
     /**
      * Dispatch a kernel into the accelerator_view.
      *
-     * This function is intended to provide a gateway to dispatch code objects, with 
+     * This function is intended to provide a gateway to dispatch code objects, with
      * some assistance from HCC.  Kernels are specified in the standard code object
-     * format, and can be created from a varety of compiler tools including the 
+     * format, and can be created from a varety of compiler tools including the
      * assembler, offline cl compilers, or other tools.    The caller also
-     * specifies the execution configuration and kernel arguments.    HCC 
+     * specifies the execution configuration and kernel arguments.    HCC
      * will copy the kernel arguments into an appropriate segment and insert
-     * the packet into the queue.   HCC will also automatically handle signal 
+     * the packet into the queue.   HCC will also automatically handle signal
      * and kernarg allocation and deallocation for the command.
      *
-     *  The kernel is dispatched asynchronously, and thus this API may return before the 
+     *  The kernel is dispatched asynchronously, and thus this API may return before the
      *  kernel finishes executing.
-     
+
      *  Kernels dispatched with this API may be interleaved with other copy and kernel
-     *  commands generated from copy or parallel_for_each commands.  
-     *  The kernel honors the execute_order associated with the accelerator_view.  
+     *  commands generated from copy or parallel_for_each commands.
+     *  The kernel honors the execute_order associated with the accelerator_view.
      *  Specifically, if execute_order is execute_in_order, then the kernel
      *  will wait for older data and kernel commands in the same queue before
-     *  beginning execution.  If execute_order is execute_any_order, then the 
-     *  kernel may begin executing without regards to the state of older kernels.  
-     *  This call honors the packer barrier bit (1 << HSA_PACKET_HEADER_BARRIER) 
+     *  beginning execution.  If execute_order is execute_any_order, then the
+     *  kernel may begin executing without regards to the state of older kernels.
+     *  This call honors the packer barrier bit (1 << HSA_PACKET_HEADER_BARRIER)
      *  if set in the aql.header field.  If set, this provides the same synchronization
      *  behaviora as execute_in_order for the command generated by this API.
      *
-     * @p aql is an HSA-format "AQL" packet. The following fields must 
+     * @p aql is an HSA-format "AQL" packet. The following fields must
      * be set by the caller:
-     *  aql.kernel_object 
+     *  aql.kernel_object
      *  aql.group_segment_size : includes static + dynamic group size
-     *  aql.private_segment_size 
+     *  aql.private_segment_size
      *  aql.grid_size_x, aql.grid_size_y, aql.grid_size_z
      *  aql.group_size_x, aql.group_size_y, aql.group_size_z
      *  aql.setup :  The 2 bits at HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS.
@@ -501,14 +501,14 @@ public:
                  (1 << HSA_PACKET_HEADER_BARRIER);
 
      * The following fields are ignored.  The API will will set up these fields before dispatching the AQL packet:
-     *  aql.completion_signal 
-     *  aql.kernarg 
-     * 
+     *  aql.completion_signal
+     *  aql.kernarg
+     *
      * @p args : Pointer to kernel arguments with the size and aligment expected by the kernel.  The args are copied and then passed directly to the kernel.   After this function returns, the args memory may be deallocated.
      * @p argSz : Size of the arguments.
      * @p cf : Written with a completion_future that can be used to track the status
-     *          of the dispatch.  May be NULL, in which case no completion_future is 
-     *          returned and the caller must use other synchronization techniqueues 
+     *          of the dispatch.  May be NULL, in which case no completion_future is
+     *          returned and the caller must use other synchronization techniqueues
      *          such as calling accelerator_view::wait() or waiting on a younger command
      *          in the same queue.
      *
@@ -518,17 +518,17 @@ public:
      *    - Dispatch the command into the queue and flush it to the GPU.
      *    - Kernargs and signals are automatically reclaimed by the HCC runtime.
      */
-    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql, 
+    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql,
                            const void * args, size_t argsize,
-                           hc::completion_future *cf=NULL) 
+                           hc::completion_future *cf=NULL)
     {
         pQueue->dispatch_hsa_kernel(aql, args, argsize, cf);
     }
 
     /**
-     * Set a CU affinity to specific command queues. 
+     * Set a CU affinity to specific command queues.
      * The setting is permanent until the queue is destroyed or CU affinity is
-     * set again. This setting is "atomic", it won't affect the dispatch in flight. 
+     * set again. This setting is "atomic", it won't affect the dispatch in flight.
      *
      * @param cu_mask a bool vector to indicate what CUs you want to use. True
      *        represents using the cu. The first 32 elements represents the first
@@ -554,7 +554,7 @@ private:
     friend class accelerator;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Kernel> friend
         void* Kalmar::mcw_cxxamp_get_kernel(const std::shared_ptr<Kalmar::KalmarQueue>&, const Kernel&);
     template<typename Kernel, int dim_ext> friend
@@ -565,7 +565,7 @@ private:
         void Kalmar::mcw_cxxamp_launch_kernel(const std::shared_ptr<Kalmar::KalmarQueue>&, size_t *, size_t *, const Kernel&);
     template<typename Kernel, int dim_ext> friend
         std::shared_ptr<Kalmar::KalmarAsyncOp> Kalmar::mcw_cxxamp_launch_kernel_async(const std::shared_ptr<Kalmar::KalmarQueue>&, size_t *, size_t *, const Kernel&);
-  
+
 #if __KALMAR_ACCELERATOR__ == 2 || __KALMAR_CPU__ == 2
     template <typename Kernel, int N> friend
         completion_future launch_cpu_task_async(const std::shared_ptr<Kalmar::KalmarQueue>&, Kernel const&, extent<N> const&);
@@ -575,27 +575,27 @@ private:
     // generic version
     template <int N, typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<N>&, const Kernel&);
-  
+
     // 1D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<1>&, const Kernel&);
-  
+
     // 2D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<2>&, const Kernel&);
-  
+
     // 3D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<3>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 3D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<3>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 2D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<2>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 1D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<1>&, const Kernel&);
@@ -629,7 +629,7 @@ class accelerator
 public:
     /**
      * Constructs a new accelerator object that represents the default
-     * accelerator. This is equivalent to calling the constructor 
+     * accelerator. This is equivalent to calling the constructor
      * @code{.cpp}
      * accelerator(accelerator::default_accelerator)
      * @endcode
@@ -752,7 +752,7 @@ public:
         pQueue->set_mode(mode);
         return pQueue;
     }
-  
+
     /**
      * Compares "this" accelerator with the passed accelerator object to
      * determine if they represent the same underlying device.
@@ -781,9 +781,9 @@ public:
      * this this accelerator.
      *
      * This method only succeeds if the default_cpu_access_type for the
-     * accelerator has not already been overriden by a previous call to this 
-     * method and the runtime selected default_cpu_access_type for this 
-     * accelerator has not yet been used for allocating an array or for an 
+     * accelerator has not already been overriden by a previous call to this
+     * method and the runtime selected default_cpu_access_type for this
+     * accelerator has not yet been used for allocating an array or for an
      * implicit array_view memory allocation on this accelerator.
      *
      * @param[in] default_cpu_access_type The default cpu access_type to be used
@@ -871,8 +871,8 @@ public:
      * Get the default cpu access_type for buffers created on this accelerator
      */
     access_type get_default_cpu_access_type() const { return pDev->get_access(); }
-  
-  
+
+
     /**
      * Returns the maximum size of tile static area available on this
      * accelerator.
@@ -880,7 +880,7 @@ public:
     size_t get_max_tile_static_size() {
       return get_default_view().get_max_tile_static_size();
     }
-  
+
     /**
      * Returns a vector of all accelerator_view associated with this accelerator.
      */
@@ -895,7 +895,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM region on the HSA agent.
-     * This region can be used to allocate accelerator memory which is accessible from the 
+     * This region can be used to allocate accelerator memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -907,7 +907,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate system memory which is accessible from the 
+     * This region can be used to allocate system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -919,7 +919,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * This region can be used to allocate finegrained system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -988,9 +988,9 @@ public:
     bool get_is_peer(const accelerator& other) const {
         return pDev->is_peer(other.pDev);
     }
-      
+
     /**
-     * Return a std::vector of this accelerator's peers. peer is other accelerator which can access this 
+     * Return a std::vector of this accelerator's peers. peer is other accelerator which can access this
      * accelerator's device memory using map_to_peer family of APIs.
      *
      */
@@ -1026,7 +1026,7 @@ public:
         return pDev->has_cpu_accessible_am();
     };
 
-    Kalmar::KalmarDevice *get_dev_ptr() const { return pDev; }; 
+    Kalmar::KalmarDevice *get_dev_ptr() const { return pDev; };
 
 private:
     accelerator(Kalmar::KalmarDevice* pDev) : pDev(pDev) {}
@@ -1155,7 +1155,7 @@ public:
         if (this->valid()) {
             if (__asyncOp != nullptr) {
                 __asyncOp->setWaitMode(mode);
-            }   
+            }
             //TODO-ASYNC - need to reclaim older AsyncOps here.
             __amp_future.wait();
         }
@@ -1213,7 +1213,7 @@ public:
      * purpose.
      * Applications should retain the parent completion_future to ensure
      * the native handle is not deallocated by the HCC runtime.  The completion_future
-     * pointer to the native handle is reference counted, so a copy of 
+     * pointer to the native handle is reference counted, so a copy of
      * the completion_future is sufficient to retain the native_handle.
      */
     void* get_native_handle() const {
@@ -1285,7 +1285,7 @@ public:
       }
       delete __thread_then;
       __thread_then = nullptr;
-      
+
       if (__asyncOp != nullptr) {
         __asyncOp = nullptr;
       }
@@ -1308,7 +1308,7 @@ private:
         : __amp_future(__future), __thread_then(nullptr), __asyncOp(nullptr) {}
 
     friend class Kalmar::HSAQueue;
-    
+
     // non-tiled parallel_for_each
     // generic version
     template <int N, typename Kernel> friend
@@ -1437,8 +1437,8 @@ accelerator_view::copy_async(const void *src, void *dst, size_t size_bytes) {
 
 inline completion_future
 accelerator_view::copy_async_ext(const void *src, void *dst, size_t size_bytes,
-                             hcCommandKind copyDir, 
-                             const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, 
+                             hcCommandKind copyDir,
+                             const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo,
                              const hc::accelerator *copyAcc)
 {
     return completion_future(pQueue->EnqueueAsyncCopyExt(src, dst, size_bytes, copyDir, srcInfo, dstInfo, copyAcc ? copyAcc->pDev : nullptr));
@@ -1878,12 +1878,12 @@ template <int N>
 class tiled_extent : public extent<N> {
 public:
     static const int rank = N;
-  
+
     /**
      * Tile size for each dimension.
      */
     int tile_dim[N];
-  
+
     /**
      * Default constructor. The origin and extent is default-constructed and
      * thus zero.
@@ -1966,7 +1966,7 @@ public:
      * @param[in] ext The extent of this tiled_extent
      * @param[in] t0 Size of tile.
      */
-    tiled_extent(const extent<1>& ext, int t0) __CPU__ __HC__ : extent(ext), dynamic_group_segment_size(0), tile_dim{t0} {} 
+    tiled_extent(const extent<1>& ext, int t0) __CPU__ __HC__ : extent(ext), dynamic_group_segment_size(0), tile_dim{t0} {}
 
     /**
      * Constructs a tiled_extent<N> with the extent "ext".
@@ -2253,7 +2253,7 @@ tiled_extent<3> extent<N>::tile_with_dynamic(int t0, int t1, int t2, int dynamic
  * @return The size of a wavefront.
  */
 #define __HSA_WAVEFRONT_SIZE__ (64)
-extern "C" unsigned int __wavesize() __HC__; 
+extern "C" unsigned int __wavesize() __HC__;
 
 
 #if __hcc_backend__==HCC_BACKEND_AMDGPU
@@ -2795,15 +2795,15 @@ inline float __amdgcn_ds_swizzle(float src, int pattern) [[hc]] {
 /**
  * move DPP intrinsic
  */
-extern "C" int __amdgcn_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl) [[hc]]; 
+extern "C" int __amdgcn_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl) [[hc]];
 
 /**
- * Shift the value of src to the right by one thread within a wavefront.  
- * 
+ * Shift the value of src to the right by one thread within a wavefront.
+ *
  * @param[in] src variable being shifted
  * @param[in] bound_ctrl When set to true, a zero will be shifted into thread 0; otherwise, the original value will be returned for thread 0
- * @return value of src being shifted into from the neighboring lane 
- * 
+ * @return value of src being shifted into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_sr1(int src, bool bound_ctrl) [[hc]];
 inline unsigned int __amdgcn_wave_sr1(unsigned int src, bool bound_ctrl) [[hc]] {
@@ -2818,14 +2818,14 @@ inline float __amdgcn_wave_sr1(float src, bool bound_ctrl) [[hc]] {
 }
 
 /**
- * Shift the value of src to the left by one thread within a wavefront.  
- * 
+ * Shift the value of src to the left by one thread within a wavefront.
+ *
  * @param[in] src variable being shifted
  * @param[in] bound_ctrl When set to true, a zero will be shifted into thread 63; otherwise, the original value will be returned for thread 63
- * @return value of src being shifted into from the neighboring lane 
- * 
+ * @return value of src being shifted into from the neighboring lane
+ *
  */
-extern "C" int __amdgcn_wave_sl1(int src, bool bound_ctrl) [[hc]];  
+extern "C" int __amdgcn_wave_sl1(int src, bool bound_ctrl) [[hc]];
 inline unsigned int __amdgcn_wave_sl1(unsigned int src, bool bound_ctrl) [[hc]] {
   __u tmp; tmp.u = src;
   tmp.i = __amdgcn_wave_sl1(tmp.i, bound_ctrl);
@@ -2839,11 +2839,11 @@ inline float __amdgcn_wave_sl1(float src, bool bound_ctrl) [[hc]] {
 
 
 /**
- * Rotate the value of src to the right by one thread within a wavefront.  
- * 
+ * Rotate the value of src to the right by one thread within a wavefront.
+ *
  * @param[in] src variable being rotated
- * @return value of src being rotated into from the neighboring lane 
- * 
+ * @return value of src being rotated into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_rr1(int src) [[hc]];
 inline unsigned int __amdgcn_wave_rr1(unsigned int src) [[hc]] {
@@ -2858,11 +2858,11 @@ inline float __amdgcn_wave_rr1(float src) [[hc]] {
 }
 
 /**
- * Rotate the value of src to the left by one thread within a wavefront.  
- * 
+ * Rotate the value of src to the left by one thread within a wavefront.
+ *
  * @param[in] src variable being rotated
- * @return value of src being rotated into from the neighboring lane 
- * 
+ * @return value of src being rotated into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_rl1(int src) [[hc]];
 inline unsigned int __amdgcn_wave_rl1(unsigned int src) [[hc]] {
@@ -2878,7 +2878,7 @@ inline float __amdgcn_wave_rl1(float src) [[hc]] {
 
 #endif
 
-/* definition to expand macro then apply to pragma message 
+/* definition to expand macro then apply to pragma message
 #define VALUE_TO_STRING(x) #x
 #define VALUE(x) VALUE_TO_STRING(x)
 #define VAR_NAME_VALUE(var) #var "="  VALUE(var)
@@ -2961,7 +2961,7 @@ inline int __shfl_up(int var, const unsigned int delta, const int width=__HSA_WA
 #elif __hcc_backend__==HCC_BACKEND_HSAIL
 
 inline int __shfl_up(int var, const unsigned int delta, const int width=__HSA_WAVEFRONT_SIZE__) __HC__ {
-    if (delta == 1 
+    if (delta == 1
         && width == __HSA_WAVEFRONT_SIZE__) {
         return __wavefront_shift_right(var);
     }
@@ -4173,7 +4173,7 @@ public:
      * There is no default constructor for array<T,N>.
      */
     array() = delete;
- 
+
     /**
      * Copy constructor. Constructs a new array<T,N> from the supplied argument
      * other. The new array is located on the same accelerator_view as the
@@ -4253,7 +4253,7 @@ public:
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
-     * @param[in] srcBegin A beginning iterator into the source container. 
+     * @param[in] srcBegin A beginning iterator into the source container.
      * @param[in] srcEnd An ending iterator into the source container.
      */
     template <typename InputIter>
@@ -4355,7 +4355,7 @@ public:
     /** @{ */
     /**
      * Equivalent to construction using
-     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".   
+     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
@@ -4423,7 +4423,7 @@ public:
      *
      * Users can optionally specify the type of CPU access desired for "this"
      * array thus requesting creation of an array that is accessible both on
-     * the specified accelerator_view "av" as well as the CPU (with the 
+     * the specified accelerator_view "av" as well as the CPU (with the
      * specified CPU access_type). If a value other than access_type_auto or
      * access_type_none is specified for the cpu_access_type parameter and the
      * accelerator corresponding to the accelerator_view “av” does not support
@@ -4498,7 +4498,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to construction using 
+     * Equivalent to construction using
      * "array(extent<N>(e0 [, e1 [, e2 ]]), av, associated_av)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
@@ -4621,7 +4621,7 @@ public:
      * This property returns the CPU "access_type" allowed for this array.
      */
     access_type get_cpu_access_type() const { return m_device.get_access(); }
-  
+
     /**
      * Assigns the contents of the array "other" to this array, using a deep
      * copy.
@@ -4667,7 +4667,7 @@ public:
         *this = std::move(arr);
         return *this;
     }
-  
+
     /**
      * Copies the contents of this array to the array given by "dest", as
      * if by calling "copy(*this, dest)".
@@ -5571,7 +5571,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -5657,7 +5657,7 @@ private:
     template <typename K, int Q> friend struct array_projection_helper;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Q, int K> friend
         bool is_flat(const array_view<Q, K>&) noexcept;
     template <typename Q, int K> friend
@@ -5670,7 +5670,7 @@ private:
         void copy(const array_view<Q, K>&, OutputIter);
     template <typename Q, int K> friend
         void copy(const array_view<const Q, K>& src, const array_view<Q, K>& dest);
-  
+
     // used by view_as and reinterpret_as
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext,
                int offset) __CPU__ __HC__
@@ -5682,7 +5682,7 @@ private:
                const index<N>& idx_b, int off) __CPU__ __HC__
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b),
         offset(off) {}
-  
+
     acc_buffer_t cache;
     hc::extent<N> extent;
     hc::extent<N> extent_base;
@@ -5867,7 +5867,7 @@ public:
         offset = other.offset;
         return *this;
     }
-  
+
     array_view& operator=(const array_view& other) __CPU__ __HC__ {
         if (this != &other) {
             cache = other.cache;
@@ -6067,7 +6067,7 @@ public:
         static_assert(N == 1, "const T& array_view::operator()(int) is only permissible on array_view<T, 1>");
         return (*this)[index<1>(i0)];
     }
-  
+
     const T& operator()(int i0, int i1) const __CPU__ __HC__ {
         static_assert(N == 2, "const T& array_view::operator()(int,int) is only permissible on array_view<T, 2>");
         return (*this)[index<2>(i0, i1)];
@@ -6152,7 +6152,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -6236,7 +6236,7 @@ private:
     template <typename K, int Q> friend struct array_projection_helper;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Q, int K> friend
         bool is_flat(const array_view<Q, K>&) noexcept;
     template <typename Q, int K> friend
@@ -6249,19 +6249,19 @@ private:
         void copy(const array_view<Q, K>&, OutputIter);
     template <typename Q, int K> friend
         void copy(const array_view<const Q, K>& src, const array_view<Q, K>& dest);
-  
+
     // used by view_as and reinterpret_as
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext,
                int offset) __CPU__ __HC__
         : cache(cache), extent(ext), extent_base(ext), offset(offset) {}
-  
+
     // used by section and projection
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext_now,
                const extent<N>& ext_b,
                const index<N>& idx_b, int off) __CPU__ __HC__
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b),
         offset(off) {}
-  
+
     acc_buffer_t cache;
     hc::extent<N> extent;
     hc::extent<N> extent_base;
@@ -7415,7 +7415,7 @@ extern unsigned int atomic_fetch_dec(unsigned int * _Dest) __CPU__ __HC__;
  * - stores the result back to the address
  *
  * @return The original value retrieved from address pointer.
- * 
+ *
  * Please refer to <a href="http://www.hsafoundation.com/html/HSA_Library.htm#PRM/Topics/06_Memory/atomic.htm">atomic_wrapinc in HSA PRM 6.6</a> for more detailed specification of the function.
  */
 extern "C" unsigned int __atomic_wrapinc(unsigned int* address, unsigned int val) __HC__;
@@ -7427,7 +7427,7 @@ extern "C" unsigned int __atomic_wrapinc(unsigned int* address, unsigned int val
  * - stores the result back to the address
  *
  * @return The original value retrieved from address pointer.
- * 
+ *
  * Please refer to <a href="http://www.hsafoundation.com/html/HSA_Library.htm#PRM/Topics/06_Memory/atomic.htm">atomic_wrapdec in HSA PRM 6.6</a> for more detailed specification of the function.
  */
 extern "C" unsigned int __atomic_wrapdec(unsigned int* address, unsigned int val) __HC__;
@@ -7579,7 +7579,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<1>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -7617,7 +7617,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<2>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -7658,7 +7658,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<index<3>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -7696,7 +7696,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<1>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -7738,7 +7738,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<2>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop
@@ -7784,7 +7784,7 @@ __attribute__((noinline,used)) completion_future parallel_for_each(
   //to ensure functor has right operator() defined
   //this triggers the trampoline code being emitted
   auto foo = &Kernel::__cxxamp_trampoline;
-  auto bar = &Kernel::operator();
+  decltype(std::declval<Kernel>()(std::declval<tiled_index<3>&>()))* bar = nullptr;
 #endif
 }
 #pragma clang diagnostic pop

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -83,9 +83,9 @@
 
 
 // Copy thresholds, in KB.  These are used for "choose-best" copy mode.
-long int HCC_H2D_STAGING_THRESHOLD    = 64; 
-long int HCC_H2D_PININPLACE_THRESHOLD = 4096; 
-long int HCC_D2H_PININPLACE_THRESHOLD = 1024; 
+long int HCC_H2D_STAGING_THRESHOLD    = 64;
+long int HCC_H2D_PININPLACE_THRESHOLD = 4096;
+long int HCC_D2H_PININPLACE_THRESHOLD = 1024;
 
 int HCC_SERIALIZE_KERNEL = 0;
 int HCC_SERIALIZE_COPY = 0;
@@ -98,9 +98,9 @@ unsigned HCC_DB = 0;
 
 
 // synchronization for copy commands in the same stream, regardless of command type.
-// Add a signal dependencies between async copies - 
+// Add a signal dependencies between async copies -
 // so completion signal from prev command used as input dep to next.
-// If FORCE_SIGNAL_DEP_BETWEEN_COPIES=0 then data copies of the same kind (H2H, H2D, D2H, D2D) 
+// If FORCE_SIGNAL_DEP_BETWEEN_COPIES=0 then data copies of the same kind (H2H, H2D, D2H, D2D)
 // are assumed to be implicitly ordered.
 // ROCR 1.2 runtime implementation currently provides this guarantee when using SDMA queues and compute shaders.
 #define FORCE_SIGNAL_DEP_BETWEEN_COPIES (0)
@@ -320,7 +320,7 @@ private:
     HSAExecutable* executable;
     uint64_t kernelCodeHandle;
     hsa_executable_symbol_t hsaExecutableSymbol;
-    uint32_t static_group_segment_size; 
+    uint32_t static_group_segment_size;
     uint32_t private_segment_size;
     uint16_t workitem_vgpr_count;
     friend class HSADispatch;
@@ -339,25 +339,25 @@ public:
                 _hsaExecutableSymbol,
                 HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE,
                 &this->static_group_segment_size);
-        STATUS_CHECK_Q(status, commandQueue, __LINE__);
+        STATUS_CHECK(status, __LINE__);
 
         status =
             hsa_executable_symbol_get_info(
                 _hsaExecutableSymbol,
                 HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
                 &this->private_segment_size);
-        STATUS_CHECK_Q(status, commandQueue, __LINE__);
+        STATUS_CHECK(status, __LINE__);
 
         workitem_vgpr_count = 0;
 
         hsa_ven_amd_loader_1_00_pfn_t ext_table = {nullptr};
         status = hsa_system_get_extension_table(HSA_EXTENSION_AMD_LOADER, 1, 0, &ext_table);
-        STATUS_CHECK_Q(status, commandQueue, __LINE__);
+        STATUS_CHECK(status, __LINE__);
 
         if (nullptr != ext_table.hsa_ven_amd_loader_query_host_address) {
             const amd_kernel_code_t* akc = nullptr;
             status = ext_table.hsa_ven_amd_loader_query_host_address(reinterpret_cast<const void*>(kernelCodeHandle), reinterpret_cast<const void**>(&akc));
-            STATUS_CHECK_Q(status, commandQueue, __LINE__);
+            STATUS_CHECK(status, __LINE__);
 
             workitem_vgpr_count = akc->workitem_vgpr_count;
         }
@@ -424,7 +424,7 @@ public:
     // HSA signals would be waited in HSA_WAIT_STATE_ACTIVE by default for HSACopy instances
     HSACopy(const void* src_, void* dst_, size_t sizeBytes_) : KalmarAsyncOp(Kalmar::hcCommandInvalid),
         isSubmitted(false), future(nullptr), depAsyncOp(nullptr), hsaQueue(nullptr), copyDevice(nullptr), waitMode(HSA_WAIT_STATE_ACTIVE),
-        src(src_), dst(dst_), 
+        src(src_), dst(dst_),
         sizeBytes(sizeBytes_),
         signalIndex(-1) {
 #if KALMAR_DEBUG
@@ -465,14 +465,14 @@ public:
 
     // synchronous version of copy
     void syncCopy(Kalmar::HSAQueue*);
-    void syncCopyExt(Kalmar::HSAQueue *hsaQueue, hc::hcCommandKind copyDir, 
-                     const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo, 
+    void syncCopyExt(Kalmar::HSAQueue *hsaQueue, hc::hcCommandKind copyDir,
+                     const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo,
                      const Kalmar::HSADevice *copyDevice, bool forceUnpinnedCopy);
 
 
 private:
-  hsa_status_t hcc_memory_async_copy(const Kalmar::HSADevice *copyDevice, void *dst, const void *src, size_t sizeBytes, 
-                                      int depSignalCnt, const hsa_signal_t *depSignals, 
+  hsa_status_t hcc_memory_async_copy(const Kalmar::HSADevice *copyDevice, void *dst, const void *src, size_t sizeBytes,
+                                      int depSignalCnt, const hsa_signal_t *depSignals,
                                       hsa_signal_t completion_signal);
 
 }; // end of HSACopy
@@ -648,12 +648,12 @@ public:
     }
 
 
-    hsa_status_t setLaunchConfiguration(int dims, size_t *globalDims, size_t *localDims, 
+    hsa_status_t setLaunchConfiguration(int dims, size_t *globalDims, size_t *localDims,
                                      int dynamicGroupSize);
 
     hsa_status_t dispatchKernelWaitComplete(Kalmar::HSAQueue*);
 
-    hsa_status_t dispatchKernelAsync(Kalmar::HSAQueue*, const void *hostKernarg, 
+    hsa_status_t dispatchKernelAsync(Kalmar::HSAQueue*, const void *hostKernarg,
                                      int hostKernargSize, bool allocSignal);
     hsa_status_t dispatchKernelAsyncFromOp(Kalmar::HSAQueue* hsaQueue);
 
@@ -988,7 +988,7 @@ public:
                 HSACopy *youngestCopyOp = static_cast<HSACopy*> (asyncOps.back().get());
                 if (newCopyOp->getCopyDevice() != youngestCopyOp->getCopyDevice()) {
                     // This covers cases where two copies are back-to-back in the queue but use different copy engines.
-                    // In this case there is no implicit dependency between the ops so we need to add one 
+                    // In this case there is no implicit dependency between the ops so we need to add one
                     // here.
                     needDep = true;
                 }
@@ -1043,9 +1043,9 @@ public:
 
         printAsyncOps(std::cerr);
 #endif
-    
-   
-        // If oldest OP doesn't have a signal, we need to enqueue 
+
+
+        // If oldest OP doesn't have a signal, we need to enqueue
         // a barrier with a signal so host can tell when it finishes
         for (int i = asyncOps.size()-1; i >= 0;  i--) {
             auto asyncOp = asyncOps[i];
@@ -1242,10 +1242,10 @@ public:
                 hsa_status_t status = HSA_STATUS_SUCCESS;
                 // Make sure host memory is accessible to gpu
                 // FIXME: host memory is allocated through OS allocator, if not, correct it.
-                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent()); 
+                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent());
                 const void* va = nullptr;
                 status = hsa_amd_memory_lock(const_cast<void*>(src), count, agent, 1, (void**)&va);
-                  
+
                 if(va == NULL || status != HSA_STATUS_SUCCESS)
                 {
                     status = hsa_amd_agents_allow_access(1, agent, NULL, src);
@@ -1379,7 +1379,7 @@ public:
                 // copy data from host buffer to device buffer
                 hsa_status_t status = HSA_STATUS_SUCCESS;
 
-                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent()); 
+                hsa_agent_t* agent = static_cast<hsa_agent_t*>(getHSAAgent());
                 sync_copy(((char*)device) + offset, *agent, addr, *static_cast<hsa_agent_t*>(getHostAgent()), count);
 #if KALMAR_DEBUG
                 std::wcerr << getDev()->get_path();
@@ -1418,7 +1418,7 @@ public:
     void* getHostAgent() override;
 
     void* getHSAAMRegion() override;
-    
+
     void* getHSACoherentHostRegion() override;
 
     void* getHSAAMHostRegion() override;
@@ -1429,7 +1429,7 @@ public:
         return true;
     }
 
-    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql, 
+    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql,
                              const void * args, size_t argsize,
                              hc::completion_future *cf) override ;
 
@@ -1508,8 +1508,8 @@ public:
         }
     }
 
-    std::shared_ptr<KalmarAsyncOp> EnqueueAsyncCopyExt(const void* src, void* dst, size_t size_bytes, 
-                                                       hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo, 
+    std::shared_ptr<KalmarAsyncOp> EnqueueAsyncCopyExt(const void* src, void* dst, size_t size_bytes,
+                                                       hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo,
                                                        const Kalmar::KalmarDevice *copyDevice) override;
 
     std::shared_ptr<KalmarAsyncOp> EnqueueAsyncCopy(const void *src, void *dst, size_t size_bytes) override ;
@@ -1536,7 +1536,7 @@ public:
 #endif
     }
 
-    void copy_ext(const void *src, void *dst, size_t size_bytes, hc::hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo, 
+    void copy_ext(const void *src, void *dst, size_t size_bytes, hc::hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo,
                   const Kalmar::KalmarDevice *copyDevice, bool forceUnpinnedCopy) override ;
 
 
@@ -1748,7 +1748,7 @@ public:
     }
 
     // Returns true if specified agent has access to the specified pool.
-    // Typically used to detect when a CPU agent has access to GPU device memory via large-bar: 
+    // Typically used to detect when a CPU agent has access to GPU device memory via large-bar:
     int hasAccess(hsa_agent_t agent, hsa_amd_memory_pool_t pool)
     {
         hsa_status_t err;
@@ -1875,7 +1875,7 @@ public:
         ri._am_host_memory_pool = (ri._found_coarsegrained_system_memory_pool)
                                       ? ri._coarsegrained_system_memory_pool
                                       : ri._finegrained_system_memory_pool;
-        
+
         ri._am_host_coherent_memory_pool = (ri._found_finegrained_system_memory_pool)
                                       ? ri._finegrained_system_memory_pool
                                       : ri._coarsegrained_system_memory_pool;
@@ -1926,14 +1926,14 @@ public:
             default:
                 this->copy_mode = UnpinnedCopyEngine::ChooseBest;
         };
-        
-        HCC_H2D_STAGING_THRESHOLD = 
+
+        HCC_H2D_STAGING_THRESHOLD =
             getenvlong("HCC_H2D_STAGING_THRESHOLD", HCC_H2D_STAGING_THRESHOLD);
-        HCC_H2D_PININPLACE_THRESHOLD =  
+        HCC_H2D_PININPLACE_THRESHOLD =
             getenvlong("HCC_H2D_PININPLACE_THRESHOLD", HCC_H2D_PININPLACE_THRESHOLD);
-        HCC_D2H_PININPLACE_THRESHOLD =  
+        HCC_D2H_PININPLACE_THRESHOLD =
             getenvlong("HCC_D2H_PININPLACE_THRESHOLD", HCC_D2H_PININPLACE_THRESHOLD);
-       
+
 
         HCC_H2D_STAGING_THRESHOLD    *= 1024;
         HCC_H2D_PININPLACE_THRESHOLD *= 1024;
@@ -1943,13 +1943,13 @@ public:
         this->cpu_accessible_am = hasAccess(hostAgent, ri._am_memory_pool);
         hsa_amd_memory_pool_t hostPool = (getHSAAMHostRegion());
         copy_engine[0] = new UnpinnedCopyEngine(agent, hostAgent, stagingSize, 2/*staging buffers*/,
-                                                this->cpu_accessible_am, 
+                                                this->cpu_accessible_am,
                                                 HCC_H2D_STAGING_THRESHOLD,
                                                 HCC_H2D_PININPLACE_THRESHOLD,
                                                 HCC_D2H_PININPLACE_THRESHOLD);
 
         copy_engine[1] = new UnpinnedCopyEngine(agent, hostAgent, stagingSize, 2/*staging Buffers*/,
-                                                this->cpu_accessible_am, 
+                                                this->cpu_accessible_am,
                                                 HCC_H2D_STAGING_THRESHOLD,
                                                 HCC_H2D_PININPLACE_THRESHOLD,
                                                 HCC_D2H_PININPLACE_THRESHOLD);
@@ -2165,7 +2165,7 @@ public:
                     }
                 }
             }
-         
+
             if (!kernel) {
                 std::cerr << "HSADevice::CreateKernel(): Unable to create kernel\n";
                 abort();
@@ -2881,7 +2881,7 @@ HSAQueue::getHSAKernargRegion() override {
     return static_cast<void*>(&(static_cast<HSADevice*>(getDev())->getHSAKernargRegion()));
 }
 
-void HSAQueue::copy_ext(const void *src, void *dst, size_t size_bytes, hc::hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo, 
+void HSAQueue::copy_ext(const void *src, void *dst, size_t size_bytes, hc::hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo,
               const Kalmar::KalmarDevice *copyDevice, bool forceUnpinnedCopy) override {
 #if KALMAR_DEBUG
     std::cerr << "HSAQueue::copy(" << src << ", " << dst << ", " << size_bytes << ")\n";
@@ -2924,8 +2924,8 @@ void HSAQueue::copy_ext(const void *src, void *dst, size_t size_bytes, hc::hcCom
 }
 
 
-std::shared_ptr<KalmarAsyncOp> HSAQueue::EnqueueAsyncCopyExt(const void* src, void* dst, size_t size_bytes, 
-                                                   hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo, 
+std::shared_ptr<KalmarAsyncOp> HSAQueue::EnqueueAsyncCopyExt(const void* src, void* dst, size_t size_bytes,
+                                                   hcCommandKind copyDir, const hc::AmPointerInfo &srcPtrInfo, const hc::AmPointerInfo &dstPtrInfo,
                                                    const Kalmar::KalmarDevice *copyDevice) override {
 
     hsa_status_t status = HSA_STATUS_SUCCESS;
@@ -2972,7 +2972,7 @@ std::shared_ptr<KalmarAsyncOp> HSAQueue::EnqueueAsyncCopy(const void *src, void 
     // Select optimal copy agent:
     // Prefer source SDMA engine if possible since this is typically the fastest, unless the source data is in host mem.
     //
-    // If the src agent cannot see both src and dest pointers, then the async copy will fault.   
+    // If the src agent cannot see both src and dest pointers, then the async copy will fault.
     // The caller of this function is responsible for avoiding this situation, by examining the
     // host and device allow-access mappings and using a CPU staging copy BEFORE calling
     // this routine.
@@ -2996,12 +2996,12 @@ std::shared_ptr<KalmarAsyncOp> HSAQueue::EnqueueAsyncCopy(const void *src, void 
 }
 
 
-void 
-HSAQueue::dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql, 
+void
+HSAQueue::dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql,
                          const void * args, size_t argSize,
-                         hc::completion_future *cf) override 
+                         hc::completion_future *cf) override
 {
-    uint16_t dims = (aql->setup >> HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) & 
+    uint16_t dims = (aql->setup >> HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) &
                     ((1 << HSA_KERNEL_DISPATCH_PACKET_SETUP_WIDTH_DIMENSIONS) - 1);
 
     if (dims == 0) {
@@ -3053,7 +3053,7 @@ HSADispatch::HSADispatch(Kalmar::HSADevice* _device, HSAKernel* _kernel,
     waitMode(HSA_WAIT_STATE_BLOCKED),
     future(nullptr),
     hsaQueue(nullptr),
-    kernargMemory(nullptr) 
+    kernargMemory(nullptr)
 {
     if (aql) {
         this->aql = *aql;
@@ -3066,7 +3066,7 @@ HSADispatch::HSADispatch(Kalmar::HSADevice* _device, HSAKernel* _kernel,
 // dispatch a kernel asynchronously
 // -  allocates signal, copies arguments into kernarg buffer, and places aql packet into queue.
 hsa_status_t
-HSADispatch::dispatchKernel(hsa_queue_t* commandQueue, const void *hostKernarg, 
+HSADispatch::dispatchKernel(hsa_queue_t* commandQueue, const void *hostKernarg,
                             int hostKernargSize, bool allocSignal) {
 
     hsa_status_t status = HSA_STATUS_SUCCESS;
@@ -3121,7 +3121,7 @@ HSADispatch::dispatchKernel(hsa_queue_t* commandQueue, const void *hostKernarg,
     }
 
 
-    hsa_kernel_dispatch_packet_t* q_aql = 
+    hsa_kernel_dispatch_packet_t* q_aql =
         &(((hsa_kernel_dispatch_packet_t*)(commandQueue->base_address))[index & queueMask]);
 
     // Copy mostly-finished AQL packet into the queue
@@ -3234,14 +3234,14 @@ HSADispatch::dispatchKernelWaitComplete(Kalmar::HSAQueue* hsaQueue) {
 
 // Flavor used when launching dispatch with args and signal created by HCC
 // (As opposed to the dispatch_hsa_kernel path)
-inline hsa_status_t 
+inline hsa_status_t
 HSADispatch::dispatchKernelAsyncFromOp(Kalmar::HSAQueue* hsaQueue)
 {
     return dispatchKernelAsync(hsaQueue, arg_vec.data(), arg_vec.size(), true);
 }
 
 inline hsa_status_t
-HSADispatch::dispatchKernelAsync(Kalmar::HSAQueue* hsaQueue, const void *hostKernarg, 
+HSADispatch::dispatchKernelAsync(Kalmar::HSAQueue* hsaQueue, const void *hostKernarg,
                                  int hostKernargSize, bool allocSignal) {
 
     if (HCC_SERIALIZE_KERNEL & 0x1) {
@@ -3373,10 +3373,10 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     aql.workgroup_size_z = workgroup_size[2];
 
     aql.setup = dims << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
-   
-   // Set fences here.  Other fields in header will be set just before dispatch: 
 
-    aql.header = 
+   // Set fences here.  Other fields in header will be set just before dispatch:
+
+    aql.header =
         ((HSA_FENCE_SCOPE_SYSTEM) << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
         ((HSA_FENCE_SCOPE_SYSTEM) << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
 
@@ -3565,9 +3565,9 @@ HSACopy::waitComplete() {
 
 
 // Small wrapper that calls hsa_amd_memory_async_copy.
-// HCC knows exactly which copy-engine it wants to perfom the copy and has already made. 
-hsa_status_t HSACopy::hcc_memory_async_copy(const Kalmar::HSADevice *copyDeviceArg, void *dst, const void *src, size_t sizeBytes, 
-                      int depSignalCnt, const hsa_signal_t *depSignals, 
+// HCC knows exactly which copy-engine it wants to perfom the copy and has already made.
+hsa_status_t HSACopy::hcc_memory_async_copy(const Kalmar::HSADevice *copyDeviceArg, void *dst, const void *src, size_t sizeBytes,
+                      int depSignalCnt, const hsa_signal_t *depSignals,
                       hsa_signal_t completion_signal)
 {
     this->copyDevice = copyDeviceArg;
@@ -3580,12 +3580,12 @@ hsa_status_t HSACopy::hcc_memory_async_copy(const Kalmar::HSADevice *copyDeviceA
     if (status != HSA_STATUS_SUCCESS) {
         throw Kalmar::runtime_exception("invalid copy agent used for hcc_memory_async_copy", status);
     }
-    if (device_type != HSA_DEVICE_TYPE_GPU) { 
+    if (device_type != HSA_DEVICE_TYPE_GPU) {
         throw Kalmar::runtime_exception("copy agent must be GPU hcc_memory_async_copy", -1);
     }
 
     // Pass same copy agent for source and device so we have control over the copy engine.
-    // The runtime will always pick the srcAgent if it is a GPU (which we checked above), and 
+    // The runtime will always pick the srcAgent if it is a GPU (which we checked above), and
     // if at least on of the pointers is in device memory. (caller should ensure this is true).
 
     status = hsa_amd_memory_async_copy(dst, copyAgent, src, copyAgent, sizeBytes, depSignalCnt, depSignals, completion_signal);
@@ -3660,7 +3660,7 @@ HSACopy::enqueueAsyncCopyCommand(Kalmar::HSAQueue* hsaQueue, const Kalmar::HSADe
 #if KALMAR_DEBUG_ASYNC_COPY
             hsa_signal_value_t v = hsa_signal_load_acquire(signal);
             std::cerr << "  hsa_amd_memory_async_copy launched " << " completionSignal="<< std::hex  << signal.handle
-                      << "  InitSignalValue=" << v << " depSignalCnt=" << depSignalCnt 
+                      << "  InitSignalValue=" << v << " depSignalCnt=" << depSignalCnt
                       << "  copyAgent=" << copyDevice
                       << "\n";
 #endif
@@ -3729,7 +3729,7 @@ HSACopy::syncCopyExt(Kalmar::HSAQueue *hsaQueue, hc::hcCommandKind copyDir, cons
 {
     bool srcInTracker = (srcPtrInfo._sizeBytes != 0);
     bool dstInTracker = (dstPtrInfo._sizeBytes != 0);
-    
+
 
 // TODO - Clean up code below.
     // Copy already called queue.wait() so there are no dependent signals.
@@ -3880,7 +3880,7 @@ HSACopy::syncCopy(Kalmar::HSAQueue* hsaQueue) {
 
     // The tracker stores information on all device memory allocations and all pinned host memory, for the specified device
     // If the memory is not found in the tracker, then it is assumed to be unpinned host memory.
-    bool srcInTracker = false;  
+    bool srcInTracker = false;
     bool srcInDeviceMem = false;
     bool dstInTracker = false;
     bool dstInDeviceMem = false;

--- a/tests/Unit/Codegen/generic_lambda_amp.cpp
+++ b/tests/Unit/Codegen/generic_lambda_amp.cpp
@@ -1,0 +1,104 @@
+#if __cplusplus >= 201402L
+    // RUN: %cxxamp %s -o %t.out && %t.out
+    #include <amp.h>
+
+    #include <type_traits>
+
+    bool generic_lambda_as_rvalue_is_valid_pfe_argument()
+    {
+        using namespace Concurrency;
+
+        array_view<int> t{1};
+
+        // Non-tiled domain.
+        parallel_for_each(extent<1>{1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<1>>::value, "");
+
+            t[idx[0]] = 1;
+        });
+        parallel_for_each(extent<2>{1, 1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<2>>::value, "");
+
+            ++t[idx[0] + idx[1]];
+        });
+        parallel_for_each(extent<3>{1, 1, 1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<3>>::value, "");
+
+            ++t[idx[0] + idx[1] + idx[2]];
+        });
+
+        // Tiled domain.
+        parallel_for_each(extent<1>{1}.tile<1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1>>::value,
+                          "");
+            ++t[tidx.local[0]];
+        });
+        parallel_for_each(extent<2>{1, 1}.tile<1, 1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1, 1>>::value,
+                          "");
+            ++t[tidx.local[0] + tidx.local[1]];
+        });
+        parallel_for_each(extent<3>{1, 1, 1}.tile<1, 1, 1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1, 1, 1>>::value,
+                          "");
+            ++t[tidx.local[0] + tidx.local[1] + tidx.local[2]];
+        });
+
+        return t[0] == 6;
+    }
+
+    bool generic_lambda_as_lvalue_is_valid_pfe_argument()
+    {
+        using namespace Concurrency;
+
+        array_view<int> t{1}; t[0] = 0;
+
+        const auto lambda = [=](auto&& idx) restrict(amp) {
+            #if __cplusplus > 201402L
+                if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                            index<1>>) {
+                    ++t[idx[0]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 index<2>>) {
+                    ++t[idx[0] + idx[1]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 index<3>>) {
+                    ++t[idx[0] + idx[1] + idx[2]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 tiled_index<1>>) {
+                    ++t[idx.local[0]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 tiled_index<1, 1>>) {
+                    ++t[idx.local[0] + idx.local[1]];
+                }
+                else ++t[idx.local[0] + idx.local[1] + idx.local[2]];
+            #else
+                ++t[0];
+            #endif
+        };
+
+        // Non-tiled domain.
+        parallel_for_each(extent<1>{1}, lambda);
+        parallel_for_each(extent<3>{1, 1, 1}, lambda);
+        parallel_for_each(extent<2>{1, 1}, lambda);
+
+        // Tiled domain.
+        parallel_for_each(extent<1>{1}.tile<1>(), lambda);
+        parallel_for_each(extent<2>{1, 1}.tile<1, 1>(), lambda);
+        parallel_for_each(extent<3>{1, 1, 1}.tile<1, 1, 1>(), lambda);
+
+        return t[0] == 6;
+    }
+
+    int main()
+    {
+        // TODO: this is temporary, and not a proper unit test.
+        if (!generic_lambda_as_rvalue_is_valid_pfe_argument()) return EXIT_FAILURE;
+        if (!generic_lambda_as_lvalue_is_valid_pfe_argument()) return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    }
+#endif

--- a/tests/Unit/Codegen/generic_lambda_hc.cpp
+++ b/tests/Unit/Codegen/generic_lambda_hc.cpp
@@ -1,0 +1,104 @@
+#if __cplusplus >= 201402L
+    // RUN: %hc %s -o %t.out && %t.out
+    #include <amp.h>
+
+    #include <type_traits>
+
+    bool generic_lambda_as_rvalue_is_valid_pfe_argument()
+    {
+        using namespace Concurrency;
+
+        array_view<int> t{1};
+
+        // Non-tiled domain.
+        parallel_for_each(extent<1>{1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<1>>::value, "");
+
+            t[idx[0]] = 1;
+        });
+        parallel_for_each(extent<2>{1, 1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<2>>::value, "");
+
+            ++t[idx[0] + idx[1]];
+        });
+        parallel_for_each(extent<3>{1, 1, 1}, [=](auto&& idx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(idx), index<3>>::value, "");
+
+            ++t[idx[0] + idx[1] + idx[2]];
+        });
+
+        // Tiled domain.
+        parallel_for_each(extent<1>{1}.tile<1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1>>::value,
+                          "");
+            ++t[tidx.local[0]];
+        });
+        parallel_for_each(extent<2>{1, 1}.tile<1, 1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1, 1>>::value,
+                          "");
+            ++t[tidx.local[0] + tidx.local[1]];
+        });
+        parallel_for_each(extent<3>{1, 1, 1}.tile<1, 1, 1>(), [=](auto&& tidx) restrict(amp) {
+            static_assert(std::is_convertible<decltype(tidx), tiled_index<1, 1, 1>>::value,
+                          "");
+            ++t[tidx.local[0] + tidx.local[1] + tidx.local[2]];
+        });
+
+        return t[0] == 6;
+    }
+
+    bool generic_lambda_as_lvalue_is_valid_pfe_argument()
+    {
+        using namespace Concurrency;
+
+        array_view<int> t{1}; t[0] = 0;
+
+        const auto lambda = [=](auto&& idx) restrict(amp) {
+            #if __cplusplus > 201402L
+                if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                            index<1>>) {
+                    ++t[idx[0]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 index<2>>) {
+                    ++t[idx[0] + idx[1]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 index<3>>) {
+                    ++t[idx[0] + idx[1] + idx[2]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 tiled_index<1>>) {
+                    ++t[idx.local[0]];
+                }
+                else if constexpr(std::is_same_v<std::decay_t<decltype(idx)>,
+                                                 tiled_index<1, 1>>) {
+                    ++t[idx.local[0] + idx.local[1]];
+                }
+                else ++t[idx.local[0] + idx.local[1] + idx.local[2]];
+            #else
+                ++t[0];
+            #endif
+        };
+
+        // Non-tiled domain.
+        parallel_for_each(extent<1>{1}, lambda);
+        parallel_for_each(extent<3>{1, 1, 1}, lambda);
+        parallel_for_each(extent<2>{1, 1}, lambda);
+
+        // Tiled domain.
+        parallel_for_each(extent<1>{1}.tile<1>(), lambda);
+        parallel_for_each(extent<2>{1, 1}.tile<1, 1>(), lambda);
+        parallel_for_each(extent<3>{1, 1, 1}.tile<1, 1, 1>(), lambda);
+
+        return t[0] == 6;
+    }
+
+    int main()
+    {
+        // TODO: this is temporary, and not a proper unit test.
+        if (!generic_lambda_as_rvalue_is_valid_pfe_argument()) return EXIT_FAILURE;
+        if (!generic_lambda_as_lvalue_is_valid_pfe_argument()) return EXIT_FAILURE;
+        return EXIT_SUCCESS;
+    }
+#endif

--- a/tests/Unit/HC/execute_order.cpp
+++ b/tests/Unit/HC/execute_order.cpp
@@ -21,13 +21,13 @@ int main() {
   accelerator_view av_any_order = acc.create_view(execute_any_order);
 
   // test dispatch a kernel to av
-  parallel_for_each(av, extent<1>(1), []() [[hc]] {});
+  parallel_for_each(av, extent<1>(1), [](index<1>) [[hc]] {});
 
   // test dispatch a kernel to av_in_order
-  parallel_for_each(av_in_order, extent<1>(1), []() [[hc]] {});
+  parallel_for_each(av_in_order, extent<1>(1), [](index<1>) [[hc]] {});
 
   // test dispatch a kernel to av_any_order
-  parallel_for_each(av_any_order, extent<1>(1), []() [[hc]] {});
+  parallel_for_each(av_any_order, extent<1>(1), [](index<1>) [[hc]] {});
 
   return 0;
 }

--- a/tests/benchEmptyKernel/bench.cpp
+++ b/tests/benchEmptyKernel/bench.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s %S/statutils.CPP -O3  %S/hsacodelib.CPP  -o %t.out -I/opt/rocm/include -L/opt/rocm/lib -lhsa-runtime64 
+// RUN: %hc %s %S/statutils.CPP -O3  %S/hsacodelib.CPP  -o %t.out -I/opt/rocm/include -L/opt/rocm/lib -lhsa-runtime64
 // RUN: %t.out 10000 %T
 // RUN: test -e pfe.dat && mv pfe.dat %T/pfe.dat
 // RUN: test -e grid_launch.dat && mv grid_launch.dat %T/grid_launch.dat
@@ -37,7 +37,7 @@
 #define DISPATCH_COUNT 10000
 #define TOL_HI 1e-4
 
-__attribute__((hc_grid_launch)) 
+__attribute__((hc_grid_launch))
 void nullkernel(const grid_launch_parm lp, float* A) {
     if (A) {
         A[0] = 0x13;
@@ -99,7 +99,7 @@ void time_dispatch_hsa_kernel(int dispatch_count, const grid_launch_parm *lp, co
   std::vector<std::chrono::duration<double>> outliers;
   remove_outliers(elapsed_timer, outliers);
   plot(testName, elapsed_timer);
-  std::cout << std::setw(20) << std::left << testName << "time, active (us):  " 
+  std::cout << std::setw(20) << std::left << testName << "time, active (us):  "
             << std::setprecision(8) << average(elapsed_timer)*1000000.0 << "\n";
 };
 
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) {
   // timing for null kernel launch appears later
 
   hc::parallel_for_each(av, hc::extent<3>(lp.grid_dim.x*lp.group_dim.x,1,1).tile(lp.group_dim.x,1,1),
-  [=](hc::index<3>& idx) __HC__ {
+  [=](hc::tiled_index<3>& idx) __HC__ {
   }).wait();
 
   // Setting lp.cf to completion_future so we can track completion: (NULL ignores all synchronization)
@@ -155,7 +155,7 @@ int main(int argc, char* argv[]) {
   for(int i = 0; i < dispatch_count; ++i) {
     start = std::chrono::high_resolution_clock::now();
     auto cf = hc::parallel_for_each(av, hc::extent<3>(lp.grid_dim.x*lp.group_dim.x,1,1).tile(lp.group_dim.x,1,1),
-    [=](hc::index<3>& idx) __HC__ {
+    [=](hc::tiled_index<3>& idx) __HC__ {
     });
     cf.wait(hc::hcWaitModeActive);
     end = std::chrono::high_resolution_clock::now();
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
   }
   remove_outliers(elapsed_pfe, outliers_pfe);
   plot("pfe", elapsed_pfe);
-  std::cout << "pfe time, active (us):                  " 
+  std::cout << "pfe time, active (us):                  "
             << std::setprecision(8) << average(elapsed_pfe)*1000000.0 << "\n";
 
 
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
   for(int i = 0; i < dispatch_count; ++i) {
     start = std::chrono::high_resolution_clock::now();
     auto cf = hc::parallel_for_each(av, hc::extent<3>(lp.grid_dim.x*lp.group_dim.x,1,1).tile(lp.group_dim.x,1,1),
-    [=](hc::index<3>& idx) __HC__ {
+    [=](hc::tiled_index<3>& idx) __HC__ {
     });
     cf.wait(hc::hcWaitModeBlocked);
     end = std::chrono::high_resolution_clock::now();
@@ -181,14 +181,14 @@ int main(int argc, char* argv[]) {
   }
   remove_outliers(elapsed_pfe, outliers_pfe);
   plot("pfe", elapsed_pfe);
-  std::cout << "pfe time, blocked (us):                 " 
+  std::cout << "pfe time, blocked (us):                 "
             << std::setprecision(8) << average(elapsed_pfe)*1000000.0 << "\n";
 
 
   // Timing null grid_launch call, active wait
   for(int i = 0; i < dispatch_count; ++i) {
     start = std::chrono::high_resolution_clock::now();
-    hc::completion_future cf; // create new completion-future 
+    hc::completion_future cf; // create new completion-future
     lp.cf = &cf;
 
     nullkernel(lp, 0x0);
@@ -201,14 +201,14 @@ int main(int argc, char* argv[]) {
   }
   remove_outliers(elapsed_grid_launch, outliers_gl);
   plot("grid_launch", elapsed_grid_launch);
-  std::cout << "grid_launch time, active (us):          " 
+  std::cout << "grid_launch time, active (us):          "
             << std::setprecision(8) << average(elapsed_grid_launch)*1000000.0 << "\n";
 
 
   // Timing null grid_launch call, blocked wait
   for(int i = 0; i < dispatch_count; ++i) {
     start = std::chrono::high_resolution_clock::now();
-    hc::completion_future cf; // create new completion-future 
+    hc::completion_future cf; // create new completion-future
     lp.cf = &cf;
 
     nullkernel(lp, 0x0);
@@ -221,7 +221,7 @@ int main(int argc, char* argv[]) {
   }
   remove_outliers(elapsed_grid_launch, outliers_gl);
   plot("grid_launch", elapsed_grid_launch);
-  std::cout << "grid_launch time, blocked (us):         " 
+  std::cout << "grid_launch time, blocked (us):         "
             << std::setprecision(8) << average(elapsed_grid_launch)*1000000.0 << "\n";
 
 

--- a/tests/benchEmptyKernel/bench.cpp
+++ b/tests/benchEmptyKernel/bench.cpp
@@ -260,7 +260,7 @@ int main(int argc, char* argv[]) {
         hc::completion_future cf;
         for (int j=0; j<p_burst_count ;j++) {
             cf = hc::parallel_for_each(av, hc::extent<3>(lp.grid_dim.x*lp.group_dim.x,1,1).tile(lp.group_dim.x,1,1),
-            [=](hc::index<3>& idx) __HC__ {
+            [=](hc::tiled_index<3>& idx) __HC__ {
             });
         };
         cf.wait(hc::hcWaitModeBlocked);


### PR DESCRIPTION
This handles the AMP/HC runtime part of enabling passing generic lambdas as arguments to p_f_e. It is matched with an associated PR against the Clang upgrade repository, since changes are needed in Clang as well. The enabled functionality is predicated on also enabling C++14+ support, which we've yet to do. The main change is to do manual overload resolution against the correct index type on the kernel path within the p_f_e against the Callable's operator(), since in a generic lambda scenario this is no longer singular, but rather a function template that stands in for a family of functions. It also fixes some tests which were ill-specified and adds unit tests for verifying functionality both in C++AMP mode and in HC mode. The latter are only enabled when running in in no less than C++14 mode. It temporarily bubbles up some Promote pass errors in the functor4, functor5 and functor6 unit tests, which will be subsequently fixed, and is otherwise unit test neutral. While I believe that a cleaner design is possible and desirable in the Runtime, that would be too big a leap at the moment. Please review and merge if adequate. Thank you.