### PR TITLE
enable amdgpu-internalize-symbols optimization

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -176,7 +176,7 @@ fi
 
 # Optimization notes:
 #  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
-$OPT $KMOPTOPT -inline -mtriple amdgcn--amdhsa -mcpu=$AMDGPU_TARGET -disable-simplify-libcalls -verify $2.linked.bc -o $2.opt.bc
+$OPT $KMOPTOPT -inline -mtriple amdgcn--amdhsa -mcpu=$AMDGPU_TARGET -amdgpu-internalize-symbols -disable-simplify-libcalls -verify $2.linked.bc -o $2.opt.bc
 
 # error handling for opt
 RETVAL=$?


### PR DESCRIPTION
Enable amdgpu-internalize-symbols which optimize the object code size by removing unreferenced symbols.  This is probably more useful to the promotion-free pass since the clang_tot_upgrade has the erase-no-kernel pass.