### PR TITLE
Use imported target for hsa to make find_package relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,13 @@ if (NOT HSA_LIBRARY)
   MESSAGE("HSA runtime library not found. Use -DHSA_LIBRARY=<path_to_libhsa-runtime64.so>.")
 endif (NOT HSA_LIBRARY)
 
+add_library(hsa-runtime64 SHARED IMPORTED GLOBAL)
+
+set_target_properties(hsa-runtime64 PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+  IMPORTED_LOCATION "${HSA_LIBRARY}"
+  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+)
 
 ################
 # Detect ROCm Device Libs

--- a/lib/hcc-config.cmake.in
+++ b/lib/hcc-config.cmake.in
@@ -4,6 +4,24 @@ set_and_check( hcc_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@" )
 set_and_check( hcc_INCLUDE_DIRS "${hcc_INCLUDE_DIR}" )
 set_and_check( hcc_LIB_INSTALL_DIR "@PACKAGE_LIB_INSTALL_DIR@" )
 
+find_path(HSA_HEADER hsa/hsa.h
+  PATHS
+    /opt/rocm/include
+)
+
+find_library(HSA_LIBRARY hsa-runtime64
+  PATHS
+    /opt/rocm/lib
+)
+
+add_library(hsa-runtime64 IMPORTED)
+
+set_target_properties(hsa-runtime64 PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+  IMPORTED_LOCATION "${HSA_LIBRARY}"
+  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+)
+
 include( "${CMAKE_CURRENT_LIST_DIR}/hcc-targets.cmake" )
 
 set( hcc_LIBRARIES hcc::hccrt hcc::hc_am)

--- a/lib/hcc-config.cmake.in
+++ b/lib/hcc-config.cmake.in
@@ -14,7 +14,7 @@ find_library(HSA_LIBRARY hsa-runtime64
     /opt/rocm/lib
 )
 
-add_library(hsa-runtime64 IMPORTED)
+add_library(hsa-runtime64 SHARED IMPORTED GLOBAL)
 
 set_target_properties(hsa-runtime64 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"

--- a/lib/hsa/CMakeLists.txt
+++ b/lib/hsa/CMakeLists.txt
@@ -2,7 +2,6 @@
 # HCC runtime (HSA implementation)
 ####################
 if (HAS_ROCM EQUAL 1)
-include_directories(${HSA_HEADER})
 add_mcwamp_library_hsa(mcwamp_hsa mcwamp_hsa.cpp unpinned_copy_engine.cpp)
 add_mcwamp_library_hc_am(hc_am hc_am.cpp)
 install(TARGETS mcwamp_hsa hc_am

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -70,12 +70,11 @@ macro(add_mcwamp_library_hsa name )
   add_compile_options(-std=c++11)
   # add HSA headers
   add_library( ${name} SHARED ${ARGN} )
-  target_include_directories(${name} SYSTEM PUBLIC ${HSA_HEADER})
   amp_target(${name})
   # LLVM and Clang shall be compiled beforehand
   add_dependencies(${name} llvm-link opt clang hc_am)
   # add HSA libraries
-  target_link_libraries(${name} ${HSA_LIBRARY})
+  target_link_libraries(${name} hsa-runtime64)
   target_link_libraries(${name} pthread)
 
   if (USE_LIBCXX)
@@ -91,12 +90,11 @@ macro(add_mcwamp_library_hc_am name )
   CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
   # add HSA headers
   add_library( ${name} SHARED ${ARGN} )
-  target_include_directories(${name} PRIVATE ${HSA_HEADER})
   amp_target(${name})
   # LLVM and Clang shall be compiled beforehand
   add_dependencies(${name} llvm-link opt clang)
   # add HSA libraries
-  target_link_libraries(${name} ${HSA_LIBRARY})
+  target_link_libraries(${name} hsa-runtime64)
   target_link_libraries(${name} pthread)
 
   if (USE_LIBCXX)


### PR DESCRIPTION
Currently, it was using an absolute path to hsa in the exported targets. This makes an imported target of hsa libraries, so that`hcc-cmake.config`(ie `find_package(hcc)`) can be relocatable. 