### PR TITLE
Fixed unpinned copy mode issue

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2116,6 +2116,7 @@ public:
         }
 
         //---
+        this->copy_mode = static_cast<UnpinnedCopyEngine::CopyMode> (HCC_UNPINNED_COPY_MODE);
         //Provide an environment variable to select the mode used to perform the copy operaton
         switch (this->copy_mode) {
             case UnpinnedCopyEngine::ChooseBest:    //0

--- a/lib/hsa/unpinned_copy_engine.cpp
+++ b/lib/hsa/unpinned_copy_engine.cpp
@@ -216,10 +216,23 @@ void UnpinnedCopyEngine::CopyHostToDeviceMemcpy(void* dst, const void* src, size
 
 void UnpinnedCopyEngine::CopyHostToDevice(UnpinnedCopyEngine::CopyMode copyMode, void* dst, const void* src, size_t sizeBytes, hsa_signal_t *waitFor)
 {
+    hsa_amd_pointer_info_t info;
+    hsa_status_t hsa_status;
+    bool isLocked = false;
+    const char *srcp = static_cast<const char*> (src);
+    info.size = sizeof(info);
+    hsa_status = hsa_amd_pointer_info(const_cast<char*> (srcp), &info, nullptr, nullptr, nullptr);
+    if(hsa_status != HSA_STATUS_SUCCESS) {
+        THROW_ERROR(hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+    }
+    tprintf (DB_COPY2, "Unpinned H2D: pointer type =%d\n", info.type);
+    if((info.type == HSA_EXT_POINTER_TYPE_HSA) || (info.type == HSA_EXT_POINTER_TYPE_LOCKED)) {
+        isLocked = true;
+    }
     if (copyMode == ChooseBest) {
         if (_isLargeBar && (sizeBytes < _hipH2DTransferThresholdDirectOrStaging)) {
             copyMode = UseMemcpy;
-        } else if (sizeBytes > _hipH2DTransferThresholdStagingOrPininplace) {
+        } else if ((sizeBytes > _hipH2DTransferThresholdStagingOrPininplace) && (!isLocked)) {
             copyMode = UsePinInPlace;
         } else {
             copyMode = UseStaging;
@@ -229,7 +242,7 @@ void UnpinnedCopyEngine::CopyHostToDevice(UnpinnedCopyEngine::CopyMode copyMode,
     if (copyMode == UseMemcpy) {
         CopyHostToDeviceMemcpy(dst, src, sizeBytes, waitFor);
 
-	} else if (copyMode == UsePinInPlace) {
+	} else if ((copyMode == UsePinInPlace) && (!isLocked)) {
         CopyHostToDevicePinInPlace(dst, src, sizeBytes, waitFor);
 
 	} else if (copyMode == UseStaging) {


### PR DESCRIPTION
- Enabled Copy mode selection through env variable
- Guarded PinInPlace logic from being called with already locked pointer.
[TestResults.txt](https://github.com/RadeonOpenCompute/hcc/files/915560/TestResults.txt)
