### PR TITLE
cleanup and refactor cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,23 +55,8 @@ set(LLVM_ROOT "${PROJECT_BINARY_DIR}/compiler")
 SET(LOCAL_LLVM_INCLUDE compiler/include)
 
 # setup compilation environment
-if (UNIX)
-SET(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin" )
-SET(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib" )
-else (UNIX)
-SET(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin" )
-SET(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib" )
-SET( CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${EXECUTABLE_OUTPUT_PATH})
-SET( CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${EXECUTABLE_OUTPUT_PATH})
-
-SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${EXECUTABLE_OUTPUT_PATH})
-SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${EXECUTABLE_OUTPUT_PATH})
-
-SET( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${LIBRARY_OUTPUT_PATH})
-SET( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${LIBRARY_OUTPUT_PATH})
-MESSAGE("(DEBUG|RELEASE) output changed to path:" "${EXECUTABLE_OUTPUT_PATH}")
-
-endif (UNIX)
+set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin" )
+set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib" )
 
 SET(PROJ_SEARCH_PATH "${PROJECT_BINARY_DIR}/include" "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/${LOCAL_LLVM_INCLUDE}" "${PROJECT_BINARY_DIR}/${LOCAL_LLVM_INCLUDE}") #  "${PROJECT_SOURCE_DIR}/compiler/utils/unittest/googletest/include")
 include_directories( ${PROJ_SEARCH_PATH} )
@@ -189,7 +174,7 @@ endif (USE_CODEXL_ACTIVITY_LOGGER EQUAL 1)
 # hcc will use libc++ if USE_LIBCXX is set to ON; otherwise, it will use libstdc++
 #################
 
-# if USE_LIBCXX is not expicitely set
+# if USE_LIBCXX is not explicitly set
 if( NOT DEFINED USE_LIBCXX )
   # default to libstdc++
   set( USE_LIBCXX "OFF" )
@@ -220,34 +205,17 @@ endif( )
 SET(KALMAR_VERSION_MAJOR "1")
 SET(KALMAR_VERSION_MINOR "0")
 
-# get date information based on UTC
-# use the last two digits of year + week number + day in the week as KALMAR_VERSION_PATCH
-# use the commit date, instead of build date
-# add xargs to remove strange trailing newline character
-execute_process(COMMAND git show -s --format=@%ct
-                COMMAND xargs
-                COMMAND date -f - --utc +%y%U%w
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                OUTPUT_VARIABLE KALMAR_VERSION_PATCH
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+include(GenerateVersionFromGit)
 
-# get commit information
-execute_process(COMMAND git rev-parse --short HEAD
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                OUTPUT_VARIABLE KALMAR_SDK_COMMIT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND git rev-parse --short HEAD
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/clang
-                OUTPUT_VARIABLE KALMAR_FRONTEND_COMMIT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND git rev-parse --short HEAD
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/compiler
-                OUTPUT_VARIABLE KALMAR_BACKEND_COMMIT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (NOT KALMAR_VERSION_STRING)
+  set(KALMAR_VERSION_STRING
+    "${KALMAR_VERSION_MAJOR}.${KALMAR_VERSION_MINOR}")
+endif()
 
 # Set HCC version string. The rule for version string is:
 # KALMAR_VERSION_MAJOR . KALMAR_VERSION_MINOR . KALMAR_VERSION_PATCH-KALMAR_SDK_COMIT-KALMAR_FRONTEND_COMMIT-KALMAR_BACKEND_COMMIT
-set(KALMAR_VERSION_STRING "${KALMAR_VERSION_MAJOR}.${KALMAR_VERSION_MINOR}.${KALMAR_VERSION_PATCH}-${KALMAR_SDK_COMMIT}-${KALMAR_FRONTEND_COMMIT}-${KALMAR_BACKEND_COMMIT}")
+add_version_info_from_git(KALMAR_VERSION_STRING
+  KALMAR_VERSION_PATCH KALMAR_SDK_COMMIT KALMAR_FRONTEND_COMMIT KALMAR_BACKEND_COMMIT)
 
 # set default installation path
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND CMAKE_INSTALL_PREFIX MATCHES "/usr/local")
@@ -639,8 +607,7 @@ set(CPACK_COMPONENTS_ALL compiler)
 include (CPack)
 MESSAGE("")
 MESSAGE("** For the first time:")
-MESSAGE("   'make world' to build HCC Clang, and library for testing.")
-MESSAGE("   'make' to build the rest of LLVM tools")
+MESSAGE("   'make' to build all")
 MESSAGE("   'make docs' to build the HTML API reference")
 MESSAGE("")
 

--- a/cmake-tests/CMakeLists.txt
+++ b/cmake-tests/CMakeLists.txt
@@ -1,7 +1,5 @@
+set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
 
-if(COMMAND CMAKE_FORCE_CXX_COMPILER)
-CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
-endif()
 add_executable(cmake-test cmake-test.cpp)
 if(TARGET hccrt)
     target_link_libraries(cmake-test hccrt hc_am)

--- a/scripts/cmake/GenerateVersionFromGit.cmake
+++ b/scripts/cmake/GenerateVersionFromGit.cmake
@@ -1,0 +1,31 @@
+function(add_version_info_from_git VERS PATCH_P SDK_COMMIT_P FRONTEND_COMMIT_P BACKEND_COMMIT_P)
+  # get date information based on UTC
+  # use the last two digits of year + week number + day in the week as KALMAR_VERSION_PATCH
+  # use the commit date, instead of build date
+  # add xargs to remove strange trailing newline character
+  execute_process(COMMAND git show -s --format=@%ct
+                  COMMAND xargs
+                  COMMAND date -f - --utc +%y%U%w
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                  OUTPUT_VARIABLE PATCH
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # get commit information
+  execute_process(COMMAND git rev-parse --short HEAD
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                OUTPUT_VARIABLE SDK_COMMIT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND git rev-parse --short HEAD
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/clang
+                  OUTPUT_VARIABLE FRONTEND_COMMIT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND git rev-parse --short HEAD
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/compiler
+                  OUTPUT_VARIABLE BACKEND_COMMIT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(${VERS} "${${VERS}}.${PATCH}-${SDK_COMMIT}-${FRONTEND_COMMIT}-${BACKEND_COMMIT}" PARENT_SCOPE)
+  set(${PATCH_P} "${PATCH}" PARENT_SCOPE)
+  set(${SDK_COMMIT_P} "${SDK_COMMIT}" PARENT_SCOPE)
+  set(${FRONTEND_COMMIT_P} "${FRONTEND_COMMIT}" PARENT_SCOPE)
+  set(${BACKEND_COMMIT_P} "${BACKEND_COMMIT}" PARENT_SCOPE)
+endfunction(add_version_info_from_git)

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -1,5 +1,3 @@
-include (CMakeForceCompiler)
-
 if(POLICY CMP0046)
   cmake_policy(PUSH)
   cmake_policy(SET CMP0046 OLD)
@@ -35,7 +33,7 @@ endmacro(amp_target name )
 # C++AMP runtime interface (mcwamp) 
 ####################
 macro(add_mcwamp_library name )
-  CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
+  set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
   add_library( ${name} ${ARGN} )
   amp_target(${name})
@@ -47,7 +45,7 @@ endmacro(add_mcwamp_library name )
 # C++AMP runtime (CPU implementation)
 ####################
 macro(add_mcwamp_library_cpu name )
-  CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
+  set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
   add_library( ${name} SHARED ${ARGN} )
   amp_target(${name})
@@ -66,7 +64,7 @@ endmacro(add_mcwamp_library_cpu name )
 # C++AMP runtime (HSA implementation) 
 ####################
 macro(add_mcwamp_library_hsa name )
-  CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
+  set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
   # add HSA headers
   add_library( ${name} SHARED ${ARGN} )
@@ -87,7 +85,7 @@ macro(add_mcwamp_library_hsa name )
 endmacro(add_mcwamp_library_hsa name )
 
 macro(add_mcwamp_library_hc_am name )
-  CMAKE_FORCE_CXX_COMPILER("${PROJECT_BINARY_DIR}/compiler/bin/clang++" MCWAMPCC)
+  set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   # add HSA headers
   add_library( ${name} SHARED ${ARGN} )
   amp_target(${name})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,7 @@ include(ProcessorCount)
 ProcessorCount(N)
 
 add_custom_target(test
-  COMMAND python ${LLVM_ROOT}/bin/llvm-lit -j ${N} --path ${LLVM_TOOLS_DIR} -sv ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND python ${LLVM_ROOT}/bin/llvm-lit --path ${LLVM_TOOLS_DIR} -sv ${CMAKE_CURRENT_BINARY_DIR}
   # DEPENDS ${CPPAMP_GTEST_LIB}
   COMMENT "Running HCC regression tests")
 


### PR DESCRIPTION
1. removed a bunch of unused variables
2. KALMAR_VERSION_STRING construction moved to module
   scripts/cmake/GenerateVersionFromGit.cmake
3. removed warnings that CMAKE_FORCE_CXX_COMPILER will be deprecated
4. removed -j parameter of llvm-lit - it runs in parralel by default
5. fixed typos