### PR TITLE
Remove pointer from tracker after unlock

### DIFF
--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -512,7 +512,10 @@ am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
     if(am_status == AM_SUCCESS)
     {
         hsa_status_t hsa_status = hsa_amd_memory_unlock(hostPtr);
-        am_memtracker_remove(hostPtr);
+    }
+    am_status_t remove_status = am_memtracker_remove(hostPtr);
+    if(remove_status != AM_SUCCESS){
+         return remove_status;
     }
     return am_status;
 }

--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -512,6 +512,7 @@ am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
     if(am_status == AM_SUCCESS)
     {
         hsa_status_t hsa_status = hsa_amd_memory_unlock(hostPtr);
+        am_memtracker_remove(hostPtr);
     }
     return am_status;
 }


### PR DESCRIPTION
This change removes pointer from am tracker once the page-locked pointer is unlocked as it is allocated by user and pinned by runtime. 