### PR TITLE
Fix create_marker to set dependency on previous asyncOp (if needed)

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1448,19 +1448,40 @@ accelerator_view::create_marker(memory_scope scope) const {
 inline unsigned int accelerator_view::get_version() const { return get_accelerator().get_version(); }
 
 inline completion_future accelerator_view::create_blocking_marker(completion_future& dependent_future, memory_scope scope) const {
-    if (dependent_future.__asyncOp) {
-        return completion_future(pQueue->EnqueueMarkerWithDependency(dependent_future.__asyncOp, scope));
-    } else {
-        return completion_future();
+    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[2]; 
+
+    // If necessary create an explicit dependency on previous command
+    // This is necessary for example if copy command is followed by marker - we need the marker to wait for the copy to complete.
+    std::shared_ptr<Kalmar::KalmarAsyncOp> depOp = pQueue->detectStreamDeps(hcCommandMarker, nullptr);
+
+    int cnt = 0;
+    if (depOp) {
+        deps[cnt++] = depOp; // retrieve async op associated with completion_future
     }
+
+    if (dependent_future.__asyncOp) {
+        deps[cnt++] = dependent_future.__asyncOp; // retrieve async op associated with completion_future
+    } 
+    
+    return completion_future(pQueue->EnqueueMarkerWithDependency(cnt, deps, scope));
 }
 
 template<typename InputIterator>
 inline completion_future
 accelerator_view::create_blocking_marker(InputIterator first, InputIterator last, memory_scope scope) const {
-    int cnt = 0;
     std::shared_ptr<Kalmar::KalmarAsyncOp> deps[5]; // array of 5 pointers to the native handle of async ops. 5 is the max supported by barrier packet
     hc::completion_future lastMarker;
+
+
+    // If necessary create an explicit dependency on previous command
+    // This is necessary for example if copy command is followed by marker - we need the marker to wait for the copy to complete.
+    std::shared_ptr<Kalmar::KalmarAsyncOp> depOp = pQueue->detectStreamDeps(hcCommandMarker, nullptr);
+
+    int cnt = 0;
+    if (depOp) {
+        deps[cnt++] = depOp; // retrieve async op associated with completion_future
+    }
+
 
     // loop through signals and group into sections of 5
     // every 5 signals goes into one barrier packet

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -244,7 +244,8 @@ public:
 
   /// enqueue marker with prior dependency
   virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(int count, std::shared_ptr <KalmarAsyncOp> *depOps, memory_scope scope) { return nullptr; }
-  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(std::shared_ptr <KalmarAsyncOp> depOp, memory_scope scope) { return EnqueueMarkerWithDependency(1, &depOp, scope); };
+
+  virtual std::shared_ptr<KalmarAsyncOp> detectStreamDeps(hcCommandKind commandKind, KalmarAsyncOp *newCopyOp) { return nullptr; };
 
 
   /// copy src to dst asynchronously

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -571,7 +571,7 @@ public:
 
     // constructor with at most 5 prior dependencies
     HSABarrier(int count, std::shared_ptr <Kalmar::KalmarAsyncOp> *dependent_op_array) : KalmarAsyncOp(Kalmar::hcCommandMarker), isDispatched(false), future(nullptr), hsaQueue(nullptr), waitMode(HSA_WAIT_STATE_BLOCKED), depCount(0) {
-        if ((count > 0) && (count <= 5)) {
+        if ((count >= 0) && (count <= 5)) {
             for (int i = 0; i < count; ++i) {
                 if (dependent_op_array[i]) {
                     // squish null ops 
@@ -1018,8 +1018,7 @@ public:
     // are often implicitly synchronized so no dependency is required.
     // Also different modes and optimizations can control when dependencies are added.
     // TODO - return reference if possible to avoid shared ptr overhead.
-    std::shared_ptr<KalmarAsyncOp> detectStreamDeps(KalmarAsyncOp *newOp) {
-        hcCommandKind newCommandKind = newOp->getCommandKind();
+    std::shared_ptr<KalmarAsyncOp> detectStreamDeps(hcCommandKind newCommandKind, KalmarAsyncOp *copyOp) {
         assert (newCommandKind != hcCommandInvalid);
 
         if (!asyncOps.empty()) {
@@ -1038,9 +1037,10 @@ public:
                 // No dependency required since Marker and Kernel share same queue and are ordered by AQL barrier bit.
                 needDep = false;
             } else if (isCopyCommand(newCommandKind) && isCopyCommand(youngestCommandKind)) {
-                HSACopy *newCopyOp = static_cast<HSACopy*> (newOp);
+                assert (copyOp);
+                HSACopy *hsaCopyOp = static_cast<HSACopy*> (copyOp);
                 HSACopy *youngestCopyOp = static_cast<HSACopy*> (asyncOps.back().get());
-                if (newCopyOp->getCopyDevice() != youngestCopyOp->getCopyDevice()) {
+                if (hsaCopyOp->getCopyDevice() != youngestCopyOp->getCopyDevice()) {
                     // This covers cases where two copies are back-to-back in the queue but use different copy engines.
                     // In this case there is no implicit dependency between the ops so we need to add one
                     // here.
@@ -1063,7 +1063,7 @@ public:
 
 
     void waitForStreamDeps (KalmarAsyncOp *newOp) {
-        std::shared_ptr<KalmarAsyncOp> depOp = detectStreamDeps(newOp);
+        std::shared_ptr<KalmarAsyncOp> depOp = detectStreamDeps(newOp->getCommandKind(), newOp);
         if (depOp != nullptr) {
             EnqueueMarkerWithDependency(1, &depOp, hc::system_scope);
         }
@@ -1584,7 +1584,7 @@ public:
         hsa_status_t status = HSA_STATUS_SUCCESS;
 
 
-        if ((count > 0) && (count <= HSA_BARRIER_DEP_SIGNAL_CNT)) {
+        if ((count >= 0) && (count <= HSA_BARRIER_DEP_SIGNAL_CNT)) {
 
             // create shared_ptr instance
             std::shared_ptr<HSABarrier> barrier = std::make_shared<HSABarrier>(count, depOps);
@@ -1599,7 +1599,7 @@ public:
             return barrier;
         } else {
             // throw an exception
-            throw Kalmar::runtime_exception("Incorrect number of dependent signals passed to HSABarrier constructor", count);
+            throw Kalmar::runtime_exception("Incorrect number of dependent signals passed to EnqueueMarkerWithDependency", count);
         }
     }
 
@@ -4208,7 +4208,7 @@ HSACopy::enqueueAsyncCopyCommand(Kalmar::HSAQueue* hsaQueue, const Kalmar::HSADe
         int depSignalCnt = 0;
         hsa_signal_t depSignal;
         setCommandKind (resolveMemcpyDirection(srcPtrInfo._isInDeviceMem, dstPtrInfo._isInDeviceMem));
-        depAsyncOp = hsaQueue->detectStreamDeps(this);
+        depAsyncOp = hsaQueue->detectStreamDeps(this->getCommandKind(), this);
 
         if (depAsyncOp) {
             depSignalCnt = 1;


### PR DESCRIPTION
Don't always rely on barrier bits for implicit ordering -
call detectStreamDeps to see if additional signal dependency is
required.

In particular if previous command was copy, creating a marker
or blocking_marker will now add the completion signal from the copy
to the dependendcy list.