### PR TITLE
Fix -gline-tables-only issue when building hcc RT

### DIFF
--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -25,7 +25,13 @@ macro(amp_target name )
     target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
     target_compile_options(${name} PUBLIC -stdlib=libc++)
   endif (USE_LIBCXX)
-	target_compile_options(${name} PUBLIC -std=c++amp -fPIC -gline-tables-only)
+	target_compile_options(${name} PUBLIC -std=c++amp -fPIC)
+
+  # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
+  # Otherwise, -gline-tables-only would override other existing debug flags
+  if ((NOT HCC_RUNTIME_DEBUG) AND ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
+	  target_compile_options(${name} PUBLIC -gline-tables-only)
+  endif ((NOT HCC_RUNTIME_DEBUG) AND ("${CMAKE_BUILD_TYPE}" STREQUAL "Release"))
 endmacro(amp_target name )
 
 ####################


### PR DESCRIPTION
Add -gline-tables-only only when building hcc RT in Release mode to prevent it from overriding other debug related compiler switches