### PR TITLE
Add hcc-extra-libs flag to clamp-link

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -95,6 +95,10 @@ do
     AMDGPU_TARGET="${ARG#*=}"
     continue
     ;;
+    --hcc-extra-libs=*)
+    HCC_EXTRA_LIBRARIES="$HCC_EXTRA_LIBRARIES ${ARG#*=}"
+    continue
+    ;;
     --dump-isa)
     KMDUMPISA=1
     ;;


### PR DESCRIPTION
This is so `clamp-link` can add extra libraries without needing an environment variable. Of course this PR [here](https://github.com/RadeonOpenCompute/hcc-clang-upgrade/pull/51) is needed so this flag can be passed to the hcc driver.