### PR TITLE
Add pinned_vector<T>, a std::vector<T> with host pinned memory

### DIFF
--- a/include/pinned_vector.hpp
+++ b/include/pinned_vector.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#ifndef _PINNED_VECTOR_H
+#define _PINNED_VECTOR_H
+
+#include <new>
+#include "hc.hpp"
+#include "hc_am.hpp"
+
+namespace hc
+{
+
+// minimal allocator that uses am_alloc to allocate pinned memory on the host,
+// with comparison functions used by the C++ standard library
+  
+template <class T>
+struct am_allocator {
+  typedef T value_type;
+
+  am_allocator() = default;
+
+  template <class U> am_allocator(const am_allocator<U>&) {}
+
+  T* allocate(std::size_t n) {
+    hc::accelerator acc;
+    auto p = static_cast<T*>(hc::am_alloc(n*sizeof(T), acc, amHostPinned));
+    if(p == nullptr){ throw std::bad_alloc(); }
+    return p;
+  }
+
+  void deallocate(T* p, std::size_t) {
+    // am_free returns an am_status_t; we can't return that, since
+    // allocate is a void function, and we can't throw an exception either,
+    // since deallocate is used in destructors. Hmmm.
+    hc::am_free(p);
+  }
+};
+
+template <class T, class U>
+bool operator==(const am_allocator<T>&, const am_allocator<U>&) { return true; }
+
+template <class T, class U>
+bool operator!=(const am_allocator<T>&, const am_allocator<U>&) { return false; }
+
+
+// convenience alias 
+template<typename T>
+using pinned_vector = std::vector<T, am_allocator<T>>;
+
+} // namespace hc
+
+#endif // _PINNED_VECTOR_H

--- a/tests/Unit/HC/pinned_vector.cpp
+++ b/tests/Unit/HC/pinned_vector.cpp
@@ -1,0 +1,62 @@
+// RUN: %hc -lhc_am %s -o %t.out && %t.out
+
+#include <iostream>
+#include <hc.hpp>
+#include <hc_am.hpp>
+#include <pinned_vector.hpp>
+
+constexpr size_t small_size = 1024;
+constexpr size_t gargantuan_size = static_cast<size_t>(-1);
+
+
+bool test_data_ptr() {
+  // pinned_vector<T> uses am_alloc for memory allocation, which inserts
+  // the resulting pointer to pinned memory in an internal tracking structure.
+  // Check if the vectors data() pointer is present in the tracking structure
+  // with expected values for some of its attributes.
+  hc::pinned_vector<char> v(small_size);
+  hc::accelerator acc;
+  hc::AmPointerInfo ap(nullptr, nullptr, 0, acc);
+
+  if(am_memtracker_getinfo(&ap, v.data()) != AM_SUCCESS){
+    std::cout << "pinned_vector memory not tracked by AmPointerTracker\n";
+    return false;
+  }
+
+  if(ap._hostPointer != ap._devicePointer
+     or ap._isInDeviceMem
+     or not ap._isAmManaged){
+    std::cout << "sanity check on tracked pinned_vector memory failed\n";
+    return false;
+  }
+
+  std::cout << "sanity check on tracked pinned_vector memory passed\n";
+  return true;
+}
+
+
+bool test_bad_alloc() {
+  // am_alloc returns nullptr if memory allocation fails. Pinned_vector's allocator
+  // is supposed to throw a bad_alloc in that case.
+  try {
+    hc::pinned_vector<char> v(gargantuan_size);
+  }
+  catch(std::bad_alloc& e){
+    std::cout << "expected bad_alloc caught\n";
+    return true;
+  }
+
+  std::cout << "expected bad_alloc not caught\n";
+  return false;
+}
+
+
+int main() {
+  bool ret = true;
+
+  ret &= test_data_ptr();
+  ret &= test_bad_alloc();
+
+  return !(ret == true);
+}
+


### PR DESCRIPTION
This pull request adds a hc::pinned_vector<T>, which is an alias for
std::vector<T, am_allocator>. The purpose of hc::pinned_vector<T> is to speed
up data transfers between host and device automagically. On our test platform
(Intel Core i7-6700K, Radeon R9 Nano), speedup is ~30% compared to data transfers
from non-pinned memory.

The underlying memory for a pinned_vector<T> is allocated with
am_alloc() using the amHostPinned flag. This allows for fast DMA copies
from a pinned_vector<T> on the host to the device and vice versa
without the need for implicitly or explicitly creating intermediate
pinned buffers on the host. The destructor of pinned_vector<T> uses
am_allocator::deallocate() to properly release the pinned memory with
am_free().
