### PR TITLE
Fixes testcases for no peer accelerators

### DIFF
--- a/tests/Unit/Pool/accelerator_get_peers.cpp
+++ b/tests/Unit/Pool/accelerator_get_peers.cpp
@@ -6,7 +6,7 @@
 /**
  * Test if hc::accelerator::get_peers() works fine.
  * Create a default accelerator and query its peers.
- * accelerator is peer of itself.
+ * accelerator acc is not peer of itself.
  * @FIXME: in current system, all dGPUs is peer of each 
  * other, we should expect the size of peers is equal to 
  * number of GPU accelerators.
@@ -22,7 +22,7 @@ int main()
 
     const auto& peers = acc.get_peers();
 
-    if(peers.size() == 0)
+    if(peers.size() >= size_all)
         return -1;
 
     return 0;

--- a/tests/Unit/Pool/map_to_peers_device_ptr.cpp
+++ b/tests/Unit/Pool/map_to_peers_device_ptr.cpp
@@ -17,7 +17,7 @@ int main()
     const auto& all = acc.get_peers();
 
     // map device pointer to all peers.
-    if(AM_SUCCESS != am_map_to_peers(dev_ptr, all.size(), all.data()))
+    if(all.size()!=0 && AM_SUCCESS != am_map_to_peers(dev_ptr, all.size(), all.data()))
         return -1;
 
     return 0;

--- a/tests/Unit/Pool/map_to_peers_host_ptr.cpp
+++ b/tests/Unit/Pool/map_to_peers_host_ptr.cpp
@@ -17,7 +17,7 @@ int main()
     const auto& peers = acc.get_peers();
 
     // map device pointer to all peers.
-    if(AM_SUCCESS != am_map_to_peers(host_ptr, peers.size(), peers.data()))
+    if(peers.size()!=0 && AM_SUCCESS != am_map_to_peers(host_ptr, peers.size(), peers.data()))
         return -1;
 
     return 0;


### PR DESCRIPTION
When checking size of peers, cannot count self as a peer, therefore must handle when size of peers is zero.