### PR TITLE
[Driver] Inline everything before launching EraseNonkernels pass

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -127,13 +127,16 @@ if [ $KMDUMPLLVM == "1" ]; then
 fi
 
 # Invoke HCC-specific opt passes
+# Inline everything before launching EraseNonkernels pass
+# Teach LLVM inliner we do want all functions used by a kernel be inlined
+# by assigning a big iniling threshold value
 if [ "$HCC_TILECHECK" == "ON" ]; then
   $OPT -load $LIB/LLVMEraseNonkernel@CMAKE_SHARED_LIBRARY_SUFFIX@ \
        -load $LIB/LLVMTileUniform@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-       -erase-nonkernels -tile-uniform -dce -globaldce < $1 -o $2.promote.bc
+       -inline -inline-threshold=1048576 -erase-nonkernels -tile-uniform -dce -globaldce < $1 -o $2.promote.bc
 else
   $OPT -load $LIB/LLVMEraseNonkernel@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-       -erase-nonkernels -dce -globaldce < $1 -o $2.promote.bc
+       -inline -inline-threshold=1048576 -erase-nonkernels -dce -globaldce < $1 -o $2.promote.bc
 fi
 
 # error handling for HCC-specific opt passes


### PR DESCRIPTION
Teach LLVM inliner we do want all functions used by a kernel be inlined
by assigning a big iniling threshold value.

This allows applications which huge device functions be properly inlined on AMD platform.