### PR TITLE
Improve linker script

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -127,13 +127,16 @@ if [ $KMDUMPLLVM == "1" ]; then
 fi
 
 # Invoke HCC-specific opt passes
+# Inline everything before launching EraseNonkernels pass
+# Teach LLVM inliner we do want all functions used by a kernel be inlined
+# by assigning a big iniling threshold value
 if [ "$HCC_TILECHECK" == "ON" ]; then
   $OPT -load $LIB/LLVMEraseNonkernel@CMAKE_SHARED_LIBRARY_SUFFIX@ \
        -load $LIB/LLVMTileUniform@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-       -erase-nonkernels -tile-uniform -dce -globaldce < $1 -o $2.promote.bc
+       -inline -inline-threshold=1048576 -erase-nonkernels -tile-uniform -dce -globaldce < $1 -o $2.promote.bc
 else
   $OPT -load $LIB/LLVMEraseNonkernel@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-       -erase-nonkernels -dce -globaldce < $1 -o $2.promote.bc
+       -inline -inline-threshold=1048576 -erase-nonkernels -dce -globaldce < $1 -o $2.promote.bc
 fi
 
 # error handling for HCC-specific opt passes

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -97,7 +97,7 @@ LIB_SEARCH_PATHS=()
 for ARG in "$@"
 do
   # matches -L<path>
-  if [[ "$ARG" =~ ^-L* ]]; then
+  if [[ "$ARG" =~ ^-L.* ]]; then
     REAL_PATH="$(readlink -f "${ARG:2}")"
     if [ $VERBOSE == 2 ]; then
       echo "add library path: ${ARG:2}, canonical path: $REAL_PATH"
@@ -106,7 +106,30 @@ do
   fi
 done
 
+# gather input arguments from linker command files
+INPUT_ARGUMENTS=()
+for ARG in "$@"
+do
+  # matches @<path>
+  if [[ "$ARG" =~ ^@.* ]]; then
+    REAL_PATH="$(readlink -f "${ARG:1}")"
+    if [ $VERBOSE == 2 ]; then
+      echo "add linker command path: ${ARG:1}, canonical path: $REAL_PATH"
+    fi
 
+    # read from linker command file
+    IFS=$'\n' read -d '' -r -a LINES < "$REAL_PATH"
+    for LINE in ${LINES[@]}
+    do
+      if [ $VERBOSE == 2 ]; then
+        echo "add linker command: $LINE"
+      fi
+      INPUT_ARGUMENTS+=($LINE)
+    done
+  else
+    INPUT_ARGUMENTS+=("$ARG")
+  fi
+done
 
 for ARG in "${INPUT_ARGUMENTS[@]}"
 do
@@ -156,7 +179,7 @@ do
     fi
 
     OBJS_TO_PROCESS+=( "$ARG" )
-  elif [[ "$ARG" =~ ^-l[^[:space:]]+$ ]] || [[ "$ARG" =~ [^[:space:]]+.a$ ]]; then
+  elif [[ "$ARG" =~ ^-l[^[:space:]]+$ ]] || [[ "$ARG" =~ [^[:space:]]+.a$ ]] || [[ "$ARG" =~ [^[:space:]]+.lo$ ]]; then
 
     # proccess a static library
 
@@ -191,11 +214,11 @@ do
         fi
       done
     else
-      # this is .a static library file specified at the commad line
+      # this is .a or .lo static library file specified at the commad line
       if [ -f "$ARG" ]; then
         FULL_LIB_PATH=$(readlink -f "$ARG")
         if [ $VERBOSE == 2 ]; then
-          echo "use .a specified at: $FULL_LIB_PATH"
+          echo "use .a / .lo specified at: $FULL_LIB_PATH"
         fi
         DETECTED_STATIC_LIBRARY="$FULL_LIB_PATH"
       fi

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -131,7 +131,7 @@ do
   fi
 done
 
-for ARG in ${INPUT_ARGUMENTS[@]}
+for ARG in "${INPUT_ARGUMENTS[@]}"
 do
 
   case $ARG in


### PR DESCRIPTION
2 changes are introduced in this PR:

- fix regressions in FilePath unit tests . Now it has not regressions in `make test`.
- provide a large inline threshold to teach inline to inline device functions into kernels even if they are very big.