### PR TITLE
Update SYNC_UPSTREAM.md

### DIFF
--- a/SYNC_UPSTREAM.md
+++ b/SYNC_UPSTREAM.md
@@ -17,6 +17,13 @@ and may contain patches not yet upstreamed. amd-common LLVM / LLD / Clang is
 automatically synchronized with upstream LLVM / LLD / Clang every 4 hours, so
 they are very close to the latest codes upstream.
 
+There are two roles in the HCC merge process. The one who conducts the upstream
+sync process through getting all the amd-common code, merging it into amd-hcc, 
+and filing the pull requests. And the one who reviews all of your sync pull
+requests. The HCC merge maintainer will take on the first role, and is required
+to interact, modify, and satisfy the changes requested by the reviewer before
+the pull requests can be accepted.
+
 Generally speaking, the process goes like this:
 
  1. Clone HCC repo manifest
@@ -124,12 +131,12 @@ There will be an `hcc-fork` directory inside the repo. It would be referred as
 - `git checkout origin/master`
 
 ### Merge amd-common LLD commits
-### From here, replace 20170626 with your date (YYYYMMDD).
+### From here, replace YYYYMMDD with your date.
 
 - change to HCC directory
 - `cd lld`
 - `git fetch --all`
-- `git checkout -b merge_20170626 origin/amd-hcc`
+- `git checkout -b merge_YYYYMMDD origin/amd-hcc`
 - `git merge origin/amd-common --no-edit`
 - Resolve any merge conflicts encountered here
 
@@ -138,7 +145,7 @@ There will be an `hcc-fork` directory inside the repo. It would be referred as
 - change to HCC directory
 - `cd compiler`
 - `git fetch --all`
-- `git checkout -b merge_20170626 origin/amd-hcc`
+- `git checkout -b merge_YYYYMMDD origin/amd-hcc`
 - `git merge origin/amd-common --no-edit`
 - Resolve any merge conflicts encountered here
 
@@ -147,7 +154,7 @@ There will be an `hcc-fork` directory inside the repo. It would be referred as
 - change to HCC directory
 - `cd compiler-rt`
 - `git fetch --all`
-- `git checkout -b merge_20170626 origin/amd-hcc`
+- `git checkout -b merge_YYYYMMDD origin/amd-hcc`
 - `git merge --no-ff compiler-rt/master --no-edit`
 - Resolve any merge conflicts encountered here
 
@@ -156,7 +163,7 @@ There will be an `hcc-fork` directory inside the repo. It would be referred as
 - change to HCC directory
 - `cd clang`
 - `git fetch --all`
-- `git checkout -b merge_20170626 origin/clang_tot_upgrade`
+- `git checkout -b merge_YYYYMMDD origin/clang_tot_upgrade`
 - `git merge --no-ff clang/amd-common --no-edit`
 - Resolve any merge conflicts encountered here
 
@@ -206,8 +213,8 @@ bin/hcc `bin/hcc-config --build --cxxflags --ldflags` \
 
 - change to HCC directory
 - `cd clang`
-- `git push clang_fork merge_20170626:merge_20170626`
-Create a pull request to merge `merge_20170626` from your clang fork
+- `git push clang_fork merge_YYYYMMDD:merge_YYYYMMDD`
+Create a pull request to merge `merge_YYYYMMDD` from your clang fork
 into https://github.com/RadeonOpenCompute/hcc-clang-upgrade
 on branch `clang_tot_upgrade`.
 
@@ -215,8 +222,8 @@ on branch `clang_tot_upgrade`.
 
 - change to HCC directory
 - `cd lld`
-- `git push lld_fork merge_20170626:merge_20170626`
-Create a pull request to merge `merge_20170626` from your lld fork
+- `git push lld_fork merge_YYYYMMDD:merge_YYYYMMDD`
+Create a pull request to merge `merge_YYYYMMDD` from your lld fork
 into https://github.com/RadeonOpenCompute/lld.git
 on branch `amd-hcc`.
 
@@ -224,8 +231,8 @@ on branch `amd-hcc`.
 
 - change to HCC directory
 - `cd compiler`
-- `git push llvm_fork merge_20170626:merge_20170626`
-Create a pull request to merge `merge_20170626` from your llvm fork
+- `git push llvm_fork merge_YYYYMMDD:merge_YYYYMMDD`
+Create a pull request to merge `merge_YYYYMMDD` from your llvm fork
 into https://github.com/RadeonOpenCompute/llvm.git
 on branch `amd-hcc`.
 
@@ -233,13 +240,22 @@ on branch `amd-hcc`.
 
 - change to HCC directory
 - `cd compiler-rt`
-- `git push compiler-rt_fork merge_20170626:merge_20170626`
-Create a pull request to merge `merge_20170626` from your compiler-rt fork
+- `git push compiler-rt_fork merge_YYYYMMDD:merge_YYYYMMDD`
+Create a pull request to merge `merge_YYYYMMDD` from your compiler-rt fork
 into https://github.com/RadeonOpenCompute/compiler-rt
 on branch `amd-hcc`.
 
 
 *** Wait until all Pull Requests are approved and merged. ***
+On github when making a pull request, the repository you are trying to update
+will have a list of reviewers who have the authority to approve pull requests
+and merge them into the repositories. During the review period, you are
+required to interact with the reviewers.
+
+For the pull requests to be approved, you must wait for a reviewer to accept
+the changes you are making. The reviewer will request changes if the code is
+not ready for merge. It is your responsibility to interact and resolve all
+conflicts so that the PR is ready for merge.
 
 ### Update HCC git submodules configuration
 
@@ -262,8 +278,8 @@ on branch `amd-hcc`.
 - `git checkout origin/master`
 - `git commit -m "[Config] revise submodule configuration"`, or provide custom
   commit log
-- `git push origin merge_20170626:merge_20170626`
-Create a pull request to merge `merge_20170626` from your hcc fork
+- `git push origin merge_YYYYMMDD:merge_YYYYMMDD`
+Create a pull request to merge `merge_YYYYMMDD` from your hcc fork
 into https://github.com/RadeonOpenCompute/hcc on branch `clang_tot_upgrade`.
 
 ### Update HCC repo manifest

--- a/SYNC_UPSTREAM.md
+++ b/SYNC_UPSTREAM.md
@@ -8,12 +8,12 @@ Upstream Clang, LLVM, and LLD all sit in different git repositories and they
 are almost changed daily. Sometimes a change upstream may affect several
 projects, but it is usually not easy to figure it out from the commit log.
 
-HCC has been configured use git submodules to track these dependencies, but
+HCC has been configured to use git submodules to track these dependencies, but
 there are users who prefer using repo tool. This document has been revised to
 cope with both git submodules and repo.
 
 HCC depends on amd-common LLVM / LLD / Clang, which is a fork maintained by AMD,
-and may contain patches yet upstreamed. amd-common LLVM / LLD / Clang is
+and may contain patches not yet upstreamed. amd-common LLVM / LLD / Clang is
 automatically synchronized with upstream LLVM / LLD / Clang every 4 hours, so
 they are very close to the latest codes upstream.
 
@@ -22,163 +22,160 @@ Generally speaking, the process goes like this:
  1. Clone HCC repo manifest
  2. Clone HCC with repo
  3. Initialize git submodules
- 4. Merge master ROCm-Device-Libs commits
- 5. Merge amd-common LLVM commits
+ 4. Add all remotes and forks for submodules
+ 5. Checkout latest master ROCm-Device-Libs
  6. Merge amd-common LLD commits
- 7. Merge master COMPILER-RT commits from llvm-mirror
- 8. Add git remote for amd-common Clang
- 9. Fetch amd-common Clang commits
-10. Merge amd-common Clang with HCC Clang
-11. Build merged HCC
+ 7. Merge amd-common LLVM commits
+ 8. Merge master COMPILER-RT commits from llvm-mirror
+ 9. Merge amd-common Clang commits
+10. Build merged HCC
+11. Full sanity tests on merged HCC (optional)
 12. Quick sanity tests on merged HCC
-13. Push HCC Clang submodules
-14. Push amd-hcc LLVM submodule
-15. Push amd-hcc LLD submodule
-16. Push amd-hcc COMPILER-RT submodule
-17. Push remove-promote-change-addr-space ROCm-Device-Libs submodule
-18. Update HCC git submodules configuration
-19. Update HCC repo manifest
+13. Push and Create Pull Request for HCC Clang submodule
+14. Push and Create Pull Request for amd-hcc LLD submodule
+15. Push and Create Pull Request for amd-hcc LLVM submodule
+16. Push and Create Pull Request for amd-hcc COMPILER-RT submodule
+17. Update HCC git submodules configuration
+18. Update HCC repo manifest
 
 Detailed step-by-step instructions are in following sections.
 
-Useful github repositories
---------------------------
+Useful github remote repositories (For reference)
+-------------------------------------------------
 git locations of repositories used in the merge process are:
 - master ROCm-Device-Libs
-  - URL: git@github.com:RadeonOpenCompute/ROCm-Device-Libs.git
+  - URL: https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
   - branch : master
 - amd-common LLVM
-  - URL : git@github.com:RadeonOpenCompute/llvm.git
+  - URL : https://github.com/RadeonOpenCompute/llvm.git
   - branch : amd-common
 - amd-common LLD
-  - URL: git@github.com:RadeonOpenCompute/lld.git
+  - URL: https://github.com/RadeonOpenCompute/lld.git
   - branch : amd-common
-- amd-common COMPILER-RT
-  - URL: git@github.com:llvm-mirror/compiler-rt.git
+- master COMPILER-RT
+  - URL: https://github.com/llvm-mirror/compiler-rt.git
   - branch : master
 - amd-common Clang
-  - URL: git@github.com:RadeonOpenCompute/clang.git
+  - URL: https://github.com/RadeonOpenCompute/clang.git
   - branch : amd-common
 
-Set SSH URL for git push
-------------------------
-HCC has been configured to use HTTPS URL by default. It is easy for users
-to clone it anonymously. But it would be hard for committing changes. Use the
-following commands to setup SSH URL.
-
-- change to HCC directory
-- `git remote set-url --push github git@github.com:RadeonOpenCompute/hcc.git`
-- `cd clang`
-- `git remote set-url --push github git@github.com:RadeonOpenCompute/hcc-clang-upgrade.git`
-- `cd ../compiler`
-- `git remote set-url --push github git@github.com:RadeonOpenCompute/llvm.git`
-- `cd ../lld`
-- `git remote set-url --push github git@github.com:RadeonOpenCompute/lld.git`
-- `cd ../compiler-rt`
-- `git remote set-url --push github git@github.com:RadeonOpenCompute/compiler-rt.git`
-- `cd ../rocdl`
-- `git remote set-url --push github git@github.com:RadeonOpenComoute/ROCm-Device-Libs.git`
+Set own forks for sub-directories
+---------------------------------
+Go to these links and fork onto personal account:
+1) https://github.com/RadeonOpenCompute/hcc
+2) https://github.com/RadeonOpenCompute/hcc-clang-upgrade
+3) https://github.com/RadeonOpenCompute/llvm
+4) https://github.com/RadeonOpenCompute/compiler-rt
+5) https://github.com/RadeonOpenCompute/lld
+Note, you'd won't need to do this for rocdl, since we will use its master branch.
 
 This only needs to be done once.
 
 Step-by-step Merge Process
 --------------------------
+Assuming that we have created forks for all the repositories above, follow this:
 
 ### Clone HCC with repo
 
 - `repo init -u https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git`
 - `repo sync`
 
-There will be an `hcc` directory inside the repo. It would be referred as
-*HCC directory* hereafter.
-
 ### Clone HCC repo manifest
 
 A manifest directory is created to track working commits for all components.
 
-- `git clone git@github.com:RadeonOpenCompute/HCC-Native-GCN-ISA.git manifest`
+- `git clone https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git manifest`
 
 This directory would be referred as *HCC manifest directory* hereafter.
 
 ### Initialize git submodules
+### From here on, replace *aaronenyeshi* with your own github id
 
-- change to HCC directory
+- `git clone https://github.com/aaronenyeshi/hcc.git hcc_fork`
+- `cd hcc_fork`
 - `git checkout clang_tot_upgrade`
 - `git submodule update --init`
 
-### Merge master ROCm-Device-Libs commits
+There will be an `hcc-fork` directory inside the repo. It would be referred as
+*HCC directory* hereafter.
+
+### Add all remotes and forks for submodules
+
+- change to HCC directory
+- `git remote add hcc_fork https://github.com/aaronenyeshi/hcc.git`
+- `cd ../lld`
+- `git remote add lld_fork https://github.com/aaronenyeshi/lld.git`
+- `cd ../compiler`
+- `git remote add llvm_fork https://github.com/aaronenyeshi/llvm.git`
+- `cd ../compiler-rt`
+- `git remote add compiler-rt_fork https://github.com/aaronenyeshi/compiler-rt.git`
+- `git remote add compiler-rt https://github.com/llvm-mirror/compiler-rt`
+- `cd ../clang`
+- `git remote add clang_fork https://github.com/aaronenyeshi/hcc-clang-upgrade.git`
+- `git remote add clang https://github.com/RadeonOpenCompute/clang`
+
+**Use `git remote -v` to verify the new remotes are added.**
+
+### Checkout latest master ROCm-Device-Libs
 
 - change to HCC directory
 - `cd rocdl`
-- `git checkout remove-promote-change-addr-space`
-- `git pull`
-- `git merge github/master --no-edit`
+- `git fetch --all`
+- `git checkout origin/master`
 
-Resolve any merge conflicts encountered here. Commit to remove-promote-change-addr-space branch.
+### Merge amd-common LLD commits
+### From here, replace 20170626 with your date (YYYYMMDD).
+
+- change to HCC directory
+- `cd lld`
+- `git fetch --all`
+- `git checkout -b merge_20170626 origin/amd-hcc`
+- `git merge origin/amd-common --no-edit`
+- Resolve any merge conflicts encountered here
 
 ### Merge amd-common LLVM commits
 
 - change to HCC directory
 - `cd compiler`
-- `git checkout amd-hcc`
-- `git pull`
-- `git merge github/amd-common --no-edit`
+- `git fetch --all`
+- `git checkout -b merge_20170626 origin/amd-hcc`
+- `git merge origin/amd-common --no-edit`
+- Resolve any merge conflicts encountered here
 
-Resolve any merge conflicts encountered here. Commit to amd-hcc branch.
-
-### Merge amd-common LLD commits
-
-- change to HCC directory
-- `cd lld`
-- `git checkout amd-hcc`
-- `git pull`
-- `git merge github/amd-common --no-edit`
-
-Resolve any merge conflicts encountered here. Commit to amd-hcc branch.
-
-### Add git remote for master COMPILER-RT
+### Merge amd-common COMPILER-RT commits from llvm-mirror
 
 - change to HCC directory
 - `cd compiler-rt`
-- `git remote -v` to check if there is a git remote pointing to:
-  `git@github.com:llvm-mirror/compiler-rt.git`
-- If there is not, add it by:
-  `git remote add compiler-rt https://github.com/llvm-mirror/compiler-rt`
-
-### Merge amd-common COMPILER-RT commits
-
-- `git checkout amd-hcc`
-- `git fetch compiler-rt`
+- `git fetch --all`
+- `git checkout -b merge_20170626 origin/amd-hcc`
 - `git merge --no-ff compiler-rt/master --no-edit`
+- Resolve any merge conflicts encountered here
 
-Resolve any merge conflicts encountered here. Commit to amd-hcc branch.
-
-### Add git remote for amd-common Clang
+### Merge amd-common Clang commits
 
 - change to HCC directory
 - `cd clang`
-- `git remote -v` to check if there is a git remote pointing to:
-  `git@github.com:RadeonOpenCompute/clang.git`
-- If there is not, add it by:
-  `git remote add clang https://github.com/RadeonOpenCompute/clang`
-
-### Fetch amd-common Clang commits
-
-- `git checkout clang_tot_upgrade`
-- `git fetch clang`
+- `git fetch --all`
+- `git checkout -b merge_20170626 origin/clang_tot_upgrade`
 - `git merge --no-ff clang/amd-common --no-edit`
-
-Resolve merge conflicts encountered here. Commit to clang_tot_upgrade branch.
+- Resolve any merge conflicts encountered here
 
 ### Build merged HCC
 
-- change to HCC directory
+- change to root directory
 - `mkdir -p build; cd build`
-- `cmake -DCMAKE_BUILD_TYPE=Release ..`
-- `make`
+- `cmake -DCMAKE_BUILD_TYPE=Release ../hcc`
+- `make -j`
 
 Fix any compilation failures if there is any. Repeat this step until HCC
 can be built.
+
+### Full sanity tests on merged HCC (optional)
+Test all unit tests.
+- change to HCC build directory
+- `make test`
+
+Resolve any issues encountered here. May see old test failures.
 
 ### Quick sanity tests on merged HCC
 Assume commands below are carried out in HCC build directory. And HCC
@@ -205,58 +202,69 @@ bin/hcc `bin/hcc-config --build --cxxflags --ldflags` \
 ./a.out ; echo $?
 ```
 
-### Push HCC Clang submodule
+### Push and Create Pull Request for HCC Clang submodule
 
 - change to HCC directory
 - `cd clang`
-- `git checkout clang_tot_upgrade`
-- `git push`
+- `git push clang_fork merge_20170626:merge_20170626`
+Create a pull request to merge `merge_20170626` from your clang fork
+into https://github.com/RadeonOpenCompute/hcc-clang-upgrade
+on branch `clang_tot_upgrade`.
 
-Following steps are to ensure "master" branch are kept the same
-as "clang_tot_upgrade" branch.
-- `git checkout master`
-- `git merge clang_tot_upgrade --no-edit`
-- `git push`
-
-Finally switch back to "clang_tot_upgrade" branch.
-- `git checkout clang_tot_upgrade`
-
-### Push amd-hcc LLD submodule
+### Push and Create Pull Request for amd-hcc LLD submodule
 
 - change to HCC directory
 - `cd lld`
-- `git checkout amd-hcc`
-- `git push`
+- `git push lld_fork merge_20170626:merge_20170626`
+Create a pull request to merge `merge_20170626` from your lld fork
+into https://github.com/RadeonOpenCompute/lld.git
+on branch `amd-hcc`.
 
-### Push amd-hcc LLVM submodule
+### Push and Create Pull Request for amd-hcc LLVM submodule
 
 - change to HCC directory
 - `cd compiler`
-- `git checkout amd-hcc`
-- `git push`
+- `git push llvm_fork merge_20170626:merge_20170626`
+Create a pull request to merge `merge_20170626` from your llvm fork
+into https://github.com/RadeonOpenCompute/llvm.git
+on branch `amd-hcc`.
 
-### Push amd-hcc COMPILER-RT submodule
+### Push and Create Pull Request for amd-hcc COMPILER-RT submodule
 
 - change to HCC directory
 - `cd compiler-rt`
-- `git checkout amd-hcc`
-- `git push`
+- `git push compiler-rt_fork merge_20170626:merge_20170626`
+Create a pull request to merge `merge_20170626` from your compiler-rt fork
+into https://github.com/RadeonOpenCompute/compiler-rt
+on branch `amd-hcc`.
 
-### Push remove-promote-change-addr-space ROCm-Device-Libs submodule
 
-- change to HCC directory
-- `cd rocdl`
-- `git checkout remove-promote-change-addr-space`
-- `git push`
+*** Wait until all Pull Requests are approved and merged. ***
 
 ### Update HCC git submodules configuration
 
 - change to HCC directory
-- `git checkout clang_tot_upgrade`
-- `git add clang compiler lld compiler-rt rocdl`
+- `git checkout origin/clang_tot_upgrade`
+- `cd clang`
+- `git fetch --all`
+- `git checkout origin/clang_tot_upgrade`
+- `cd ../compiler`
+- `git fetch --all`
+- `git checkout origin/amd-hcc`
+- `cd compiler-rt`
+- `git fetch --all`
+- `git checkout origin/amd-hcc`
+- `cd lld`
+- `git fetch --all`
+- `git checkout origin/amd-hcc`
+- `cd rocdl`
+- `git fetch --all`
+- `git checkout origin/master`
 - `git commit -m "[Config] revise submodule configuration"`, or provide custom
   commit log
-- `git push` to push HCC git submodules configuration online
+- `git push origin merge_20170626:merge_20170626`
+Create a pull request to merge `merge_20170626` from your hcc fork
+into https://github.com/RadeonOpenCompute/hcc on branch `clang_tot_upgrade`.
 
 ### Update HCC repo manifest
 


### PR DESCRIPTION
I've updated the SYNC_UPSTREAM.md document for HCC Merge Maintenance. It has been changed so that users who do not have write access to RadeonOpenCompute/hcc can perform HCC Merge on their own forks and branches.

However, I did not modify the repo or manifest descriptions.