### PR TITLE
support for RHEL7/CentOS7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,20 @@ endif( )
 
 # Accepted values for DISTRO_ID: trusty (Ubuntu 14.04), xenial (Ubuntu 16.06), fd23 (Fedora 23)
 string(TOLOWER "${DISTRO_ID}" DISTRO_ID )
-if( DISTRO_ID MATCHES "ubuntu" OR DISTRO_ID MATCHES "fedora" )
+if( DISTRO_ID MATCHES "ubuntu" OR DISTRO_ID MATCHES "fedora" 
+   OR DISTRO_ID MATCHES "centos" OR DISTRO_ID MATCHES "redhatenterpriseserver")
   message( STATUS "Detected distribution: ${DISTRO_ID}:${DISTRO_RELEASE}" )
 else()
   message( "This cmakefile does not natively support ${DISTRO_ID}:${DISTRO_RELEASE}.  Continuing with Ubuntu logic" )
   set( DISTRO_ID "ubuntu" )
   set( DISTRO_RELEASE "16.04" )
+endif()
+
+# Need special handling for RHEL 7 or CentOS 7
+if (DISTRO_ID MATCHES "centos" OR DISTRO_ID MATCHES "redhatenterpriseserver")
+  set(HCC_TOOLCHAIN_RHEL ON) 
+else()
+  set(HCC_TOOLCHAIN_RHEL OFF) 
 endif()
 
 include (MCWAMP)
@@ -316,6 +324,7 @@ add_custom_target(clang
           -DKALMAR_BACKEND_COMMIT=${KALMAR_BACKEND_COMMIT}
           -DKALMAR_BACKEND=${KALMAR_BACKEND}
           -DAMDGPU_TARGET=${AMDGPU_TARGET}
+          -DHCC_TOOLCHAIN_RHEL=${HCC_TOOLCHAIN_RHEL}
           -DLLVM_TARGETS_TO_BUILD="AMDGPU\;X86"
           -DLLVM_INCLUDE_EXAMPLES=off
           -DLLVM_EXTERNAL_PROJECTS="clang;compiler-rt;lld"

--- a/hcc_config/CMakeLists.txt
+++ b/hcc_config/CMakeLists.txt
@@ -8,7 +8,10 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/../hcc_config)
 set(CMAKE_CXX_FLAGS "-std=c++11" )
 
 if (USE_LIBCXX)
-  add_definitions(-DUSE_LIBCXX  -DLIBCXX_HEADER=${LIBCXX_HEADER}) 
+  add_definitions(-DUSE_LIBCXX  -DLIBCXX_HEADER=${LIBCXX_HEADER})
+  if (HCC_TOOLCHAIN_RHEL)
+    add_definitions(-DHCC_TOOLCHAIN_RHEL)
+  endif()
 endif (USE_LIBCXX)
 
 

--- a/hcc_config/hcc_config.cpp
+++ b/hcc_config/hcc_config.cpp
@@ -152,7 +152,10 @@ void ldflags(void) {
 
     // extra libraries if using libc++ for C++ runtime   
 #ifdef USE_LIBCXX
-    std::cout << " -lc++ -lc++abi";
+    std::cout << " -stdlib=libc++ ";
+    #ifndef HCC_TOOLCHAIN_RHEL
+      std::cout << " -lc++abi ";
+    #endif
 #endif
     std::cout << " -ldl -lm -lpthread";
 

--- a/include/hc_rt_debug.h
+++ b/include/hc_rt_debug.h
@@ -4,7 +4,9 @@
 #include <cstdio>
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#ifndef USE_LIBCXX
 #include <cxxabi.h>
+#endif
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -96,7 +98,9 @@ namespace hc {
       unw_word_t offp;
       if (unw_get_proc_name(&cursor, func, sizeof(func), &offp) == 0) {
         int status;
+#ifndef USE_LIBCXX
         demangled = abi::__cxa_demangle(func, nullptr, nullptr, &status);
+#endif
         print_func_name = demangled ? demangled : func;
       }
       else {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,8 +24,12 @@ add_library(hccrt INTERFACE)
 target_compile_options(hccrt INTERFACE -hc)
 target_link_libraries(hccrt INTERFACE "-hc -L $<TARGET_FILE_DIR:$<TARGET_NAME:mcwamp>> -Wl,-rpath $<TARGET_FILE_DIR:$<TARGET_NAME:mcwamp>>" "-Wl,--whole-archive" mcwamp "-Wl,--no-whole-archive")
 target_link_libraries(hccrt INTERFACE dl m)
+
 if (USE_LIBCXX)
-  target_link_libraries(hccrt INTERFACE c++ c++abi)
+  target_link_libraries(hccrt INTERFACE -stdlib=libc++)
+  if (NOT HCC_TOOLCHAIN_RHEL)
+    target_link_libraries(hccrt INTERFACE c++abi)
+  endif()
 endif (USE_LIBCXX)
 
 # Library interface for building shared libraries

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -22,7 +22,10 @@
 #include <utility>
 #include <vector>
 #include <algorithm>
+
+#ifndef USE_LIBCXX
 #include <cxxabi.h>
+#endif
 
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_finalize.h>
@@ -2290,8 +2293,9 @@ public:
 
         if (!kernel) {
             int demangleStatus = 0;
+#ifndef USE_LIBCXX
             demangled = abi::__cxa_demangle(fun, nullptr, nullptr, &demangleStatus);
-
+#endif
             std::string shortName = demangleStatus ? fun : std::string(demangled);
             try {
                 if (demangleStatus == 0) {

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -19,6 +19,16 @@ include(ImportedTargets)
 # For example: cmake -DHCC_RUNTIME_CFLAGS=-g would configure HCC runtime be built
 # with debug information while other parts are not.
 
+macro(add_libcxx_option_if_needed name)
+  if (USE_LIBCXX)
+    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
+    target_compile_options(${name} PUBLIC -stdlib=libc++)
+    if (NOT HCC_TOOLCHAIN_RHEL)
+      target_link_libraries(${name} INTERFACE c++abi)
+    endif()
+  endif (USE_LIBCXX)
+endmacro(add_libcxx_option_if_needed name)
+
 macro(amp_target name )
   set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
@@ -26,10 +36,7 @@ macro(amp_target name )
   target_include_directories(${name} SYSTEM PRIVATE ${GTEST_INC_DIR} ${LIBCXX_INC_DIR})
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})
   target_include_directories(${name} SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
-  if (USE_LIBCXX)
-    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
-    target_compile_options(${name} PUBLIC -stdlib=libc++)
-  endif (USE_LIBCXX)
+  add_libcxx_option_if_needed(${name})
   target_compile_options(${name} PUBLIC -std=c++amp -fPIC)
 
   # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
@@ -58,13 +65,7 @@ macro(add_mcwamp_library_cpu name )
   amp_target(${name})
   # LLVM and Clang shall be compiled beforehand
   add_dependencies(${name} llvm-link opt clang rocdl)
-
-  if (USE_LIBCXX)  
-    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
-    target_link_libraries(${name} c++)
-    target_link_libraries(${name} c++abi)
-  endif (USE_LIBCXX)
-
+  add_libcxx_option_if_needed(${name})
 endmacro(add_mcwamp_library_cpu name )
 
 ####################
@@ -79,13 +80,7 @@ macro(add_mcwamp_library_hsa name )
   target_link_libraries(${name} hsa-runtime64)
   target_link_libraries(${name} pthread)
   target_link_libraries(${name} unwind)
-
-  if (USE_LIBCXX)
-    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
-    target_link_libraries(${name} c++)
-    target_link_libraries(${name} c++abi)
-  endif (USE_LIBCXX)
-
+  add_libcxx_option_if_needed(${name})
   target_link_libraries(${name} hc_am)
 endmacro(add_mcwamp_library_hsa name )
 
@@ -97,13 +92,7 @@ macro(add_mcwamp_library_hc_am name )
   # add HSA libraries
   target_link_libraries(${name} hsa-runtime64)
   target_link_libraries(${name} pthread)
-
-  if (USE_LIBCXX)
-    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
-    target_link_libraries(${name} c++)
-    target_link_libraries(${name} c++abi)
-  endif (USE_LIBCXX)
-
+  add_libcxx_option_if_needed(${name})
 endmacro(add_mcwamp_library_hc_am name )
 
 if(POLICY CMP0046)

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -26,6 +26,7 @@ macro(add_libcxx_option_if_needed name)
     if (NOT HCC_TOOLCHAIN_RHEL)
       target_link_libraries(${name} INTERFACE c++abi)
     endif()
+    add_definitions(-DUSE_LIBCXX)
   endif (USE_LIBCXX)
 endmacro(add_libcxx_option_if_needed name)
 


### PR DESCRIPTION
- choose to use libc++ due to older gcc version on rhel7
- link to libstdc++ due to dependency in libc++
- disable abi::__cxa_demangle to avoid conflicts between libcxx and libstdc++ headers