### PR TITLE
Fix queue empty check for commands w/o signals.

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1178,7 +1178,10 @@ public:
 					if (v != 0) {
 						return false;
 					}
-				}
+                } else {
+                    // no signal, have to assume the command is still running
+                    return false;
+                }
             }
         };
         return true;


### PR DESCRIPTION
If the command doesn't have a signal, assume it is not yet ready.
Commands without signals come through the
hcc_dispatch_hsa-kerninterface.


********************
Testing Time: 180.24s
********************
Failing Tests (9):
    HCC :: Unit/AsyncPFE/async_av_dependent8.cpp
    HCC :: Unit/AsyncPFE/async_av_independent4.cpp
    HCC :: Unit/Atomic/atomic_add_float_global.cpp
    HCC :: Unit/Design/addr_space.cpp
    HCC :: Unit/HC/multi_acc.cpp
    HCC :: Unit/HC/multi_acc_array2.cpp
    HCC :: Unit/HC/reduction_hc.cpp
    HCC :: Unit/HC/reduction_tile_static.cpp
    HCC :: Unit/ParallelSTL/is_partitioned_carray.cpp

  Expected Passes    : 717
  Expected Failures  : 30
  Unexpected Failures: 9
tests/CMakeFiles/test.dir/build.make:57: recipe for target 'tests/CMakeFiles/test' failed