### PR TITLE
[HIP Texture] The GPU virtual address for texture memory needs to be

### DIFF
--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -19,7 +19,8 @@ namespace hc {
 class AmPointerInfo {
 public:
     void *      _hostPointer;   ///< Host pointer.  If host access is not allowed, NULL.
-    void *      _devicePointer; ///< Device pointer.  
+    void *      _devicePointer; ///< Device pointer.
+    void *      _unalignedDevicePointer; ///< Unaligned device pointer
     size_t      _sizeBytes;     ///< Size of allocation.
     hc::accelerator _acc;       ///< Accelerator where allocation is physically located.
     bool        _isInDeviceMem; ///< Memory is physically resident on a device (if false, memory is located on host)
@@ -31,9 +32,10 @@ public:
     void *      _appPtr;             ///< App-specific pointer to additional information.
 
 
-    AmPointerInfo(void *hostPointer, void *devicePointer, size_t sizeBytes, hc::accelerator &acc,  bool isInDeviceMem=false, bool isAmManaged=false) :
+    AmPointerInfo(void *hostPointer, void *devicePointer, void* unalignedDevicePointer, size_t sizeBytes, hc::accelerator &acc,  bool isInDeviceMem=false, bool isAmManaged=false) :
         _hostPointer(hostPointer),
         _devicePointer(devicePointer),
+        _unalignedDevicePointer(unalignedDevicePointer),
         _sizeBytes(sizeBytes),
         _acc(acc),
         _isInDeviceMem(isInDeviceMem),
@@ -54,6 +56,26 @@ struct hsa_agent_s;
 
 namespace hc {
 
+
+/**
+ * Allocate a block of @p size bytes of memory on the specified @p acc.
+ *
+ * The contents of the newly allocated block of memory are not initialized.
+ *
+ * If @p size == 0, 0 is returned.
+ *
+ * Flags:
+ *  amHostPinned : Allocated pinned host memory and map it into the address space of the specified accelerator.
+ *
+ *
+ * @return : On success, pointer to the newly allocated memory is returned.
+ * The pointer is typecast to the desired return type.
+ *
+ * If an error occurred trying to allocate the requested memory, 0 is returned.
+ *
+ * @see am_free, am_copy
+ */
+auto_voidp am_aligned_alloc(size_t size, hc::accelerator &acc, unsigned flags, size_t alignment = 0);
 
 /**
  * Allocate a block of @p size bytes of memory on the specified @p acc.

--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -26,6 +26,7 @@ AmPointerInfo & AmPointerInfo::operator= (const AmPointerInfo &other)
 {
     _hostPointer = other._hostPointer;
     _devicePointer = other._devicePointer;
+    _unalignedDevicePointer = other._unalignedDevicePointer;
     _sizeBytes = other._sizeBytes;
     _acc = other._acc;
     _isInDeviceMem = other._isInDeviceMem;
@@ -192,7 +193,7 @@ size_t AmPointerTracker::reset (const hc::accelerator &acc)
     for (auto iter = _tracker.begin() ; iter != _tracker.end(); ) {
         if (iter->second._acc == acc) {
             if (iter->second._isAmManaged) {
-                hsa_amd_memory_pool_free(const_cast<void*> (iter->first._basePointer));
+                hsa_amd_memory_pool_free(const_cast<void*> (iter->second._unalignedDevicePointer));
             }
             count++;
 
@@ -238,9 +239,8 @@ AmPointerTracker g_amPointerTracker;  // Track all am pointer allocations.
 namespace hc {
 
 // Allocate accelerator memory, return NULL if memory could not be allocated:
-auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags) 
+auto_voidp am_aligned_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags, size_t alignment)
 {
-
     void *ptr = NULL;
 
     if (sizeBytes != 0 ) {
@@ -256,8 +256,13 @@ auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
             }
 
             if (alloc_region && alloc_region->handle != -1) {
-
+                sizeBytes = alignment != 0 ? sizeBytes + alignment : sizeBytes;
                 hsa_status_t s1 = hsa_amd_memory_pool_allocate(*alloc_region, sizeBytes, 0, &ptr);
+
+                void *unalignedPtr = ptr;
+                if (alignment != 0) {
+                    ptr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(ptr) + alignment - 1) & ~(alignment - 1));
+                }
 
                 if (s1 != HSA_STATUS_SUCCESS) {
                     ptr = NULL;
@@ -267,7 +272,7 @@ auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
                             hsa_amd_memory_pool_free(ptr);
                             ptr = NULL;
                         } else {
-                            hc::AmPointerInfo ampi(ptr/*hostPointer*/, ptr /*devicePointer*/, sizeBytes, acc, false/*isDevice*/, true /*isAMManaged*/);
+                            hc::AmPointerInfo ampi(ptr/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, false/*isDevice*/, true /*isAMManaged*/);
                             g_amPointerTracker.insert(ptr,ampi);
 
                             // Host memory is always mapped to all possible peers:
@@ -279,7 +284,7 @@ auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
                             }
                         }
                     } else {
-                        hc::AmPointerInfo ampi(NULL/*hostPointer*/, ptr /*devicePointer*/, sizeBytes, acc, true/*isDevice*/, true /*isAMManaged*/);
+                        hc::AmPointerInfo ampi(NULL/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, true/*isDevice*/, true /*isAMManaged*/);
                         g_amPointerTracker.insert(ptr,ampi);
                     }
                 }
@@ -290,19 +295,23 @@ auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
     return ptr;
 };
 
+auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
+{
+    return am_aligned_alloc(sizeBytes, acc, flags, 0);
+};
 
 am_status_t am_free(void* ptr) 
 {
     am_status_t status = AM_SUCCESS;
 
     if (ptr != NULL) {
-
+        auto info = g_amPointerTracker.find(ptr);
+        if (info != g_amPointerTracker.end()) {
+            hsa_amd_memory_pool_free(info->second._unalignedDevicePointer);
+        }
         int numRemoved = g_amPointerTracker.remove(ptr) ;
         if (numRemoved == 0) {
             status = AM_ERROR_MISC;
-        } else {
-            // See also tracker::reset which can free memory.
-            hsa_amd_memory_pool_free(ptr);
         }
     }
     return status;
@@ -489,7 +498,7 @@ am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* p
         return AM_ERROR_MISC;
 
     hc::accelerator ptrAcc;
-    AmPointerInfo info(nullptr, nullptr, 0, ptrAcc, false, false);
+    AmPointerInfo info(nullptr, nullptr, nullptr, 0, ptrAcc, false, false);
     auto status = am_memtracker_getinfo(&info, ptr);
     if(AM_SUCCESS != status)
         return status;
@@ -582,7 +591,7 @@ am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, size_t size,
     hsa_status_t hsa_status = hsa_amd_memory_lock(hostPtr, size, &agents[0], num_visible_ac, &devPtr);
     if(hsa_status == HSA_STATUS_SUCCESS)
     {
-       hc::AmPointerInfo ampi(hostPtr, devPtr, size, ac, false, false);
+       hc::AmPointerInfo ampi(hostPtr, devPtr, devPtr, size, ac, false, false);
        g_amPointerTracker.insert(hostPtr, ampi);
        am_status = AM_SUCCESS;
     }
@@ -592,7 +601,7 @@ am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, size_t size,
 am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
 {
     am_status_t am_status = AM_ERROR_MISC;
-    hc::AmPointerInfo amPointerInfo(NULL, NULL, 0, ac, 0, 0);
+    hc::AmPointerInfo amPointerInfo(NULL, NULL, NULL, 0, ac, 0, 0);
     am_status = am_memtracker_getinfo(&amPointerInfo, hostPtr);
     if(am_status == AM_SUCCESS)
     {

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3584,8 +3584,8 @@ std::shared_ptr<KalmarAsyncOp> HSAQueue::EnqueueAsyncCopy(const void *src, void 
 
 
     hc::accelerator acc;
-    hc::AmPointerInfo srcPtrInfo(NULL, NULL, 0, acc, 0, 0);
-    hc::AmPointerInfo dstPtrInfo(NULL, NULL, 0, acc, 0, 0);
+    hc::AmPointerInfo srcPtrInfo(NULL, NULL, NULL, 0, acc, 0, 0);
+    hc::AmPointerInfo dstPtrInfo(NULL, NULL, NULL, 0, acc, 0, 0);
 
     bool srcInTracker = (hc::am_memtracker_getinfo(&srcPtrInfo, src) == AM_SUCCESS);
     bool dstInTracker = (hc::am_memtracker_getinfo(&dstPtrInfo, dst) == AM_SUCCESS);
@@ -4804,8 +4804,8 @@ HSACopy::syncCopy() {
     bool dstInDeviceMem = false;
 
     hc::accelerator acc;
-    hc::AmPointerInfo srcPtrInfo(NULL, NULL, 0, acc, 0, 0);
-    hc::AmPointerInfo dstPtrInfo(NULL, NULL, 0, acc, 0, 0);
+    hc::AmPointerInfo srcPtrInfo(NULL, NULL, NULL, 0, acc, 0, 0);
+    hc::AmPointerInfo dstPtrInfo(NULL, NULL, NULL, 0, acc, 0, 0);
 
     if (hc::am_memtracker_getinfo(&srcPtrInfo, src) == AM_SUCCESS) {
         srcInTracker = true;


### PR DESCRIPTION
aligned.

In this change, a bigger buffer will be allocated for alignment purpose
and _unalignedDevicePointer is added in struct AmPointerInfo for
original allocated address.