### PR TITLE
fix addr_space unit test

### DIFF
--- a/tests/Unit/Design/addr_space.cpp
+++ b/tests/Unit/Design/addr_space.cpp
@@ -13,16 +13,17 @@ float x(float *p) restrict(amp) {
 int main(void) {
   const int vecSize = 1000;
 
+  std::random_device rd;
+  std::default_random_engine gen(rd());
+  std::uniform_real_distribution<float> dis(-4.0f * M_PI, 4.0f * M_PI);
+
   // Alloc & init input data
   extent<1> e(vecSize);
-  array<float, 1> a(vecSize);
-  array<float, 1> b(vecSize);
-  array<float, 1> c(vecSize);
-  array_view<float> ga(a);
-  array_view<float> gb(b);
-  array_view<float> gc(c);
+  array_view<float> ga(vecSize);
+  array_view<float> gb(vecSize);
+  array_view<float> gc(vecSize);
   for (index<1> i(0); i[0] < vecSize; i++) {
-    ga[i] = rand() / 1000.0f;
+    ga[i] = dis(gen);
   }
 
   parallel_for_each(
@@ -37,7 +38,7 @@ int main(void) {
 
   float sum = 0;
   for(unsigned i = 0; i < vecSize; i++) {
-    sum += fast_math::fabs(fast_math::fabs(gc[i]) - fast_math::fabs(gb[i]));
+    sum = sum + fast_math::fabs(gc[i] - gb[i]);
   }
   return (sum > 0.1f);
 }


### PR DESCRIPTION
This test would fail intermittently probably due to imprecision of the sin functions with large input values.  Fix the test to use a more reasonable inputs.