### PR TITLE
hc::accelerator_view::copy() enhancement

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4469,7 +4469,8 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
             srcAgent=hostAgent; dstAgent=hostAgent;
 
             /* H2H case
-             * Simply pass this->src and this->dst to ROCR runtime.
+             * We expect ROCR runtime to continue use the CPU for host to host
+             * copies, and thus must pass host pointers here.
              */
             dstPtr = this->dst;
             srcPtr = const_cast<void*>(this->src);
@@ -4479,8 +4480,8 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
 
             /* H2D case
              * Destination is simply this->dst.
-             * Source has to be calculated by adding mapped GPU device pointer
-             * with potential offsets specified in user codes.
+             * Source has to be calculated by adding the offset to the pinned
+             * host pointer.
              */
             dstPtr = this->dst;
             srcPtr = reinterpret_cast<unsigned char*>(srcPtrInfo._devicePointer) +
@@ -4490,10 +4491,10 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
         case Kalmar::hcMemcpyDeviceToHost: 
             srcAgent=copyAgent; dstAgent=hostAgent;
 
-            /* H2D case
+            /* D2H case
              * Source is simply this->src.
-             * Desination has to be calculated by adding mapped GPU device
-             * pointer with potential offsets specified in user codes.
+             * Desination has to be calculated by adding the offset to the
+             * pinned host pointer.
              */
             dstPtr = reinterpret_cast<unsigned char*>(dstPtrInfo._devicePointer) +
                      (reinterpret_cast<unsigned char*>(this->dst) -

--- a/tests/Unit/AcceleratorViewCopy/avcopy_with_offsets_host_locked.cpp
+++ b/tests/Unit/AcceleratorViewCopy/avcopy_with_offsets_host_locked.cpp
@@ -1,0 +1,126 @@
+// RUN: %hc %s -o %t.out -lhc_am && %t.out
+
+// Test hc::acclerator_view::copy()
+// with GPU buffers having offsets from the result of am_alloc
+// with CPU buffers page locked, and have offsets
+
+#include <hc.hpp>
+#include <hc_am.hpp>
+
+void rocm_device_synchronize()
+{
+  hc::accelerator_view av = hc::accelerator().get_default_view();
+  hc::completion_future fut = av.create_marker();
+  fut.wait();
+}
+void deep_copy(void * dst, const void * src, size_t n) {
+  hc::accelerator_view av = hc::accelerator().get_default_view();
+  av.copy( src , dst , n*sizeof(int));
+}
+
+template<int N, int offset>
+bool test() {
+  bool ret = true;
+
+  hc::accelerator acc;
+
+  // ap, bp are device memory buffers
+  int * ap = hc::am_alloc((offset+N)*sizeof(int),acc,0);
+  int * bp = hc::am_alloc((offset+N)*sizeof(int),acc,0);
+
+  // a, b are device memory with offsets
+  int * a = &ap[offset];
+  int * b = &bp[offset];
+
+  // h_ap, h_ap are un-locked host memory buffers
+  int * h_ap = (int *)malloc((offset+N)*sizeof(int));
+  int * h_bp = (int *)malloc((offset+N)*sizeof(int));
+
+  // page lock allocated host pointers
+  if ((hc::am_memory_host_lock(acc, h_ap, (offset+N)*sizeof(int), &acc, 1) != AM_SUCCESS) ||
+      (hc::am_memory_host_lock(acc, h_bp, (offset+N)*sizeof(int), &acc, 1) != AM_SUCCESS)) {
+    ret = false;
+  }
+
+  // h_a, h_b are page-locked host memory with offsets
+  int * h_a = &h_ap[offset];
+  int * h_b = &h_bp[offset];
+
+  // initialize h_a, h_b
+  for(int i=0; i<N; i++)
+    h_a[i] = i+1;
+  for(int i=0; i<N; i++)
+    h_b[i] = 5555;
+
+  // execute a kernel to populate data on GPU
+  hc::extent<1> e(N);
+  hc::parallel_for_each(e,[=](hc::index<1> idx)__HC__{
+    a[idx[0]] = 5;
+  });
+
+  // test 1. D2H copy
+  deep_copy(h_b,a,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != 5)
+      ret = false;
+  }
+
+  // test 2. H2D followed by D2D and then D2H copy
+  deep_copy(a,h_a,N);
+  deep_copy(b,a,N);
+  deep_copy(h_b,b,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != (i+1))
+      ret = false;
+  }
+
+  // test 3. do another D2H
+  deep_copy(h_b,a,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != (i+1))
+      ret = false;
+  }
+
+  // flush GPU queue
+  rocm_device_synchronize();
+
+  // page unlock allocated host pointers
+  if ((hc::am_memory_host_unlock(acc, h_ap) != AM_SUCCESS) ||
+      (hc::am_memory_host_unlock(acc, h_bp) != AM_SUCCESS)) {
+    ret = false;
+  }
+
+end: 
+  // release resources
+  free(h_ap);
+  free(h_bp);
+  hc::am_free(ap);
+  hc::am_free(bp);
+
+  return ret;
+}
+
+int main() {
+  bool ret = true;
+
+  ret &= test<64, 0>();
+  ret &= test<64, 64>();
+  ret &= test<1024, 0>();
+  ret &= test<1024, 17>();
+  ret &= test<1024, 32>();
+  ret &= test<1024, 129>();
+  ret &= test<1024, 256>();
+  ret &= test<1024, 513>();
+  ret &= test<1024, 1024>();
+
+  return !(ret == true);
+}

--- a/tests/Unit/AcceleratorViewCopy/avcopy_with_offsets_host_unlocked.cpp
+++ b/tests/Unit/AcceleratorViewCopy/avcopy_with_offsets_host_unlocked.cpp
@@ -1,0 +1,113 @@
+// RUN: %hc %s -o %t.out -lhc_am && %t.out
+
+// Test hc::acclerator_view::copy()
+// with GPU buffers having offsets from the result of am_alloc
+// with CPU buffers un-locked, and have offsets
+
+#include <hc.hpp>
+#include <hc_am.hpp>
+
+void rocm_device_synchronize()
+{
+  hc::accelerator_view av = hc::accelerator().get_default_view();
+  hc::completion_future fut = av.create_marker();
+  fut.wait();
+}
+void deep_copy(void * dst, const void * src, size_t n) {
+  hc::accelerator_view av = hc::accelerator().get_default_view();
+  av.copy( src , dst , n*sizeof(int));
+}
+
+template<int N, int offset>
+bool test() {
+  bool ret = true;
+
+  hc::accelerator acc;
+
+  // ap, bp are device memory buffers
+  int * ap = hc::am_alloc((offset+N)*sizeof(int),acc,0);
+  int * bp = hc::am_alloc((offset+N)*sizeof(int),acc,0);
+
+  // a, b are device memory with offsets
+  int * a = &ap[offset];
+  int * b = &bp[offset];
+
+  // h_ap, h_ap are un-locked host memory buffers
+  int * h_ap = (int *)malloc((offset+N)*sizeof(int));
+  int * h_bp = (int *)malloc((offset+N)*sizeof(int));
+
+  // h_a, h_b are un-locked host memory with offsets
+  int * h_a = &h_ap[offset];
+  int * h_b = &h_bp[offset];
+
+  // initialize h_a, h_b
+  for(int i=0; i<N; i++)
+    h_a[i] = i+1;
+  for(int i=0; i<N; i++)
+    h_b[i] = 5555;
+
+  // execute a kernel to populate data on GPU
+  hc::extent<1> e(N);
+  hc::parallel_for_each(e,[=](hc::index<1> idx)__HC__{
+    a[idx[0]] = 5;
+  });
+
+  // test 1. D2H copy
+  deep_copy(h_b,a,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != 5)
+      ret = false;
+  }
+
+  // test 2. H2D followed by D2D and then D2H copy
+  deep_copy(a,h_a,N);
+  deep_copy(b,a,N);
+  deep_copy(h_b,b,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != (i+1))
+      ret = false;
+  }
+
+  // test 3. do another D2H
+  deep_copy(h_b,a,N);
+
+  for(int i=0; i<N; i++) {
+    if (h_a[i] != (i+1))
+      ret = false;
+    if (h_b[i] != (i+1))
+      ret = false;
+  }
+
+  // flush GPU queue
+  rocm_device_synchronize();
+
+  // release resources
+  free(h_ap);
+  free(h_bp);
+  hc::am_free(ap);
+  hc::am_free(bp);
+
+  return ret;
+}
+
+int main() {
+  bool ret = true;
+
+  ret &= test<64, 0>();
+  ret &= test<64, 64>();
+  ret &= test<1024, 0>();
+  ret &= test<1024, 17>();
+  ret &= test<1024, 32>();
+  ret &= test<1024, 129>();
+  ret &= test<1024, 256>();
+  ret &= test<1024, 513>();
+  ret &= test<1024, 1024>();
+
+  return !(ret == true);
+}


### PR DESCRIPTION
improve copy implementation logic to take offsets into consideration

Old logic simply uses pointers returned by AM trackers, but it doesn't
consider the case where user codes could add offsets from pointers returned by
am_alloc().

One example would be:

int* buffer = am_alloc(size);
int* src = &buffer[offset];
av.copy(src, dst, size-offset);

In this PR the logic of hc::acclerator_view::copy() is improved to be
aware of this kind of use cases, and 2 test cases are provided.