### PR TITLE
Improve Printf implementation to use char arrays on GPU

### DIFF
--- a/include/hc_printf.hpp
+++ b/include/hc_printf.hpp
@@ -65,7 +65,7 @@ static inline PrintfPacket* createPrintfBuffer(hc::accelerator& a, const unsigne
   PrintfPacket* printfBuffer = NULL;
   if (numElements > 5) {
     printfBuffer = hc::am_alloc(sizeof(PrintfPacket) * numElements, a, amHostCoherent);
-    printfFormatBuffer = hc::am_alloc(sizeof(char) * numElements, a, amHostCoherent);
+    printfFormatBuffer = hc::am_alloc(sizeof(char) * numElements * 8, a, amHostCoherent);
 
     // initialize the printf buffer header
     printfBuffer[0].type = PRINTF_BUFFER_SIZE;

--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -14,20 +14,19 @@ int main() {
   using namespace hc;
 
   accelerator acc = accelerator();
-  char* printf_fbuf = NULL;
-  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE, printf_fbuf);
+  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
 
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
       const char* str1 = "Hello HC from %s: %03d\n";
       const char* str2 = "thread";
       const char* str3 = "Hello again from %s: %03d\n";
-      printf(printf_buf, printf_fbuf, str1, str2, tidx.global[0]);
-      printf(printf_buf, printf_fbuf, str3, "thread", tidx.global[0]);
+      printf(printf_buf, str1, str2, tidx.global[0]);
+      printf(printf_buf, str3, "thread", tidx.global[0]);
   }).wait();
 
-  processPrintfBuffer(printf_buf, printf_fbuf);
+  processPrintfBuffer(printf_buf);
 
-  deletePrintfBuffer(printf_buf, printf_fbuf);
+  deletePrintfBuffer(printf_buf);
 
   return 0;
 }

--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -1,4 +1,3 @@
-
 // RUN: %hc %s -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <hc.hpp>
@@ -9,26 +8,26 @@
 #define TILE (64)
 #define GLOBAL (TILE*2)
 
-#define PRINTF_BUFFER_SIZE (2048)
+#define PRINTF_BUFFER_SIZE (16384)
 
 int main() {
   using namespace hc;
 
   accelerator acc = accelerator();
-  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
-
-  const char* str1 = "Hello HC from %s: %03d\n";
-  const char* str2 = "thread";
-  const char* str3 = "Hello again from %s: %03d\n";
+  char* printf_fbuf = NULL;
+  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE, printf_fbuf);
 
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
-      printf(printf_buf, str1, str2, tidx.global[0]);
-      printf(printf_buf, str3, str2, tidx.global[0]);
+      const char* str1 = "Hello HC from %s: %03d\n";
+      const char* str2 = "thread";
+      const char* str3 = "Hello again from %s: %03d\n";
+      printf(printf_buf, printf_fbuf, str1, str2, tidx.global[0]);
+      printf(printf_buf, printf_fbuf, str3, "thread", tidx.global[0]);
   }).wait();
 
-  processPrintfBuffer(printf_buf);
+  processPrintfBuffer(printf_buf, printf_fbuf);
 
-  deletePrintfBuffer(printf_buf);
+  deletePrintfBuffer(printf_buf, printf_fbuf);
 
   return 0;
 }


### PR DESCRIPTION
Allocated a new buffer to store format strings used in printf calls.
Strings created on gpu will be copied into the string buffer on
host coherent memory, and will be printed after kernels. Users can
also write strings directly into arguments of printf call, as shown
in testcase.

TODO: We want to hide the printf implementation from user. Also we
want the printf buffer to be cyclical, so that we can reuse space
that is already printed. There is also a memory access fault that we
run into when the space used is close to buffer size, which needs
further investigation.