### PR TITLE
Printf - Ordering in Buffers using 1 atomic inst

### DIFF
--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -16,6 +16,10 @@ int main() {
   accelerator acc = accelerator();
   PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
 
+  if (!printf_buf) {
+    std::printf("createPrintfBuffer failed.\n");
+  }
+
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
       const char* str1 = "Hello HC from %s: %03d\n";
       const char* str2 = "thread";
@@ -30,6 +34,8 @@ int main() {
 
   return 0;
 }
+
+// CHECK-NOT: createPrintfBuffer failed.
 
 // CHECK-DAG: Hello HC from thread: 000
 // CHECK-DAG: Hello HC from thread: 063

--- a/tests/Unit/HSA/printf_minimal.cpp
+++ b/tests/Unit/HSA/printf_minimal.cpp
@@ -8,7 +8,7 @@
 #define TILE (16)
 #define GLOBAL (TILE)
 
-#define PRINTF_BUFFER_SIZE (54)
+#define PRINTF_BUFFER_SIZE (53)
 
 int main() {
   using namespace hc;
@@ -18,7 +18,7 @@ int main() {
 
   // Testing 16 threads with exact buffer size
   // Each printf here 2 args + 1 counter = 3
-  // 3 args * 16 = 48 + 6 overhead = 54
+  // 3 args * 16 = 48 + 5 overhead = 53
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
       const char* str1 = "Thread %03d\n";
       printf(printf_buf, str1, tidx.global[0]);

--- a/tests/Unit/HSA/printf_minimal.cpp
+++ b/tests/Unit/HSA/printf_minimal.cpp
@@ -16,6 +16,10 @@ int main() {
   accelerator acc = accelerator();
   PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
 
+  if (!printf_buf) {
+    std::printf("createPrintfBuffer failed.\n");
+  }
+
   // Testing 16 threads with exact buffer size
   // Each printf here 2 args + 1 counter = 3
   // 3 args * 16 = 48 + 5 overhead = 53
@@ -30,6 +34,8 @@ int main() {
 
   return 0;
 }
+
+// CHECK-NOT: createPrintfBuffer failed.
 
 // CHECK-DAG: Thread 000
 // CHECK-DAG: Thread 007

--- a/tests/Unit/HSA/printf_ptr_addr.cpp
+++ b/tests/Unit/HSA/printf_ptr_addr.cpp
@@ -16,6 +16,10 @@ int main() {
   accelerator acc = accelerator();
   PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
 
+  if (!printf_buf) {
+    std::printf("createPrintfBuffer failed.\n");
+  }
+
   // Here we can print the string address with %p if we cast to (void*)
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
       const char* str1 = "Thread: %03d, String Address: %p\n";
@@ -28,6 +32,8 @@ int main() {
 
   return 0;
 }
+
+// CHECK-NOT: createPrintfBuffer failed.
 
 // CHECK-DAG: Thread: 000, String Address: [[ADDR:0x[0-9a-f]+]]
 // CHECK-DAG: Thread: 007, String Address: [[ADDR]]


### PR DESCRIPTION
Previously, the packets were being allocated into the two buffers in different orders with respect to each other. Now using a single atomic compare_exchange_weak, we can maintain ordering in both buffers with respect with each other. Also, string arguments in a single printf, will be allocated consecutively in-order as well. Offsets will be managed in a single ullong, which can be divided into 2 4byte uints. Also, we are now performing a look-ahead to check for the space required to allocation into the string buffer, so we can perform space allocation in printf command chunks.

Also small update to test.