### PR TITLE
Fix compiler error - hsa_signal_s is not a pointer

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1250,7 +1250,7 @@ public:
                 auto asyncOp = asyncOps[i];
                 if (!foundFirstValidOp) {
                     hsa_signal_t sig =  *(static_cast <hsa_signal_t*> (asyncOp->getNativeHandle()));
-                    assert(sig->handle != 0);
+                    assert(sig.handle != 0);
                     foundFirstValidOp = true;
                 }
                 // wait on valid futures only


### PR DESCRIPTION
Here was the compilation error:
/root/hcc/lib/hsa/mcwamp_hsa.cpp:1253:31: error: member reference type 'hsa_signal_t'
      (aka 'hsa_signal_s') is not a pointer; did you mean to use '.'?
                    assert(sig->handle != 0);
                           ~~~^~
                              .
/usr/include/assert.h:89:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^~~~
1 error generated.
Should use . since it is an object, not pointer.