### PR TITLE
RHEL and CentOS should also be using -c++abi

### DIFF
--- a/hcc_config/hcc_config.cpp
+++ b/hcc_config/hcc_config.cpp
@@ -150,12 +150,11 @@ void ldflags(void) {
         }
     }
 
-    // extra libraries if using libc++ for C++ runtime   
+    // extra libraries if using libc++ for C++ runtime
+    // If using RHEL or CentOS, must also use c++abi
 #ifdef USE_LIBCXX
-    std::cout << " -stdlib=libc++ ";
-    #ifndef HCC_TOOLCHAIN_RHEL
-      std::cout << " -lc++abi ";
-    #endif
+    std::cout << " -stdlib=libc++";
+    std::cout << " -lc++ -lc++abi ";
 #endif
     std::cout << " -ldl -lm -lpthread";
 


### PR DESCRIPTION
For CentOS and RHEL, we want to use -stdlib=libc++ -lc++ -lc++abi. Related to SWDEV-131972. https://github.com/ROCm-Developer-Tools/HIP/pull/177 