### PR TITLE
Improve Link Perf by disabling slp-vectorize

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -194,7 +194,7 @@ fi
 #  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
 # Teach LLVM inliner we do want all functions used by a kernel be inlined
 # by assigning a big iniling threshold value
-$OPT -inline -inline-threshold=1048576 -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -infer-address-spaces -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify $2.linked.bc -o $2.opt.bc
+$OPT -inline -inline-threshold=1048576 -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -infer-address-spaces -amdgpu-internalize-symbols -disable-slp-vectorization -vectorize-slp=false -disable-simplify-libcalls $KMOPTOPT -verify $2.linked.bc -o $2.opt.bc
 
 # error handling for opt
 RETVAL=$?


### PR DESCRIPTION
SLP Vectorization is already enabled in Clang frontend ToolChains, so we do not need it for Link time optimizations. This improvement will cut link-time of rocBLAS from 8 mins to 6 mins. Also there is performance increase in run-time of rocblas-test as well.

In detail for compilation time, rocBLAS takes 8 mins for linking, 4 mins for each target. Of the 4 mins, 2 mins spent on opt and 2 mins spent on llc. By removing the slp-vectorize in opt, we will improve opt to run in 1 min.