### PR TITLE
Adding build parameters for hip integration testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,33 @@ properties([buildDiscarder(logRotator(
     daysToKeepStr: '',
     numToKeepStr: '10')),
     disableConcurrentBuilds(),
+    parameters([booleanParam( name: 'run_hip_integration_testing', defaultValue: false, description: 'Build hip with this compiler and run hip unit tests' ),
+                string( name: 'hip_integration_branch', defaultValue: 'ROCm-Developer-Tools/HIP/master', description: 'Path to hip branch to build & test' )]),
     [$class: 'CopyArtifactPermissionProperty', projectNames: '*']
   ])
+
+////////////////////////////////////////////////////////////////////////
+// -- AUXILLARY HELPER FUNCTIONS
+
+////////////////////////////////////////////////////////////////////////
+// Return user description if a build was manually kicked off (like build now button clicked),
+// or null if some other trigger caused the build
+@NonCPS
+String get_build_cause( )
+{
+    def build_cause = currentBuild.rawBuild.getCause( hudson.model.Cause$UserIdCause )
+    if( build_cause == null )
+      return build_cause
+
+    return build_cause.getShortDescription( )
+}
+
+// Not used right now, seems to always return 0
+@NonCPS
+def get_num_change_sets( )
+{
+  return currentBuild.changeSets.size( );
+}
 
 node( 'rocmtest' )
 {
@@ -170,15 +195,14 @@ node( 'rocmtest' )
   stage('hip integration')
   {
     // If this a clang_tot_upgrade build, kick off downstream hip build so that the two projects are in sync
-    // if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'clang_tot_upgrade' ) )
-    // {
-    //   build( job: 'kknox/HIP/ci-fix', wait: false )
-    // }
-    // // If this is a PR build, test compiler against downstream hip project
-    // else if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'pr-' ) )
-    // {
-    //   build( job: 'kknox/HIP/ci-fix', parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
-    // }
-    build( job: 'kknox/HIP/ci-fix', parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
+    if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'clang_tot_upgrade' ) )
+    {
+      build( job: 'ROCm-Developer-Tools/HIP/master', wait: false )
+    }
+    // If hip integration testing is requested by the user, launch a hip build job to use this transient compiler
+    else if( params.run_hip_integration_testing )
+    {
+      build( job: params.hip_integration_branch, parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,7 @@ node( 'rocmtest' )
       {
         sh "cd ${build_dir_release_abs}; make package"
         archiveArtifacts artifacts: "${build_dir_release_rel}/*.deb", fingerprint: true
+        archiveArtifacts artifacts: "docker/dockerfile-hcc-lc-*", fingerprint: true
         // archiveArtifacts artifacts: "${build_dir_release_rel}/*.rpm", fingerprint: true
       }
     }
@@ -169,14 +170,15 @@ node( 'rocmtest' )
   stage('hip integration')
   {
     // If this a clang_tot_upgrade build, kick off downstream hip build so that the two projects are in sync
-    if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'clang_tot_upgrade' ) )
-    {
-      build( job: 'ROCm-Developer-Tools/HIP/master', wait: false )
-    }
-    // If this is a PR build, test compiler against downstream hip project
-    else if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'pr-' ) )
-    {
-      build( job: 'ROCm-Developer-Tools/HIP/master', parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
-    }
+    // if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'clang_tot_upgrade' ) )
+    // {
+    //   build( job: 'kknox/HIP/ci-fix', wait: false )
+    // }
+    // // If this is a PR build, test compiler against downstream hip project
+    // else if( env.BRANCH_NAME.toLowerCase( ).startsWith( 'pr-' ) )
+    // {
+    //   build( job: 'kknox/HIP/ci-fix', parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
+    // }
+    build( job: 'kknox/HIP/ci-fix', parameters: [booleanParam( name: 'hcc_integration_test', value: true )] )
   }
 }


### PR DESCRIPTION
The ability to enable hip integration testing has been enabled for a while, but I am now making the ability explicit.  There are now two build parameters: 
1.  A boolean checkbox to enable hip integration testing
2.  A string field to specify the hip test to branch

The primary reason for this is two fold:
1.  I'm still learning how to connect projects.  I can't claim that I know what I'm doing yet :)  Putting an explicit opt-in will prevent blatant mis-builds like we have experienced in the past week.
2.  There are more integration builds happening than I want.  I filter integration builds to only the main branch and PR's, but PR's can kick off multiple times even when nothing in the PR has changed.  This happens when the main branch changes, jenkins re-builds all PR's again, but we don't necessarily want to issue a new HiP build.

I'll send a separate email about how this looks