### PR TITLE
Integrate hcc-config as part of the driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/clang-tools-extra/CMakeLists.txt)
   set(LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR "${PROJECT_SOURCE_DIR}/clang-tools-extra")
 endif()
 
+add_definitions("-I${CMAKE_CURRENT_BINARY_DIR}/hcc_config")
 add_subdirectory(${CLANG_SRC_DIR})
 
 install(PROGRAMS $<TARGET_FILE:llvm-as>

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -43,6 +43,7 @@ if os.environ.get('HSA_TOOLS_LIB'):
 if os.environ.get('LD_LIBRARY_PATH'):
     config.environment['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH']
 
+config.environment['HCC_BUILD'] = "1"
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -76,22 +77,11 @@ def inferClang(PATH):
 
 cxx_options = ' ' + ' '.join([
   "-I%s" % config.gtest_src_dir,
-  "-DGTEST_HAS_TR1_TUPLE=0",
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--cxxflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
+  "-DGTEST_HAS_TR1_TUPLE=0"
 ]) + ' '
 
-link_options = ' ' + ' '.join([
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--ldflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
-  "-lpthread",
-  ]) + ' '
+link_options = ' '
+
 gtest_link_options = ' ' + ' '.join([
   "-lmcwamp_gtest",
 ]) + ' '


### PR DESCRIPTION
This change removes the need to use hcc-config when compiling with hcc. All of the options (except for 'hc' and 'std=c++amp') added by --cxxflags and --ldflags are now being included inside the hcc tool chain. To invoke hcc in build mode, instead of setting the --build flag in hcc-config, now it is required to set the HCC_BUILD environmental variable.