### PR TITLE
Parallelize CLAMP_DEVICE for each AMDGPU_TARGET

### DIFF
--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -404,19 +404,24 @@ if [ ${#LINK_KERNEL_ARGS[@]} != 0 ]; then
   CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS="-inputs=$TEMP_DIR/__empty.o"
   CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS="-targets=host-x86_64-unknown-linux"
 
+  declare -a pids
   # for each GPU target, lower to GCN ISA in HSACO format
   for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}; do
-    { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET;
+    { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET; } &
 
     # error handling
-    ret=$ret+$?;
+    pids+=("${pids[@]}" "$!")
 
     # augment arguments to clang-offload-bundler
-    CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco";
-    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"; } &
+    CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco"
+    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"
   done
 
-  wait
+  # collect all the error codes from forked processes
+  # error handling
+  for pid in ${pids[*]}; do
+    wait $pid || ret=$((ret+$?))
+  done
   if [ $ret != 0 ]; then
     exit $ret
   fi

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -406,18 +406,21 @@ if [ ${#LINK_KERNEL_ARGS[@]} != 0 ]; then
 
   # for each GPU target, lower to GCN ISA in HSACO format
   for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}; do
-    $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET
+    { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET;
 
     # error handling
-    ret=$?
-    if [ $ret != 0 ]; then
-      exit $ret
-    fi
+    ret=$ret+$?;
 
     # augment arguments to clang-offload-bundler
-    CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco"
-    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"
+    CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco";
+    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"; } &
   done
+
+  wait
+  if [ $ret != 0 ]; then
+    exit $ret
+  fi
+
 
   # invoke clang-offload-bundler
   $CLANG_OFFLOAD_BUNDLER -type=o $CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS $CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS -outputs=$TEMP_DIR/kernel.bundle


### PR DESCRIPTION
This change will make parallel the CLAMP_DEVICE calls for each AMDGPU_TARGET. With this patch, multiple CLAMP_DEVICE processes can run in parallel the major link-time tools opt and llc. Each clamp_device call should be target specific and thus not affect each other. There are significant performance gains on building projects like rocBLAS.