### PR TITLE
compile hcc libs in hc mode

### DIFF
--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -38,7 +38,7 @@ macro(amp_target name )
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})
   target_include_directories(${name} SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
   add_libcxx_option_if_needed(${name})
-  target_compile_options(${name} PUBLIC -std=c++amp -fPIC)
+  target_compile_options(${name} PUBLIC -hc -std=c++amp -fPIC)
 
   # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
   # Otherwise, -gline-tables-only would override other existing debug flags


### PR DESCRIPTION
This would allow code in hcc libraries to use the hc extensions 