### PR TITLE
[DOC] revise SYNC_UPSTREAM.md

### DIFF
--- a/SYNC_UPSTREAM.md
+++ b/SYNC_UPSTREAM.md
@@ -10,7 +10,8 @@ projects, but it is usually not easy to figure it out from the commit log.
 
 HCC has been configured to use git submodules to track these dependencies, but
 there are users who prefer using repo tool. This document has been revised to
-cope with both git submodules and repo.
+cope with both git submodules and repo. Maintaining repo manifest is an
+optional step for now.
 
 HCC depends on amd-common LLVM / LLD / Clang, which is a fork maintained by AMD,
 and may contain patches not yet upstreamed. amd-common LLVM / LLD / Clang is
@@ -23,28 +24,6 @@ and filing the pull requests. And the one who reviews all of your sync pull
 requests. The HCC merge maintainer will take on the first role, and is required
 to interact, modify, and satisfy the changes requested by the reviewer before
 the pull requests can be accepted.
-
-Generally speaking, the process goes like this:
-
- 1. Clone HCC repo manifest
- 2. Clone HCC with repo
- 3. Initialize git submodules
- 4. Add all remotes and forks for submodules
- 5. Checkout latest master ROCm-Device-Libs
- 6. Merge amd-common LLD commits
- 7. Merge amd-common LLVM commits
- 8. Merge master COMPILER-RT commits from llvm-mirror
- 9. Merge master CLANG-TOOLS-EXTRA commits from llvm-mirror
-10. Merge amd-common Clang commits
-11. Build merged HCC
-12. Full sanity tests on merged HCC (optional)
-13. Quick sanity tests on merged HCC
-14. Push and Create Pull Request for HCC Clang submodule
-15. Push and Create Pull Request for amd-hcc LLD submodule
-16. Push and Create Pull Request for amd-hcc LLVM submodule
-17. Push and Create Pull Request for amd-hcc COMPILER-RT submodule
-18. Update HCC git submodules configuration
-19. Update HCC repo manifest
 
 Detailed step-by-step instructions are in following sections.
 
@@ -70,63 +49,50 @@ git locations of repositories used in the merge process are:
   - URL: https://github.com/RadeonOpenCompute/clang.git
   - branch : amd-common
 
-Set own forks for sub-directories
----------------------------------
-Go to these links and fork onto personal account:
+Set own forks for HCC modules
+-----------------------------
+Go to these links and fork onto your personal account. If you have old forks,
+please remove them, or create another fork which tracks the tip of
+corresponding repositories.
+
 1) https://github.com/RadeonOpenCompute/hcc
 2) https://github.com/RadeonOpenCompute/hcc-clang-upgrade
 3) https://github.com/RadeonOpenCompute/llvm
 4) https://github.com/RadeonOpenCompute/compiler-rt
 5) https://github.com/RadeonOpenCompute/clang-tools-extra
 6) https://github.com/RadeonOpenCompute/lld
-Note, you'd won't need to do this for rocdl, since we will use its master branch.
 
-This only needs to be done once.
+Note, you'd won't need to do this for rocdl, since we will use its master branch.
 
 Step-by-step Merge Process
 --------------------------
 Assuming that we have created forks for all the repositories above, follow this:
 
-### Clone HCC with repo
+### From here on, replace *your_name* with your own github id
 
-- `repo init -u https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git`
-- `repo sync`
-
-### Clone HCC repo manifest
-
-A manifest directory is created to track working commits for all components.
-
-- `git clone https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git manifest`
-
-This directory would be referred as *HCC manifest directory* hereafter.
-
-### Initialize git submodules
-### From here on, replace *aaronenyeshi* with your own github id
-
-- `git clone https://github.com/aaronenyeshi/hcc.git hcc_fork`
+- `git clone git@github.com:your_name/hcc.git hcc_fork`
 - `cd hcc_fork`
 - `git checkout clang_tot_upgrade`
 - `git submodule update --init`
 
-There will be an `hcc-fork` directory inside the repo. It would be referred as
-*HCC directory* hereafter.
+This directory would be referred as *HCC directory* hereafter.
 
 ### Add all remotes and forks for submodules
 
 - change to HCC directory
-- `git remote add hcc_fork https://github.com/aaronenyeshi/hcc.git`
-- `cd ../lld`
-- `git remote add lld_fork https://github.com/aaronenyeshi/lld.git`
+- `git remote add hcc_fork git@github.com:your_name/hcc.git`
+- `cd lld`
+- `git remote add lld_fork git@github.com:your_name/lld.git`
 - `cd ../compiler`
-- `git remote add llvm_fork https://github.com/aaronenyeshi/llvm.git`
+- `git remote add llvm_fork git@github.com:your_name/llvm.git`
 - `cd ../compiler-rt`
-- `git remote add compiler-rt_fork https://github.com/aaronenyeshi/compiler-rt.git`
+- `git remote add compiler-rt_fork git@github.com:your_name/compiler-rt.git`
 - `git remote add compiler-rt https://github.com/llvm-mirror/compiler-rt`
 - `cd ../clang-tools-extra`
-- `git remote add clang-tools-extra_fork https://github.com/aaronenyeshi/clang-tools-extra.git`
+- `git remote add clang-tools-extra_fork git@github.com:your_name/clang-tools-extra.git`
 - `git remote add clang-tools-extra https://github.com/llvm-mirror/clang-tools-extra`
 - `cd ../clang`
-- `git remote add clang_fork https://github.com/aaronenyeshi/hcc-clang-upgrade.git`
+- `git remote add clang_fork git@github.com:your_name/hcc-clang-upgrade.git`
 - `git remote add clang https://github.com/RadeonOpenCompute/clang`
 
 **Use `git remote -v` to verify the new remotes are added.**
@@ -186,10 +152,10 @@ There will be an `hcc-fork` directory inside the repo. It would be referred as
 
 ### Build merged HCC
 
-- change to root directory
-- `mkdir -p build; cd build`
+- change to HCC directory
+- `cd ..; mkdir -p build; cd build`
 - `cmake -DCMAKE_BUILD_TYPE=Release ../hcc`
-- `make -j`
+- `make -j$(nproc)`
 
 Fix any compilation failures if there is any. Repeat this step until HCC
 can be built.
@@ -207,14 +173,14 @@ directory is at `~/hcc`.
 
 Test with one C++AMP FP math unit test.
 ```bash
-bin/hcc `bin/clamp-config --build --cxxflags --ldflags` -lm \
+compiler/bin/hcc `bin/clamp-config --build --cxxflags --ldflags` -lm \
   ~/hcc/tests/Unit/AmpMath/amp_math_cos.cpp
 ./a.out ; echo $?
 ```
 
 Test with one grid_launch unit test with AM library usage.
 ```bash
-bin/hcc `bin/hcc-config --build --cxxflags --ldflags` -lhc_am \
+compiler/bin/hcc `bin/hcc-config --build --cxxflags --ldflags` -lhc_am \
   ~/hcc/tests/Unit/GridLaunch/glp_const.cpp
 ./a.out ; echo $?
 ```
@@ -292,26 +258,56 @@ conflicts so that the PR is ready for merge.
 - `cd ../compiler`
 - `git fetch --all`
 - `git checkout origin/amd-hcc`
-- `cd compiler-rt`
-- `git fetch --all`
-- `cd clang-tools-extra`
+- `cd ../compiler-rt`
 - `git fetch --all`
 - `git checkout origin/amd-hcc`
-- `cd lld`
+- `cd ../clang-tools-extra`
 - `git fetch --all`
 - `git checkout origin/amd-hcc`
-- `cd rocdl`
+- `cd ../lld`
+- `git fetch --all`
+- `git checkout origin/amd-hcc`
+- `cd ../rocdl`
 - `git fetch --all`
 - `git checkout origin/master`
+
+- change to HCC directory
+- `git checkout -b merge_YYYYMMDD clang_tot_upgrade`
+- `git add clang clang-tools-extra compiler compiler-rt lld rocdl`
 - `git commit -m "[Config] revise submodule configuration"`, or provide custom
   commit log
 - `git push origin merge_YYYYMMDD:merge_YYYYMMDD`
 Create a pull request to merge `merge_YYYYMMDD` from your hcc fork
 into https://github.com/RadeonOpenCompute/hcc on branch `clang_tot_upgrade`.
 
-### Update HCC repo manifest
+Upon reaching here, the merge process is completed.
 
-- change to HCC directory
+
+### (Optional) Update HCC repo manifest
+### Clone HCC with repo
+
+- Create a directory called 'repo'. It would be called as *HCC Repo directory*
+  hereafter.
+- `repo init -u https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git`
+- `repo sync`
+
+### Clone HCC repo manifest
+
+A manifest directory is created to track working commits for all components.
+
+- `git clone https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git manifest`
+
+This directory would be referred as *HCC manifest directory* hereafter.
+
+### Initialize git submodules
+
+- change to HCC Repo directory
+- `cd hcc`
+- `git checkout clang_tot_upgrade`
+- `git pull`
+- `git submodule update --init`
+
+### Update HCC repo manifest
 - `repo manifest -r > default.xml`
 - copy `default.xml` to HCC manifest directory
 - change too HCC manifest directory
@@ -319,4 +315,3 @@ into https://github.com/RadeonOpenCompute/hcc on branch `clang_tot_upgrade`.
 - `git commit -m "[Config] revise manifest"`, or provide custom commit log
 - `git push` to push HCC repo manifest online
 
-Upon reaching here, the merge process is completed.


### PR DESCRIPTION
- Make `repo manifest` an optional step as it's not actively used by CI
- Editorial changes