### PR TITLE
Workaround AMDGPU backend stability isue in SI waitcnt insertion pass

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -213,7 +213,7 @@ if [ $KMDUMPLLVM == "1" ]; then
   cp $2.opt.bc ${KMDUMPDIR}/dump-$AMDGPU_TARGET.opt.bc
 fi
 
-$LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -filetype=obj -o $2.isabin $2.opt.bc
+$LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -filetype=obj -enable-si-insert-waitcnts=0 -o $2.isabin $2.opt.bc
 
 # error handling for llc
 RETVAL=$?
@@ -224,7 +224,7 @@ fi
 
 if [ $KMDUMPISA == "1" ]; then
   cp $2.isabin ./dump-$AMDGPU_TARGET.isabin
-  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -filetype=asm -o $2.isa $2.opt.bc
+  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -filetype=asm -enable-si-insert-waitcnts=0 -o $2.isa $2.opt.bc
   mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
 fi
 


### PR DESCRIPTION
It has been observed some workloads have trouble in SI waitcnt insertion pass
in AMDGPU backend. In this commit we temporarily disable using the pass.