### PR TITLE
update hc::printf

### DIFF
--- a/hcc_config/hcc_config.cpp
+++ b/hcc_config/hcc_config.cpp
@@ -165,6 +165,7 @@ void ldflags(void) {
         if (p == std::string("ON"))
         std::cout << " -lmcwamp_atomic";
 
+    std::cout << " -lhc_am";
     std::cout << " -Wl,--whole-archive -lmcwamp -Wl,--no-whole-archive";
 
 #ifdef CODEXL_ACTIVITY_LOGGER_ENABLED

--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1236,6 +1236,8 @@ public:
             //TODO-ASYNC - need to reclaim older AsyncOps here.
             __amp_future.wait();
         }
+
+        Kalmar::getContext()->flushPrintfBuffer();
     }
 
     template <class _Rep, class _Period>

--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "hc.hpp"
+#include <cstddef>
+#include <mutex>
 #include <initializer_list>
 
 typedef int am_status_t;
@@ -21,7 +23,7 @@ public:
     void *      _hostPointer;   ///< Host pointer.  If host access is not allowed, NULL.
     void *      _devicePointer; ///< Device pointer.
     void *      _unalignedDevicePointer; ///< Unaligned device pointer
-    size_t      _sizeBytes;     ///< Size of allocation.
+    std::size_t      _sizeBytes;     ///< Size of allocation.
     hc::accelerator _acc;       ///< Accelerator where allocation is physically located.
     bool        _isInDeviceMem; ///< Memory is physically resident on a device (if false, memory is located on host)
     bool        _isAmManaged;   ///< Memory was allocated by AM and should be freed when am_reset is called.
@@ -32,7 +34,7 @@ public:
     void *      _appPtr;             ///< App-specific pointer to additional information.
 
 
-    AmPointerInfo(void *hostPointer, void *devicePointer, void* unalignedDevicePointer, size_t sizeBytes, hc::accelerator &acc,  bool isInDeviceMem=false, bool isAmManaged=false) :
+    AmPointerInfo(void *hostPointer, void *devicePointer, void* unalignedDevicePointer, std::size_t sizeBytes, hc::accelerator &acc,  bool isInDeviceMem=false, bool isAmManaged=false) :
         _hostPointer(hostPointer),
         _devicePointer(devicePointer),
         _unalignedDevicePointer(unalignedDevicePointer),
@@ -75,7 +77,8 @@ namespace hc {
  *
  * @see am_free, am_copy
  */
-auto_voidp am_aligned_alloc(size_t size, hc::accelerator &acc, unsigned flags, size_t alignment = 0);
+
+auto_voidp am_aligned_alloc(std::size_t size, hc::accelerator &acc, unsigned flags, std::size_t alignment = 0);
 
 /**
  * Allocate a block of @p size bytes of memory on the specified @p acc.
@@ -95,7 +98,7 @@ auto_voidp am_aligned_alloc(size_t size, hc::accelerator &acc, unsigned flags, s
  *
  * @see am_free, am_copy
  */
-auto_voidp am_alloc(size_t size, hc::accelerator &acc, unsigned flags);
+auto_voidp am_alloc(std::size_t size, hc::accelerator &acc, unsigned flags);
 
 /**
  * Free a block of memory previously allocated with am_alloc.
@@ -112,7 +115,7 @@ am_status_t am_free(void*  ptr);
  * @return AM_SUCCESS on error or AM_ERROR_MISC if an error occurs.
  * @see am_alloc, am_free
  */
-am_status_t am_copy(void*  dst, const void*  src, size_t size) __attribute__ (( deprecated ("use accelerator_view::copy instead (and note src/dst order reversal)" ))) ;
+am_status_t am_copy(void*  dst, const void*  src, std::size_t size) __attribute__ (( deprecated ("use accelerator_view::copy instead (and note src/dst order reversal)" ))) ;
 
 
 
@@ -173,7 +176,7 @@ am_status_t am_memtracker_remove(void* ptr);
  * @returns Number of entries reset.
  * @see am_memtracker_getinfo
  */
-size_t am_memtracker_reset(const hc::accelerator &acc);
+std::size_t am_memtracker_reset(const hc::accelerator &acc);
 
 /**
  * Print the entries in the memory tracker table.
@@ -189,7 +192,7 @@ void am_memtracker_print(void * targetAddress=nullptr);
  *
  * User memory is registered with am_tracker_add.
  **/
-void am_memtracker_sizeinfo(const hc::accelerator &acc, size_t *deviceMemSize, size_t *hostMemSize, size_t *userMemSize);
+void am_memtracker_sizeinfo(const hc::accelerator &acc, std::size_t *deviceMemSize, std::size_t *hostMemSize, std::size_t *userMemSize);
 
 
 void am_memtracker_update_peers(const hc::accelerator &acc, int peerCnt, hsa_agent_s *agents);
@@ -206,7 +209,7 @@ void am_memtracker_update_peers(const hc::accelerator &acc, int peerCnt, hsa_age
  * @return AM_ERROR_MISC if @p ptr is not found in the pointer tracker.
  * @return AM_ERROR_MISC if @p peers incudes a non peer accelerator.
  */
-am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* peers); 
+am_status_t am_map_to_peers(void* ptr, std::size_t num_peer, const hc::accelerator* peers); 
 
 /*
  * Locks a host pointer to a vector of agents
@@ -219,7 +222,7 @@ am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* p
  * @return AM_SUCCESS if lock is successfully.
  * @return AM_ERROR_MISC if lock is unsuccessful.
  */
-am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, size_t size, hc::accelerator *visibleAc, size_t numVisibleAc);
+am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, std::size_t size, hc::accelerator *visibleAc, std::size_t numVisibleAc);
 
 /*
  * Unlock page locked host memory

--- a/include/hc_am_internal.hpp
+++ b/include/hc_am_internal.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "hc_am.hpp"
+
+namespace hc {
+  namespace internal {
+
+   /**
+    * Allocate a block of size bytes of host coherent system memory.
+    *
+    * The contents of the newly allocated block of memory are not initialized.
+    *
+    * @return : On success, pointer to the newly allocated memory is returned.
+    * The pointer is typecast to the desired return type.
+    *
+    * If an error occurred trying to allocate the requested memory, nullptr is returned.
+    *
+    * Use am_free to free the newly allocated memory.
+    *
+    * @see am_free, am_copy
+    */
+    auto_voidp am_alloc_host_coherent(size_t);
+
+  } // namespace internal
+} // namespace hc

--- a/include/hc_printf.hpp
+++ b/include/hc_printf.hpp
@@ -131,13 +131,13 @@ static inline void copy_n(char* dest, const char* src, unsigned int len) [[hc,cp
 // return the memory size (including '/0') if it's a C-string
 template <typename T>
 std::size_t mem_size_if_string(typename std::enable_if< std::is_same<T,const char*>::value 
-                                        || std::is_same<T,char*>::value, T>::type  s) [[hc,cpu]] {
+                                                        || std::is_same<T,char*>::value, T>::type  s) [[hc,cpu]] {
   return string_length(s) + 1;
 }
 
 template <typename T>
 std::size_t mem_size_if_string(typename std::enable_if< !std::is_same<T,const char*>::value 
-                                        && !std::is_same<T,char*>::value, T>::type  s) [[hc,cpu]] {
+                                                         && !std::is_same<T,char*>::value, T>::type  s) [[hc,cpu]] {
   return 0;
 }
 

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -553,6 +553,9 @@ public:
 
     /// get tick frequency
     virtual uint64_t getSystemTickFrequency() { return 0L; };
+
+    // flush the device printf buffer
+    virtual void flushPrintfBuffer() {};
 };
 
 KalmarContext *getContext();

--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -1,5 +1,9 @@
+
+#include "hc.hpp"
 #include "hc_am.hpp"
 
+#include <cstddef>
+#include <mutex>
 #include <cstdint>
 #include <iomanip>
 #include <hsa/hsa.h>
@@ -43,7 +47,7 @@ AmPointerInfo & AmPointerInfo::operator= (const AmPointerInfo &other)
 struct AmMemoryRange {
     const void * _basePointer;
     const void * _endPointer;
-    AmMemoryRange(const void *basePointer, size_t sizeBytes) :
+    AmMemoryRange(const void *basePointer, std::size_t sizeBytes) :
         _basePointer(basePointer), _endPointer((const unsigned char*)basePointer + sizeBytes - 1) {};
 };
 
@@ -137,7 +141,7 @@ public:
     void readerUnlock() { _mutex.unlock(); };
 
 
-    size_t reset (const hc::accelerator &acc);
+    std::size_t reset (const hc::accelerator &acc);
     void update_peers (const hc::accelerator &acc, int peerCnt, hsa_agent_t *peerAgents) ;
 
 private:
@@ -183,12 +187,12 @@ AmPointerTracker::MapTrackerType::iterator  AmPointerTracker::find (const void *
 //---
 // Remove all tracked locations, and free the associated memory (if the range was originally allocated by AM).
 // Returns count of ranges removed.
-size_t AmPointerTracker::reset (const hc::accelerator &acc) 
+std::size_t AmPointerTracker::reset (const hc::accelerator &acc) 
 {
     std::lock_guard<std::mutex> l (_mutex);
     mprintf ("reset: \n");
 
-    size_t count = 0;
+    std::size_t count = 0;
     // relies on C++11 (erase returns iterator)
     for (auto iter = _tracker.begin() ; iter != _tracker.end(); ) {
         if (iter->second._acc == acc) {
@@ -239,7 +243,7 @@ AmPointerTracker g_amPointerTracker;  // Track all am pointer allocations.
 namespace hc {
 
 // Allocate accelerator memory, return NULL if memory could not be allocated:
-auto_voidp am_aligned_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags, size_t alignment)
+auto_voidp am_aligned_alloc(std::size_t sizeBytes, hc::accelerator &acc, unsigned flags, std::size_t alignment)
 {
     void *ptr = NULL;
 
@@ -295,7 +299,7 @@ auto_voidp am_aligned_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned fla
     return ptr;
 };
 
-auto_voidp am_alloc(size_t sizeBytes, hc::accelerator &acc, unsigned flags)
+auto_voidp am_alloc(std::size_t sizeBytes, hc::accelerator &acc, unsigned flags)
 {
     return am_aligned_alloc(sizeBytes, acc, flags, 0);
 };
@@ -318,7 +322,7 @@ am_status_t am_free(void* ptr)
 }
 
 
-am_status_t am_copy(void*  dst, const void*  src, size_t sizeBytes)
+am_status_t am_copy(void*  dst, const void*  src, std::size_t sizeBytes)
 {
     am_status_t am_status = AM_ERROR_MISC;
     hsa_status_t err = hsa_memory_copy(dst, src, sizeBytes);
@@ -458,12 +462,12 @@ void am_memtracker_print(void *targetAddress)
 
 
 //---
-void am_memtracker_sizeinfo(const hc::accelerator &acc, size_t *deviceMemSize, size_t *hostMemSize, size_t *userMemSize)
+void am_memtracker_sizeinfo(const hc::accelerator &acc, std::size_t *deviceMemSize, std::size_t *hostMemSize, std::size_t *userMemSize)
 {
     *deviceMemSize = *hostMemSize = *userMemSize = 0;
     for (auto iter = g_amPointerTracker.readerLockBegin() ; iter != g_amPointerTracker.end(); iter++) {
         if (iter->second._acc == acc) {
-            size_t sizeBytes = iter->second._sizeBytes;
+            std::size_t sizeBytes = iter->second._sizeBytes;
             if (iter->second._isAmManaged) {
                 if (iter->second._isInDeviceMem) {
                     *deviceMemSize += sizeBytes;
@@ -481,7 +485,7 @@ void am_memtracker_sizeinfo(const hc::accelerator &acc, size_t *deviceMemSize, s
 
 
 //---
-size_t am_memtracker_reset(const hc::accelerator &acc)
+std::size_t am_memtracker_reset(const hc::accelerator &acc)
 {
     return g_amPointerTracker.reset(acc);
 }
@@ -491,7 +495,7 @@ void am_memtracker_update_peers (const hc::accelerator &acc, int peerCnt, hsa_ag
     return g_amPointerTracker.update_peers(acc, peerCnt, peerAgents);
 }
 
-am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* peers) 
+am_status_t am_map_to_peers(void* ptr, std::size_t num_peer, const hc::accelerator* peers) 
 {
     // check input
     if(nullptr == ptr || 0 == num_peer || nullptr == peers)
@@ -524,8 +528,9 @@ am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* p
         else
             return AM_ERROR_MISC;
     }
-    
-    std::vector<hsa_agent_t> agents{hc::accelerator::get_all().size()};
+
+    const std::size_t max_agent = hc::accelerator::get_all().size();
+    hsa_agent_t agents[max_agent];
   
     int peer_count = 0;
 
@@ -578,7 +583,7 @@ am_status_t am_map_to_peers(void* ptr, size_t num_peer, const hc::accelerator* p
     return AM_SUCCESS;
 }
 
-am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, size_t size, hc::accelerator *visible_ac, size_t num_visible_ac)
+am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, std::size_t size, hc::accelerator *visible_ac, std::size_t num_visible_ac)
 {
     am_status_t am_status = AM_ERROR_MISC;
     void *devPtr;
@@ -613,5 +618,13 @@ am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
     }
     return am_status;
 }
+
+  namespace internal {
+    auto_voidp am_alloc_host_coherent(size_t size) {
+      hc::accelerator acc = hc::accelerator();
+      void* buffer = hc::am_alloc(size, acc, amHostCoherent);
+      return buffer;
+    }
+  } // end namespace internal
 
 } // end namespace hc.

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -276,7 +276,7 @@ static unsigned extractBits(unsigned v, unsigned pos, unsigned w)
 namespace hc {
 
 // printf buffer size (in number of packets, see hc_printf.hpp)
-constexpr unsigned int default_printf_buffer_size = 1024;
+constexpr unsigned int default_printf_buffer_size = 2048;
 
 // address of the global printf buffer in host coherent system memory
 PrintfPacket* printf_buffer = nullptr;

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1349,11 +1349,6 @@ public:
         }
         // clear async operations table
         asyncOps.clear();
-
-        // flush the printf buffer
-        if (hc::printf_buffer != nullptr) {
-            processPrintfBuffer(hc::printf_buffer);
-        }
    }
 
     void LaunchKernel(void *ker, size_t nr_dim, size_t *global, size_t *local) override {
@@ -3315,7 +3310,7 @@ public:
         // deallocate the printf buffer
         if (hc::printf_buffer != nullptr) {
            // do a final flush
-           hc::processPrintfBuffer(hc::printf_buffer);
+           flushPrintfBuffer();
 
            hc::deletePrintfBuffer(hc::printf_buffer);
            hc::printf_buffer = nullptr;
@@ -3366,6 +3361,10 @@ public:
         uint64_t timestamp_frequency_hz = 0L;
         hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &timestamp_frequency_hz);
         return timestamp_frequency_hz;
+    }
+
+    void flushPrintfBuffer() override {
+      hc::processPrintfBuffer(hc::printf_buffer);
     }
 };
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -38,10 +38,10 @@
 #include "kalmar_runtime.h"
 #include "kalmar_aligned_alloc.h"
 
-#include <hc_am.hpp>
-
+#include "hc_am_internal.hpp"
 #include "unpinned_copy_engine.h"
 #include "hc_rt_debug.h"
+#include "hc_printf.hpp"
 
 #include <time.h>
 #include <iomanip>
@@ -269,6 +269,22 @@ static unsigned extractBits(unsigned v, unsigned pos, unsigned w)
 {
     return (v >> pos) & ((1 << w) - 1);
 };
+
+
+
+
+namespace hc {
+
+// printf buffer size (in number of packets, see hc_printf.hpp)
+constexpr unsigned int default_printf_buffer_size = 1024;
+
+// address of the global printf buffer in host coherent system memory
+PrintfPacket* printf_buffer = nullptr;
+
+// store the address of agent accessible hc::printf_buffer;
+PrintfPacket** gpu_printf_buffer_ptr = nullptr;
+
+} // namespace hc
 
 
 namespace Kalmar {
@@ -1333,6 +1349,11 @@ public:
         }
         // clear async operations table
         asyncOps.clear();
+
+        // flush the printf buffer
+        if (hc::printf_buffer != nullptr) {
+            processPrintfBuffer(hc::printf_buffer);
+        }
    }
 
     void LaunchKernel(void *ker, size_t nr_dim, size_t *global, size_t *local) override {
@@ -2953,6 +2974,12 @@ private:
                                            NULL, &hsaExecutable);
             STATUS_CHECK(status, __LINE__);
 
+            // Define the global symbol hc::printf_buffer with the actual address
+            status = hsa_executable_agent_global_variable_define(hsaExecutable, agent
+                                                            , "_ZN2hc13printf_bufferE"
+                                                            , hc::gpu_printf_buffer_ptr);
+            STATUS_CHECK(status, __LINE__);
+
 #if KALMAR_DEBUG
             dumpHSAAgentInfo(agent, "Loading code object ");
 #endif
@@ -3147,6 +3174,14 @@ public:
 
         signalPoolMutex.unlock();
 #endif
+
+        // initialize the printf buffer
+        if (hc::printf_buffer == nullptr) {
+          hc::printf_buffer = hc::createPrintfBuffer(hc::default_printf_buffer_size);
+          hc::gpu_printf_buffer_ptr = hc::internal::am_alloc_host_coherent(sizeof(void*));
+          *hc::gpu_printf_buffer_ptr = hc::printf_buffer;
+        }
+
         init_success = true;
     }
 
@@ -3276,6 +3311,17 @@ public:
 
         if (!init_success)
           return;
+
+        // deallocate the printf buffer
+        if (hc::printf_buffer != nullptr) {
+           // do a final flush
+           hc::processPrintfBuffer(hc::printf_buffer);
+
+           hc::deletePrintfBuffer(hc::printf_buffer);
+           hc::printf_buffer = nullptr;
+           hc::am_free(hc::gpu_printf_buffer_ptr);
+           hc::gpu_printf_buffer_ptr = nullptr;
+        }
 
         // destroy all KalmarDevices associated with this context
         for (auto dev : Devices)

--- a/lib/hsa/unpinned_copy_engine.cpp
+++ b/lib/hsa/unpinned_copy_engine.cpp
@@ -17,6 +17,9 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <cassert>
+#include <atomic>
+#include <hc.hpp>
 #include <hc_am.hpp>
 
 #include <hsa/hsa_ext_amd.h>

--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -8,29 +8,23 @@
 #define TILE (64)
 #define GLOBAL (TILE*2)
 
-#define PRINTF_BUFFER_SIZE (16384)
-
 int main() {
   using namespace hc;
 
-  accelerator acc = accelerator();
-  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
-
-  if (!printf_buf) {
-    std::printf("createPrintfBuffer failed.\n");
-  }
+  hc::array_view<hc::PrintfError,1> err(GLOBAL*2);
 
   parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
       const char* str1 = "Hello HC from %s: %03d\n";
       const char* str2 = "thread";
       const char* str3 = "Hello again from %s: %03d\n";
-      printf(printf_buf, str1, str2, tidx.global[0]);
-      printf(printf_buf, str3, "thread", tidx.global[0]);
+#if 1
+      err[tidx.global[0]*2] = printf(str1, str2, tidx.global[0]);
+      err[tidx.global[0]*2 + 1] = printf(str3, "thread", tidx.global[0]);
+#else
+      printf(str1, str2, tidx.global[0]);
+      printf(str3, "thread", tidx.global[0]);
+#endif
   }).wait();
-
-  processPrintfBuffer(printf_buf);
-
-  deletePrintfBuffer(printf_buf);
 
   return 0;
 }
@@ -41,7 +35,6 @@ int main() {
 // CHECK-DAG: Hello HC from thread: 063
 // CHECK-DAG: Hello HC from thread: 064
 // CHECK-DAG: Hello HC from thread: 127
-
 // CHECK-DAG: Hello again from thread: 000
 // CHECK-DAG: Hello again from thread: 063
 // CHECK-DAG: Hello again from thread: 064

--- a/tests/Unit/HSA/printf_error_check.cpp
+++ b/tests/Unit/HSA/printf_error_check.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -lhc_am -o %t.out && %t.out | %FileCheck %s
+// RUN: %hc %s -DCHECK_PRINTF_ERROR -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>
 #include <hc.hpp>

--- a/tests/Unit/HSA/printf_minimal.cpp
+++ b/tests/Unit/HSA/printf_minimal.cpp
@@ -3,41 +3,11 @@
 #include <hc.hpp>
 #include <hc_printf.hpp>
 
-#include <iostream>
-
-#define TILE (16)
-#define GLOBAL (TILE)
-
-#define PRINTF_BUFFER_SIZE (53)
-
 int main() {
-  using namespace hc;
-
-  accelerator acc = accelerator();
-  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
-
-  if (!printf_buf) {
-    std::printf("createPrintfBuffer failed.\n");
-  }
-
-  // Testing 16 threads with exact buffer size
-  // Each printf here 2 args + 1 counter = 3
-  // 3 args * 16 = 48 + 5 overhead = 53
-  parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
-      const char* str1 = "Thread %03d\n";
-      printf(printf_buf, str1, tidx.global[0]);
-  }).wait();
-
-  processPrintfBuffer(printf_buf);
-
-  deletePrintfBuffer(printf_buf);
-
+  hc::parallel_for_each(hc::extent<1>(1), []() [[hc]] {
+      hc::printf("Accelerator: Hello World!\n");
+  });
   return 0;
 }
 
-// CHECK-NOT: createPrintfBuffer failed.
-
-// CHECK-DAG: Thread 000
-// CHECK-DAG: Thread 007
-// CHECK-DAG: Thread 008
-// CHECK-DAG: Thread 015
+// CHECK: Accelerator: Hello World!

--- a/tests/Unit/HSA/printf_ptr_addr.cpp
+++ b/tests/Unit/HSA/printf_ptr_addr.cpp
@@ -5,35 +5,19 @@
 
 #include <iostream>
 
-#define TILE (16)
-#define GLOBAL (TILE)
-
-#define PRINTF_BUFFER_SIZE (256)
+#define GLOBAL (64)
 
 int main() {
-  using namespace hc;
-
-  accelerator acc = accelerator();
-  PrintfPacket* printf_buf = createPrintfBuffer(acc, PRINTF_BUFFER_SIZE);
-
-  if (!printf_buf) {
-    std::printf("createPrintfBuffer failed.\n");
-  }
 
   // Here we can print the string address with %p if we cast to (void*)
-  parallel_for_each(extent<1>(GLOBAL).tile(TILE), [=](tiled_index<1> tidx) [[hc]] {
+  hc::parallel_for_each(hc::extent<1>(GLOBAL), [=](hc::index<1> idx) [[hc]] {
       const char* str1 = "Thread: %03d, String Address: %p\n";
-      printf(printf_buf, str1, tidx.global[0], (void*)str1);
+      hc::printf(str1, idx[0], (void*)str1);
   }).wait();
-
-  processPrintfBuffer(printf_buf);
-
-  deletePrintfBuffer(printf_buf);
 
   return 0;
 }
 
-// CHECK-NOT: createPrintfBuffer failed.
 
 // CHECK-DAG: Thread: 000, String Address: [[ADDR:0x[0-9a-f]+]]
 // CHECK-DAG: Thread: 007, String Address: [[ADDR]]


### PR DESCRIPTION
- auto-initialization and deallocation of printf buffer
- use a global printf buffer; remove explicitly passing the printf buffer to printf as parameter
- process the printf buffer on the host when completion_future::wait() is called or before the printf buffer is deallocated
- pick up fixes for pfe lambda function