### PR TITLE
Integrate hcc-config as part of the driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/clang-tools-extra/CMakeLists.txt)
   set(LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR "${PROJECT_SOURCE_DIR}/clang-tools-extra")
 endif()
 
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/hcc_config")
 add_subdirectory(${CLANG_SRC_DIR})
 
 install(PROGRAMS $<TARGET_FILE:llvm-as>

--- a/amp-conformance/run_tests.pl.in
+++ b/amp-conformance/run_tests.pl.in
@@ -67,14 +67,12 @@ my $AMPTESTINC='@AMPTESTINC@';
 my $RUNTESTSDIR='@RUNTESTSDIR@';
 
 
+$ENV{'HCC_BUILD'}="1";
 my $CLANG_AMP="$CLANG_AMP_BUILD_DIR/compiler/bin/clang++";
-my $CLAMP_CONFIG=`find $CLANG_AMP_BUILD_DIR/bin -name clamp-config -print`;
-$CLAMP_CONFIG =~ s/^\s+//;
-$CLAMP_CONFIG =~ s/\s+$//;
-my $CLAMP_CXXFLAGS=`$CLAMP_CONFIG --build --cxxflags`;
+my $CLAMP_CXXFLAGS=" -std=c++amp";
 $CLAMP_CXXFLAGS =~ s/^\s+//;
 $CLAMP_CXXFLAGS =~ s/\s+$//;
-my $CLAMP_LDFLAGS=`$CLAMP_CONFIG --build --ldflags`;
+my $CLAMP_LDFLAGS=" -std=c++amp";
 $CLAMP_LDFLAGS =~ s/^\s+//;
 $CLAMP_LDFLAGS =~ s/\s+$//;
 my $SHARED_CXXFLAGS="$CLAMP_CXXFLAGS -I$AMPTESTINC -I/usr/include -I$CLANG_AMP_BUILD_DIR/compiler/lib/clang/5.0.0/include/";

--- a/amp-conformance/test_one.pl.in
+++ b/amp-conformance/test_one.pl.in
@@ -50,14 +50,12 @@ my $AMPTESTLIB="@AMPTESTLIB@";
 my $AMPTESTINC="@AMPTESTINC@";
 my $RUNTESTSDIR="@RUNTESTSDIR@";
 
+$ENV{'HCC_BUILD'}="1";
 my $CLANG_AMP="$CLANG_AMP_BUILD_DIR/compiler/bin/clang++";
-my $CLAMP_CONFIG=`find $CLANG_AMP_BUILD_DIR/bin -name clamp-config -print`;
-$CLAMP_CONFIG =~ s/^\s+//;
-$CLAMP_CONFIG =~ s/\s+$//;
-my $CLAMP_CXXFLAGS=`$CLAMP_CONFIG --build --cxxflags`;
+my $CLAMP_CXXFLAGS=" -std=c++amp";
 $CLAMP_CXXFLAGS =~ s/^\s+//;
 $CLAMP_CXXFLAGS =~ s/\s+$//;
-my $CLAMP_LDFLAGS=`$CLAMP_CONFIG --build --ldflags`;
+my $CLAMP_LDFLAGS=" -std=c++amp";
 $CLAMP_LDFLAGS =~ s/^\s+//;
 $CLAMP_LDFLAGS =~ s/\s+$//;
 my $SHARED_CXXFLAGS="$CLAMP_CXXFLAGS -I$AMPTESTINC -I/usr/include -I$CLANG_AMP_BUILD_DIR/compiler/lib/clang/5.0.0/include/";

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -43,6 +43,7 @@ if os.environ.get('HSA_TOOLS_LIB'):
 if os.environ.get('LD_LIBRARY_PATH'):
     config.environment['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH']
 
+config.environment['HCC_BUILD'] = "1"
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -76,22 +77,12 @@ def inferClang(PATH):
 
 cxx_options = ' ' + ' '.join([
   "-I%s" % config.gtest_src_dir,
-  "-DGTEST_HAS_TR1_TUPLE=0",
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--cxxflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
+  "-DGTEST_HAS_TR1_TUPLE=0"
 ]) + ' '
 
 link_options = ' ' + ' '.join([
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--ldflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
-  "-lpthread",
   ]) + ' '
+
 gtest_link_options = ' ' + ' '.join([
   "-lmcwamp_gtest",
 ]) + ' '


### PR DESCRIPTION
This change removes the need to use hcc-config when compiling with hcc. All of the options (except for 'hc' and 'std=c++amp') added by --cxxflags and --ldflags are now being included inside the hcc tool chain. To invoke hcc in build mode, instead of setting the --build flag in hcc-config, now it is required to set the HCC_BUILD environmental variable.