### PR TITLE
Adding back the "VLA removal" patch

### DIFF
--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -529,9 +529,8 @@ am_status_t am_map_to_peers(void* ptr, std::size_t num_peer, const hc::accelerat
             return AM_ERROR_MISC;
     }
 
-    const std::size_t max_agent = hc::accelerator::get_all().size();
-    hsa_agent_t agents[max_agent];
-  
+    std::vector<hsa_agent_t> agents{hc::accelerator::get_all().size()};
+
     int peer_count = 0;
 
     for(auto i = 0; i < num_peer; i++)
@@ -576,7 +575,7 @@ am_status_t am_map_to_peers(void* ptr, std::size_t num_peer, const hc::accelerat
     // allow access to the agents
     if(peer_count)
     {
-        hsa_status_t status = hsa_amd_agents_allow_access(peer_count, agents, NULL, ptr);
+        hsa_status_t status = hsa_amd_agents_allow_access(peer_count, agents.data(), NULL, ptr);
         return status == HSA_STATUS_SUCCESS ? AM_SUCCESS : AM_ERROR_MISC;
     }
    


### PR DESCRIPTION
https://github.com/RadeonOpenCompute/hcc/commit/7a9f924f8f1d28385db7b7d4e05ec648f16d924b#diff-0855eb741786f902183a16b1ebb25343

was mistakenly removed by my recent printf commit.  Adding the VLA removal patch back to hcc