### PR TITLE
Create a function to re-initialize the printf buffer 

### DIFF
--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -33,6 +33,18 @@ public:
     unsigned    _appAllocationFlags; ///< App-specific allocation flags.  (Used by HIP to store allocation flags)
     void *      _appPtr;             ///< App-specific pointer to additional information.
 
+    // creates a dummy copy of AmPointerInfo
+    AmPointerInfo() :
+        _hostPointer(nullptr),
+        _devicePointer(nullptr),
+        _unalignedDevicePointer(nullptr),
+        _sizeBytes(0),
+        _isInDeviceMem(false),
+        _isAmManaged(false),
+        _allocSeqNum(0),
+        _appId(-1),
+        _appAllocationFlags(0),
+        _appPtr(nullptr)  {};
 
     AmPointerInfo(void *hostPointer, void *devicePointer, void* unalignedDevicePointer, std::size_t sizeBytes, hc::accelerator &acc,  bool isInDeviceMem=false, bool isAmManaged=false) :
         _hostPointer(hostPointer),

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -554,6 +554,9 @@ public:
     /// get tick frequency
     virtual uint64_t getSystemTickFrequency() { return 0L; };
 
+    // initialize the printf buffer
+    virtual void initPrintfBuffer() {};
+
     // flush the device printf buffer
     virtual void flushPrintfBuffer() {};
 };

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -282,7 +282,7 @@ constexpr unsigned int default_printf_buffer_size = 2048;
 PrintfPacket* printf_buffer = nullptr;
 
 // store the address of agent accessible hc::printf_buffer;
-PrintfPacket** gpu_printf_buffer_ptr = nullptr;
+PrintfPacket** printf_buffer_locked_va = nullptr;
 
 } // namespace hc
 
@@ -2972,7 +2972,7 @@ private:
             // Define the global symbol hc::printf_buffer with the actual address
             status = hsa_executable_agent_global_variable_define(hsaExecutable, agent
                                                             , "_ZN2hc13printf_bufferE"
-                                                            , hc::gpu_printf_buffer_ptr);
+                                                            , hc::printf_buffer_locked_va);
             STATUS_CHECK(status, __LINE__);
 
 #if KALMAR_DEBUG
@@ -3054,6 +3054,8 @@ private:
     */
     hsa_agent_t host;
 
+    // GPU devices
+    std::vector<hsa_agent_t> agents;
 
     std::ofstream hccProfileFile; // if using a file open it here
     std::ostream *hccProfileStream = nullptr; // point at file or default stream
@@ -3137,7 +3139,6 @@ public:
         STATUS_CHECK(status, __LINE__);
 
         // Iterate over the agents to find out gpu device
-        std::vector<hsa_agent_t> agents;
         status = hsa_iterate_agents(&HSAContext::find_gpu, &agents);
         STATUS_CHECK(status, __LINE__);
 
@@ -3308,9 +3309,9 @@ public:
            flushPrintfBuffer();
 
            hc::deletePrintfBuffer(hc::printf_buffer);
-           hc::printf_buffer = nullptr;
-           hc::am_free(hc::gpu_printf_buffer_ptr);
-           hc::gpu_printf_buffer_ptr = nullptr;
+           status = hsa_amd_memory_unlock(&hc::printf_buffer);
+           STATUS_CHECK(status, __LINE__);
+           hc::printf_buffer_locked_va = nullptr;
         }
 
         // destroy all KalmarDevices associated with this context
@@ -3359,6 +3360,7 @@ public:
     }
 
     void initPrintfBuffer() override {
+
         if (hc::printf_buffer != nullptr) {
           // Check whether the printf buffer is still valid
           // because it may have been annihilated by HIP's hipDeviceReset().
@@ -3367,14 +3369,20 @@ public:
           am_status_t status = am_memtracker_getinfo(&info, hc::printf_buffer);
           if (status != AM_SUCCESS) {
             hc::printf_buffer = nullptr;
-            hc::gpu_printf_buffer_ptr = nullptr;
           }
         }
 
         if (hc::printf_buffer == nullptr) {
           hc::printf_buffer = hc::createPrintfBuffer(hc::default_printf_buffer_size);
-          hc::gpu_printf_buffer_ptr = hc::internal::am_alloc_host_coherent(sizeof(void*));
-          *hc::gpu_printf_buffer_ptr = hc::printf_buffer;
+        }
+
+        // pinned hc::printf_buffer so that the GPUs could access it
+        if (hc::printf_buffer_locked_va == nullptr) {
+          hsa_status_t status = HSA_STATUS_SUCCESS;
+          hsa_agent_t* hsa_agents = agents.data();
+          status = hsa_amd_memory_lock(&hc::printf_buffer, sizeof(hc::printf_buffer), 
+                                       hsa_agents, agents.size(), (void**)&hc::printf_buffer_locked_va);
+          STATUS_CHECK(status, __LINE__);
         }
     }
 


### PR DESCRIPTION
- HIP's hipDeviceReset() may destroy the printf buffer. Create a backdoor for HIP to re-initialize the printf buffer after a hipDeviceReset()

- pinned the pointer to the printf buffer instead of allocating another piece of coherent system memory of it, this removes one more item that could be destroyed by hipDeviceReset()