### PR TITLE
add missing header <random>

### DIFF
--- a/tests/Unit/Design/addr_space.cpp
+++ b/tests/Unit/Design/addr_space.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <amp_math.h>
+#include <random>
 
 using namespace concurrency;
 


### PR DESCRIPTION
test fails to compile on Fedora due to missing header