### PR TITLE
Fix unit tests aarch64

### DIFF
--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/1d.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/1d.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/PointerArrayElementType.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/PointerArrayElementType.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/PointerToPointer.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/PointerToPointer.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/bitfield.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/bitfield.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/bool_array.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/bool_array.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/char_array.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/char_array.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/function_pointer.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/function_pointer.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/function_reference.cpp
+++ b/tests/Unit/AutoRestricted/Negative/2_4_1_3_Comp_Type_Negative/function_reference.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/CXXThrowExpr.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/CXXThrowExpr.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/CXXTryStmt.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/CXXTryStmt.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Dtor_has_multiple_restrictions.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Dtor_has_multiple_restrictions.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/DynamicCastExpr.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/DynamicCastExpr.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Enum.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Enum.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/GotoStmt.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/GotoStmt.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/TypeidExpr.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/TypeidExpr.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Volatile.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/Volatile.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/Stmt_Cases/char_short_wchar_longlong_longdouble.cpp
+++ b/tests/Unit/AutoRestricted/Negative/Stmt_Cases/char_short_wchar_longlong_longdouble.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_mutable_keyword.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_mutable_keyword.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_and_mutable_keyword.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_and_mutable_keyword.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_keyword_1.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_keyword_1.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_keyword_2.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/after_throw_keyword_2.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/auto_in_function_prototype.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/auto_in_function_prototype.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_CV.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_CV.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_function_name.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_function_name.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_function_type.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/before_function_type.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/most_vexing_parse.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/most_vexing_parse.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/on_more_declarations.cpp
+++ b/tests/Unit/AutoRestricted/Negative/auto-on-wrong-place/on_more_declarations.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/diagnose_before_perform_inferring_CPU.cpp
+++ b/tests/Unit/AutoRestricted/Negative/diagnose_before_perform_inferring_CPU.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/infer_error_cpu.cpp
+++ b/tests/Unit/AutoRestricted/Negative/infer_error_cpu.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/AutoRestricted/Negative/restriction_inferred_should_have_no_non-auto-restriction_added.cpp
+++ b/tests/Unit/AutoRestricted/Negative/restriction_inferred_should_have_no_non-auto-restriction_added.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/Codegen/compile_error_for_arraytype.cpp
+++ b/tests/Unit/Codegen/compile_error_for_arraytype.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/InvalidLambda/empty_lambda2.cpp
+++ b/tests/Unit/InvalidLambda/empty_lambda2.cpp
@@ -8,15 +8,3 @@ int main()
     auto fun = [&]() restrict(cpu,amp) { return 0; };
     concurrency::parallel_for_each(gpu_resultsv.get_extent(), [=] (concurrency::index<1> idx) restrict (amp) { gpu_resultsv[idx] = fun(); });
 }
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Wrong scripts to cause "__ATTRIBUTE_CTOR__" without any identifier in kernel.cl
-//
-#if 0
-// R1UN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O3 -o %t.ll && mkdir -p %t
-// R1UN: %llc -march=c -o %t/kernel_.cl < %t.ll
-// R1UN: cat %opencl_math_dir/opencl_math.cl %t/kernel_.cl > %t/kernel.cl
-// R1UN: pushd %t && objcopy -B i386:x86-64 -I binary -O elf64-x86-64 kernel.cl %t/kernel.o && popd
-// R1UN: %cxxamp %link %t/kernel.o %s -o %t.out && %t.out
-#endif
-//////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/Unit/Overload/Negative/call_cpu_funtion_in_amp_function_or_lambda_or_pfe.cpp
+++ b/tests/Unit/Overload/Negative/call_cpu_funtion_in_amp_function_or_lambda_or_pfe.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/Overload/Negative/call_distinct_from_dual_context.cpp
+++ b/tests/Unit/Overload/Negative/call_distinct_from_dual_context.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/empty_restriction.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/empty_restriction.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/id_is_unrecognized.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/id_is_unrecognized.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/non-comma_between_ids.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/non-comma_between_ids.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/non-id_at_two_ends.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/non-id_at_two_ends.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/should_not_parse.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/should_not_parse.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the

--- a/tests/Unit/RestrictionSpecifier/Negative/space.cpp
+++ b/tests/Unit/RestrictionSpecifier/Negative/space.cpp
@@ -1,4 +1,4 @@
-// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -m32 -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
+// RUN: %amp_device -D__KALMAR_ACCELERATOR__ %s -emit-llvm -c -S -O2 -o %t.ll 2>&1 | %FileCheck --strict-whitespace %s
 
 //////////////////////////////////////////////////////////////////////////////////
 // Do not delete or add any line; it is referred to by absolute line number in the


### PR DESCRIPTION
Tests changed in this PR would fail on Ubuntu on `aarch64`. After some study it appears `-m32` have detrimental effect on `aarch64` system and standard C++ headers can't be found. Remove them this PR.

This PR won't affect test result on `x86_64`.