### PR TITLE
add the missing the array header

### DIFF
--- a/hc2/headers/functions/hsa_interfaces.hpp
+++ b/hc2/headers/functions/hsa_interfaces.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include <array>
 
 static
 inline


### PR DESCRIPTION
was discovered on CentOS because mcwamp_hsa.cpp failed to compile