### PR TITLE
Don't use hcc-config for unit tests

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -76,22 +76,12 @@ def inferClang(PATH):
 
 cxx_options = ' ' + ' '.join([
   "-I%s" % config.gtest_src_dir,
-  "-DGTEST_HAS_TR1_TUPLE=0",
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--cxxflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
+  "-DGTEST_HAS_TR1_TUPLE=0"
 ]) + ' '
 
 link_options = ' ' + ' '.join([
-  subprocess.Popen([
-      os.path.join(config.executable_output_path, 'clamp-config'),
-      "--build",
-      "--ldflags"],
-      stdout=subprocess.PIPE).communicate()[0].rstrip('\n'),
-  "-lpthread",
-  ]) + ' '
+]) + ' '
+
 gtest_link_options = ' ' + ' '.join([
   "-lmcwamp_gtest",
 ]) + ' '


### PR DESCRIPTION
This is a follow up change to https://github.com/RadeonOpenCompute/hcc-clang-upgrade/pull/100. 