### PR TITLE
Fix hybrid arch code object loading

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -341,6 +341,10 @@ extern "C" void PushArgPtrImpl(void *ker, int idx, size_t sz, const void *v);
 namespace Kalmar {
 class HSAQueue;
 class HSADevice;
+
+namespace CLAMP {
+  void LoadInMemoryProgram(KalmarQueue*);
+} // namespace CLAMP
 } // namespace Kalmar
 
 ///
@@ -2462,6 +2466,12 @@ public:
     }
 
     void* CreateKernel(const char* fun, Kalmar::KalmarQueue *queue) override {
+        // try load kernels lazily in case it was not done so at bootstrap
+        // due to HCC_LAZYINIT env var
+        if (executables.size() == 0) {
+          CLAMP::LoadInMemoryProgram(queue);
+        }
+
         std::string str(fun);
         HSAKernel *kernel = programs[str];
 

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -389,6 +389,8 @@ public:
     if (lazyinit_env != nullptr) {
       if (std::string("ON") == lazyinit_env) {
         to_init = false;
+      } else if (strtol(lazyinit_env, nullptr, 0)) {
+        to_init = false;
       }
     }
 

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -349,7 +349,7 @@ inline bool DetermineAndGetProgram(KalmarQueue* pQueue, size_t* kernel_size, voi
   return FoundCompatibleKernel;
 }
 
-void BuildProgram(KalmarQueue* pQueue) {
+void LoadInMemoryProgram(KalmarQueue* pQueue) {
   size_t kernel_size = 0;
   void* kernel_source = nullptr;
 
@@ -401,13 +401,14 @@ public:
 
       const std::vector<KalmarDevice*> devices = context->getDevices();
 
+      // load kernels on the default queue for each device
       for (auto dev = devices.begin(); dev != devices.end(); dev++) {
 
-        // get default queue on the default device
+        // get default queue on the device
         std::shared_ptr<KalmarQueue> queue = (*dev)->get_default_queue();
 
-        // build kernels on the default queue on the default device
-        CLAMP::BuildProgram(queue.get());
+        // load kernels on the default queue for the device
+        CLAMP::LoadInMemoryProgram(queue.get());
       }
     }
   }


### PR DESCRIPTION
This PR addresses a peculiar issue on machines with hybrid GPU targets (ex: `gfx803` + `gfx900`):

When a program is built to support only a particular GPU target, but not other available ones on the system, then it would fail to launch. This hinders development / testing for HCC/HIP applications which use assembly codes only available on certain targets.

The current behavior inside HCC runtime is:
 
- HCC runtime tries to eagerly do:
  - Initialize ROCR runtime at bootstrap
  - Load code objects for each agent
  - Aborts when there is no compatible code object found for an agent
- `HCC_LAZYINIT=ON` is broken right now as no code objects would then be ever loaded.

 
This PR changes the behavior of HCC runtime to:
- HCC runtime tries to eagerly:
  - initialize ROCR runtime at bootstrap
  - Load code objects for each agent, but don’t abort when there is no compatible code object for an agent
  - `HCC_LAZYINIT` defers above initialization until 1st kernel dispatch
- Try load code object at 1st kernel dispatch, on an agent in case it wasn’t done yet
- The program would still abort in `CreateKernel` in case incorrect agent is used to dispatch a kernel (ex: try run a binary with `gfx900`-only kernels on a `gfx803` agent).


No test case is given in this PR because although it's easy to come up one like: https://github.com/adityaatluri/gemm-vega64 , but it's hard to create a test environment for this configuration with hybrid targets for now.