### PR TITLE
Use hcc in scripts instead of clang

### DIFF
--- a/lib/hc-host-assemble.in
+++ b/lib/hc-host-assemble.in
@@ -14,7 +14,7 @@ then
 fi
 
 BINDIR=$(dirname "$0")
-CLANG=$BINDIR/clang
+CLANG=$BINDIR/hcc
 OPT=$BINDIR/opt
 LLVM_AS=$BINDIR/llvm-as
 LLVM_DIS=$BINDIR/llvm-dis

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -15,7 +15,7 @@ then
 fi
 
 BINDIR=$(dirname "$0")
-CLANG=$BINDIR/clang
+CLANG=$BINDIR/hcc
 LLVM_LINK=$BINDIR/llvm-link
 OPT=$BINDIR/opt
 LLVM_AS=$BINDIR/llvm-as


### PR DESCRIPTION
hcc is a symlink to clang, so this is effectively the same.  It also
makes it possible to install an hcc executable in the same bindir
as system clang.