### PR TITLE
Allow markers to be dependent on any command (not just markers)

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -869,8 +869,8 @@ public:
     std::shared_future<void>* getFuture() override { return future; }
     void acquire_scope(hc::memory_scope acquireScope) { _acquire_scope = acquireScope;};
 
-    bool barrierNextSyncNeedsSysRelease() const { return _barrierNextSyncNeedsSysRelease; };
-    bool barrierNextKernelNeedsSysAcquire() const { return _barrierNextKernelNeedsSysAcquire; };
+    bool barrierNextSyncNeedsSysRelease() const override { return _barrierNextSyncNeedsSysRelease; };
+    bool barrierNextKernelNeedsSysAcquire() const override { return _barrierNextKernelNeedsSysAcquire; };
 
 
     void setWaitMode(Kalmar::hcWaitMode mode) override {


### PR DESCRIPTION
if last command was copy we can make the marker depend hcc
will make the marker wait on the signal written by the copy.
So the HSABarrier::depAsyncOps[] now contains HSAOps not
just HSABarrier.  Refactor some other code to support this.