### PR TITLE
Vgrps limit

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4681,7 +4681,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 		}
 		workgroup_total_size = workgroup_size[0] * workgroup_size[1] * workgroup_size[2];
 	}
-	std::cout << "fixed workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] <<" " << workgroup_size[2] << std::endl;
+	std::cout << "cfixed workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] <<" " << workgroup_size[2] << std::endl;
 
 
     aql.workgroup_size_x = workgroup_size[0];

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4658,7 +4658,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 	if (max_num_vgprs_per_work_item < workitem_vgpr_count)
 	{
 		std::string msg = "The number of VGPRs (" + std::to_string(kernel->workitem_vgpr_count) + ") needed by this launch (" +
-			std::to_string(kernel->getKernelName()) + ") exceeds HW (" +
+			kernel->getKernelName() + ") exceeds HW (" +
 			std::to_string(max_num_vgprs_per_work_item) + ")";
 		throw Kalmar::runtime_exception(msg.c_str(), 0);
 	}

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4610,15 +4610,6 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     std::cerr << "dynamic group segment size: " << dynamicGroupSize << "\n";
 #endif
 
-	if (dims < 3)
-	{
-		globalDims[2] = 1;
-	}
-	if (dims < 2)
-	{
-		globalDims[1] = 1;
-	}
-
     // Set global dims:
     aql.grid_size_x = globalDims[0];
     aql.grid_size_y = (dims > 1 ) ? globalDims[1] : 1;
@@ -4630,7 +4621,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     int workgroup_size[3];
 
 	std::cout << "workgroup_max_dim = " << workgroup_max_dim[0] << " " << workgroup_max_dim[1] << " " << workgroup_max_dim[2] << "\n";
-	std::cout << "globalDims = " << globalDims[0] << " " << globalDims[1] << " " << globalDims[2] << "\n";
+	std::cout << "globalDims = " << aql.grid_size_x << " " << aql.grid_size_y << " " << aql.grid_size_z << "\n";
 
     workgroup_size[0] = computeLaunchAttr(globalDims[0], localDims[0], workgroup_max_dim[0]);
     workgroup_size[1] = (dims > 1) ? computeLaunchAttr(globalDims[1], localDims[1], workgroup_max_dim[1]) : 1;

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4621,8 +4621,8 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     const uint16_t* workgroup_max_dim = device->getWorkgroupMaxDim();
     int workgroup_size[3];
 
-	size_t gdimt[3] = { 1,1,1 };
-	size_t wkmaxdim[3] = { -1,-1,-1 };
+	int64_t gdimt[3] = { 1,1,1 };
+	int64_t wkmaxdim[3] = { -1,-1,-1 };
 	for (int i = 0; i < dims; i++)
 	{
 		gdimt[i] = globalDims[i];

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4657,7 +4657,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 
 	if (max_num_vgprs_per_work_item < workitem_vgpr_count)
 	{
-		msg = "The number of VGPRs (" + std::to_string(kernel->workitem_vgpr_count) + ") needed by this launch (" +
+		std::string msg = "The number of VGPRs (" + std::to_string(kernel->workitem_vgpr_count) + ") needed by this launch (" +
 			(kernel->getKernelName()) + ") exceeds HW (" +
 			max_num_vgprs_per_work_item + ")";
 		throw Kalmar::runtime_exception(msg.c_str(), 0);

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4621,16 +4621,6 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     const uint16_t* workgroup_max_dim = device->getWorkgroupMaxDim();
     int workgroup_size[3];
 
-	int64_t gdimt[3] = { 1,1,1 };
-	int64_t wkmaxdim[3] = { -1,-1,-1 };
-	for (int i = 0; i < dims; i++)
-	{
-		gdimt[i] = globalDims[i];
-		wkmaxdim[i] = workgroup_max_dim[i];
-	}
-
-	std::cout << "workgroup_max_dim = " << workgroup_max_dim[0] << " " << workgroup_max_dim[1] << " " << workgroup_max_dim[2] << "\n";
-	std::cout << "globalDims = " << gdimt[0] << " " << gdimt[1] << " " << gdimt[2] << "\n";
 
     workgroup_size[0] = computeLaunchAttr(globalDims[0], localDims[0], workgroup_max_dim[0]);
     workgroup_size[1] = (dims > 1) ? computeLaunchAttr(globalDims[1], localDims[1], workgroup_max_dim[1]) : 1;
@@ -4660,8 +4650,6 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
       workitem_vgpr_count = 1;
     size_t max_num_work_items_per_cu = (max_num_vgprs_per_work_item / workitem_vgpr_count) * num_work_items_per_simd * num_simds_per_cu;
 
-	std::cout << "num VGPRs = " << workitem_vgpr_count << std::endl;
-	std::cout << "workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] << " " << workgroup_size[2] << std::endl;
 
 	if (max_num_vgprs_per_work_item < workitem_vgpr_count)
 	{
@@ -4681,7 +4669,6 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 		}
 		workgroup_total_size = workgroup_size[0] * workgroup_size[1] * workgroup_size[2];
 	}
-	std::cout << "cfixed workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] <<" " << workgroup_size[2] << std::endl;
 
 
     aql.workgroup_size_x = workgroup_size[0];

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4610,11 +4610,19 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     std::cerr << "dynamic group segment size: " << dynamicGroupSize << "\n";
 #endif
 
+	if (dims < 3)
+	{
+		globalDims[2] = 1;
+	}
+	if (dims < 2)
+	{
+		globalDims[1] = 1;
+	}
+
     // Set global dims:
     aql.grid_size_x = globalDims[0];
     aql.grid_size_y = (dims > 1 ) ? globalDims[1] : 1;
     aql.grid_size_z = (dims > 2 ) ? globalDims[2] : 1;
-
 
     // Set group dims
     // for each workgroup dimension, make sure it does not exceed the maximum allowable limit
@@ -4653,7 +4661,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     size_t max_num_work_items_per_cu = (max_num_vgprs_per_work_item / workitem_vgpr_count) * num_work_items_per_simd * num_simds_per_cu;
 
 	std::cout << "num VGPRs = " << workitem_vgpr_count << std::endl;
-	std::cout << "workgroup_total_size = " << workgroup_total_size << std::endl;
+	std::cout << "workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] << " " << workgroup_size[2] << std::endl;
 
 	if (max_num_vgprs_per_work_item < workitem_vgpr_count)
 	{
@@ -4673,7 +4681,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 		}
 		workgroup_total_size = workgroup_size[0] * workgroup_size[1] * workgroup_size[2];
 	}
-	std::cout << "fixed workgroup_total_size = " << workgroup_total_size << std::endl;
+	std::cout << "fixed workgroup_size = " << workgroup_size[0] <<" " <<workgroup_size[1] <<" "<< workgroup_size[2] << std::endl;
 
 
     aql.workgroup_size_x = workgroup_size[0];

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4615,13 +4615,22 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
     aql.grid_size_y = (dims > 1 ) ? globalDims[1] : 1;
     aql.grid_size_z = (dims > 2 ) ? globalDims[2] : 1;
 
+
     // Set group dims
     // for each workgroup dimension, make sure it does not exceed the maximum allowable limit
     const uint16_t* workgroup_max_dim = device->getWorkgroupMaxDim();
     int workgroup_size[3];
 
+	size_t gdimt[3] = { 1,1,1 };
+	size_t wkmaxdim[3] = { -1,-1,-1 };
+	for (int i = 0; i < dims; i++)
+	{
+		gdimt[i] = globalDims[i];
+		wkmaxdim[i] = workgroup_max_dim[i];
+	}
+
 	std::cout << "workgroup_max_dim = " << workgroup_max_dim[0] << " " << workgroup_max_dim[1] << " " << workgroup_max_dim[2] << "\n";
-	std::cout << "globalDims = " << aql.grid_size_x << " " << aql.grid_size_y << " " << aql.grid_size_z << "\n";
+	std::cout << "globalDims = " << gdimt[0] << " " << gdimt[1] << " " << gdimt[2] << "\n";
 
     workgroup_size[0] = computeLaunchAttr(globalDims[0], localDims[0], workgroup_max_dim[0]);
     workgroup_size[1] = (dims > 1) ? computeLaunchAttr(globalDims[1], localDims[1], workgroup_max_dim[1]) : 1;
@@ -4672,7 +4681,7 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 		}
 		workgroup_total_size = workgroup_size[0] * workgroup_size[1] * workgroup_size[2];
 	}
-	std::cout << "fixed workgroup_size = " << workgroup_size[0] <<" " <<workgroup_size[1] <<" "<< workgroup_size[2] << std::endl;
+	std::cout << "fixed workgroup_size = " << workgroup_size[0] << " " << workgroup_size[1] <<" " << workgroup_size[2] << std::endl;
 
 
     aql.workgroup_size_x = workgroup_size[0];

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4658,8 +4658,8 @@ HSADispatch::setLaunchConfiguration(int dims, size_t *globalDims, size_t *localD
 	if (max_num_vgprs_per_work_item < workitem_vgpr_count)
 	{
 		std::string msg = "The number of VGPRs (" + std::to_string(kernel->workitem_vgpr_count) + ") needed by this launch (" +
-			(kernel->getKernelName()) + ") exceeds HW (" +
-			max_num_vgprs_per_work_item + ")";
+			std::to_string(kernel->getKernelName()) + ") exceeds HW (" +
+			std::to_string(max_num_vgprs_per_work_item) + ")";
 		throw Kalmar::runtime_exception(msg.c_str(), 0);
 	}
 


### PR DESCRIPTION
hello. 
I am japanese. so if there was any impolite words or poor English, please excuse me.
this pull request is very important. please consider.
 
I changed the fixing way of workgroup_size.

On the original code, we cannot run a kernel which use many VGPRs per work item.
because, although the original code have considered fixing workitem_size so that it will be in the limit number of workitem_max_dim, this have never made workgroup_size small.
As a result, it have made workitem_total_size 1024 in most cases.
For example, when workitem_total_size was set to 1024, we cannot use more than 64 VGPRs despite of the actual maximum VGPRs number of 256 on GCN architecture.

Most application such like Deep Leaning, FFT or Matrix operations would not need so many VGPRs. I supposed this is why no one mentioned about this problem. but in the Computational Fluid Dynamics, its code will be very complex and need many VGPRs. to run such a code, we have to reduce workgroup_size rather than VGPRs.

I would be the first person who run the Computational Fluid Dynamic code on ROCm.
best regards.