### PR TITLE
insert to a non-const iterator

### DIFF
--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -69,7 +69,7 @@ namespace hc2
                     std::copy_n(it, sizeof(y.cbuf), y.cbuf);
                     it += sizeof(y.cbuf);
 
-                    y.triple.insert(y.triple.cend(), it, it + y.triple_sz);
+                    y.triple.insert(y.triple.end(), it, it + y.triple_sz);
 
                     std::copy_n(
                         f + y.offset, y.bundle_sz, std::back_inserter(y.blob));


### PR DESCRIPTION
the range string::insert takes an iterator rather than a const_iterator as 1st argument 