### PR TITLE
add precheckin dependencies to auto-merge docker file

### DIFF
--- a/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
+++ b/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
@@ -2,11 +2,6 @@
 FROM ubuntu:16.04
 MAINTAINER David Salinas <david.salinas@amd.com>
 
-# Parameters related to building hcc-lc
-ARG rocm_install_path=/opt/rocm
-ARG rocm_build_path=/usr/local/src/hcc-lc
-ARG build_type=Release
-
 # Download and install an up to date version of cmake, because compiling
 # LLVM has implemented a requirement of cmake v3.4.4 or greater
 ARG cmake_prefix=/opt/cmake
@@ -21,6 +16,12 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \
     rocm-utils \
+    hcc hip_base hip_hcc \
+    gfortran gfortran-5 libgfortran-5-dev libgfortran3 \
+    libboost-program-options-dev \
+    libyaml-0-2 \
+    python2.7 python-yaml \
+    cmake-qt-gui cmake-curses-gui \
     file \
     build-essential \
     git \


### PR DESCRIPTION
I've added install dependencies for the precheckin tests (rocBLAS, rocFFT, rocRAND) to the docker file for the auto-upstream-merge tool.  This should allow us to avoid using "./install.sh -d" and just use "install.sh -ic".   We want to ensure that the tool, when it runs the precheckin tests, that the tests are using the "development" HCC/HIP it just built from the result of the upstream merge, and not the default installed hcc/hip