### PR TITLE
Make amp flag private

### DIFF
--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -39,7 +39,6 @@ macro(amp_target name )
   target_include_directories(${name} SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
   add_libcxx_option_if_needed(${name})
   target_compile_options(${name} PUBLIC -hc -fPIC)
-  target_compile_options(${name} PRIVATE -std=c++amp)
 
   # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
   # Otherwise, -gline-tables-only would override other existing debug flags

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -38,7 +38,8 @@ macro(amp_target name )
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})
   target_include_directories(${name} SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
   add_libcxx_option_if_needed(${name})
-  target_compile_options(${name} PUBLIC -hc -std=c++amp -fPIC)
+  target_compile_options(${name} PUBLIC -hc -fPIC)
+  target_compile_options(${name} PRIVATE -std=c++amp)
 
   # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
   # Otherwise, -gline-tables-only would override other existing debug flags


### PR DESCRIPTION
This is so users can set their own C++ version.
  