### PR TITLE
[DOCKER] install libnuma-dev since libhsakmt dependends on it

### DIFF
--- a/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
+++ b/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
@@ -55,6 +55,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     debianutils \
     cmake \
     libunwind-dev \
+    libnuma-dev \
     hsa-rocr-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -37,6 +37,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     debianutils \
     cmake \
     libunwind-dev \
+    libnuma-dev \
     hsa-rocr-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
new dependency introduced in rocm 1.7