### PR TITLE
workaround build issue on RHEL

### DIFF
--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -69,7 +69,7 @@ namespace hc2
                     std::copy_n(it, sizeof(y.cbuf), y.cbuf);
                     it += sizeof(y.cbuf);
 
-                    y.triple.append(it, it + y.triple_sz);
+                    y.triple.assign(it, it + y.triple_sz);
 
                     std::copy_n(
                         f + y.offset, y.bundle_sz, std::back_inserter(y.blob));

--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -69,7 +69,7 @@ namespace hc2
                     std::copy_n(it, sizeof(y.cbuf), y.cbuf);
                     it += sizeof(y.cbuf);
 
-                    y.triple.insert(y.triple.cend(), it, it + y.triple_sz);
+                    y.triple.append(it, it + y.triple_sz);
 
                     std::copy_n(
                         f + y.offset, y.bundle_sz, std::back_inserter(y.blob));


### PR DESCRIPTION
This is to workaround the issue that the new std::string implementation not being available on RHEL since their g++ is not using the C++11 ABI