### PR TITLE
[RUNTIME] fix potential undefined behavior in mutex locking / unlocking

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2288,6 +2288,8 @@ public:
                 if (rq->_hccQueue == nullptr) {
                     DBOUT(DB_QUEUE, "Found unused rocrQueue=" << rq << " for thief=" << thief << ".  hwQueue=" << rq->_hwQueue << "\n")
                     foundRQ = rq;
+                    // update the queue pointers to indicate the theft
+                    foundRQ->assignHccQueue(thief);
                     break;
                 }
             }
@@ -2295,8 +2297,6 @@ public:
             this->rocrQueuesMutex.unlock();
 
             if (foundRQ != nullptr) {
-                // update the queue pointers to indicate the theft
-                foundRQ->assignHccQueue(thief);
                 break; // while !foundRQ
             }
 
@@ -2315,6 +2315,8 @@ public:
                         assert (victimHccQueue->rocrQueue == rq);  // ensure the link is consistent.
                         victimHccQueue->rocrQueue = nullptr;
                         foundRQ = rq;
+                        // update the queue pointers to indicate the theft:
+                        foundRQ->assignHccQueue(thief);
                         DBOUT(DB_QUEUE, "Stole existing rocrQueue=" << rq << " from victimHccQueue=" << victimHccQueue << " to hccQueue=" << thief << "\n")
                         break; // for
                     }
@@ -2324,8 +2326,6 @@ public:
             this->rocrQueuesMutex.unlock();
 
             if (foundRQ != nullptr) {
-                // update the queue pointers to indicate the theft:
-                foundRQ->assignHccQueue(thief);
                 break; // while !foundRQ
             }
         }

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2260,64 +2260,74 @@ public:
     class UnpinnedCopyEngine      *copy_engine[2]; // one for each direction.
     UnpinnedCopyEngine::CopyMode  copy_mode;
 
-
     // Creates or steals a rocrQueue and returns it in theif->rocrQueue
     void createOrstealRocrQueue(Kalmar::HSAQueue *thief) {
+        RocrQueue *foundRQ = nullptr;
 
-        std::lock_guard<std::mutex> (this->rocrQueuesMutex);
+        this->rocrQueuesMutex.lock();
 
+        // Allocate a new queue when we are below the HCC_MAX_QUEUES limit
         if (rocrQueues.size() < HCC_MAX_QUEUES) {
+            foundRQ = new RocrQueue(agent, this->queue_size, thief);
+            rocrQueues.push_back(foundRQ);
+            DBOUT(DB_QUEUE, "Create new rocrQueue=" << foundRQ << " for thief=" << thief << "\n")
+        }
 
-            // Allocate a new queue, we are belowthe HCC_MAX_QUEUES limit :
-            //
+        this->rocrQueuesMutex.unlock();
 
-            auto rq = new RocrQueue(agent, this->queue_size, thief);
-            rocrQueues.push_back(rq);
+        if (foundRQ != nullptr)
+            return;
 
-            DBOUT(DB_QUEUE, "Create new rocrQueue=" << rq << " for thief=" << thief << "\n")
+        // Steal an unused queue when we reaches the limit
+        while (!foundRQ) {
 
-        } else {
-            RocrQueue *foundRQ = nullptr;
-            while (!foundRQ) {
-                // First make a pass to see if we can find an unused queue:
-                for (auto rq : rocrQueues) {
-                    if (rq->_hccQueue == nullptr) {
-                        DBOUT(DB_QUEUE, "Found unused rocrQueue=" << rq << " for thief=" << thief << ".  hwQueue=" << rq->_hwQueue << "\n")
-                        foundRQ = rq;
-                        break;
-                    }
+            this->rocrQueuesMutex.lock();
+
+            // First make a pass to see if we can find an unused queue
+            for (auto rq : rocrQueues) {
+                if (rq->_hccQueue == nullptr) {
+                    DBOUT(DB_QUEUE, "Found unused rocrQueue=" << rq << " for thief=" << thief << ".  hwQueue=" << rq->_hwQueue << "\n")
+                    foundRQ = rq;
+                    break;
                 }
-                if (!foundRQ) {
-                    for (auto rq : rocrQueues) {
-                        if (rq->_hccQueue != thief)  {
-                            auto victimHccQueue = rq->_hccQueue;
-                            // victimHccQueue==nullptr should be detected by above loop.
-                            std::lock_guard<std::mutex> (victimHccQueue->qmutex);
-                            if (victimHccQueue->isEmpty()) {
-                                DBOUT(DB_LOCK, " ptr:" << this << " lock_guard...\n");
-
-                                assert (victimHccQueue->rocrQueue == rq);  // ensure the link is consistent.
-                                victimHccQueue->rocrQueue = nullptr;
-                                foundRQ = rq;
-                                DBOUT(DB_QUEUE, "Stole existing rocrQueue=" << rq << " from victimHccQueue=" << victimHccQueue << " to hccQueue=" << thief << "\n")
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (foundRQ) {
-
-                    // update the queue pointers to indicate the theft:
-                    foundRQ->assignHccQueue(thief);
-
-                    break; // while !foundVictim
-                };
-
-                // Allow other threads a small window to release threads to make progress:
-                this->rocrQueuesMutex.unlock();
-                this->rocrQueuesMutex.lock();
             }
 
+            this->rocrQueuesMutex.unlock();
+
+            if (foundRQ != nullptr) {
+                // update the queue pointers to indicate the theft
+                foundRQ->assignHccQueue(thief);
+                break; // while !foundRQ
+            }
+
+            this->rocrQueuesMutex.lock();
+
+            // Second pass, try steal from a ROCR queue associated with an HCC queue, but with no active tasks
+
+            for (auto rq : rocrQueues) {
+                if (rq->_hccQueue != thief)  {
+                    auto victimHccQueue = rq->_hccQueue;
+                    // victimHccQueue==nullptr should be detected by above loop.
+                    std::lock_guard<std::mutex> (victimHccQueue->qmutex);
+                    if (victimHccQueue->isEmpty()) {
+                        DBOUT(DB_LOCK, " ptr:" << this << " lock_guard...\n");
+
+                        assert (victimHccQueue->rocrQueue == rq);  // ensure the link is consistent.
+                        victimHccQueue->rocrQueue = nullptr;
+                        foundRQ = rq;
+                        DBOUT(DB_QUEUE, "Stole existing rocrQueue=" << rq << " from victimHccQueue=" << victimHccQueue << " to hccQueue=" << thief << "\n")
+                        break; // for
+                    }
+                }
+            }
+
+            this->rocrQueuesMutex.unlock();
+
+            if (foundRQ != nullptr) {
+                // update the queue pointers to indicate the theft:
+                foundRQ->assignHccQueue(thief);
+                break; // while !foundRQ
+            }
         }
     };
 


### PR DESCRIPTION
In the function changed in this commit, originally an RAII lock_guard is
present for a mutex. And in the later part of the function the unlock/lock
member functions of the mutex are directly invoked. Such codes is not ideal.

It was also proven certain user codes would run into soft hang situation.

In this commit we remove the lock_guard and always use lock/unlock member
function calls. The user codes affected above have been proven to run.