### PR TITLE
Use Binary IR avoids LL non-GlobalValue limit

### DIFF
--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -88,20 +88,20 @@ if [ -f "$2" ]; then
   mv "$2" "$TEMP_DIR/$BASENAME.tmp.o"
 fi
 
-$LLVM_DIS "$KERNEL_INPUT" -o "$TEMP_NAME.ll"
+cp $KERNEL_INPUT "$TEMP_NAME.bc"
 if [ $KMDUMPLLVM == "1" ]; then
+  $LLVM_DIS "$TEMP_NAME.bc" -o "$TEMP_NAME.ll"
   cp "$TEMP_NAME.ll" ./dump.kernel_input.ll
 fi
-$OPT -load $LIBPATH/LLVMDirectFuncCall.so -redirect < "$TEMP_NAME.ll" 2>"$TEMP_NAME.kernel_redirect.ll" >/dev/null
+$OPT -load $LIBPATH/LLVMDirectFuncCall.so -redirect < "$TEMP_NAME.bc" 2>"$TEMP_NAME.kernel_redirect.bc" >/dev/null
 if [ $KMDUMPLLVM == "1" ]; then
-  cp "$TEMP_NAME.kernel_redirect.ll" ./dump.kernel_redirect.ll
+  cp "$TEMP_NAME.kernel_redirect.bc" ./dump.kernel_redirect.bc
 fi
-if [[ -s "$TEMP_NAME.kernel_redirect.ll" ]]; then
-  $OPT -load $LIBPATH/LLVMWrapperGen.so -gensrc < "$TEMP_NAME.ll" 2>"$TEMP_NAME.camp.cpp" >/dev/null
+if [[ -s "$TEMP_NAME.kernel_redirect.bc" ]]; then
+  $OPT -load $LIBPATH/LLVMWrapperGen.so -gensrc < "$TEMP_NAME.bc" 2>"$TEMP_NAME.camp.cpp" >/dev/null
   if [ $KMDUMPLLVM == "1" ]; then
     cp "$TEMP_NAME.camp.cpp" ./dump.kernel_camp.cpp
   fi
-  $LLVM_AS "$TEMP_NAME.kernel_redirect.ll" -o "$TEMP_NAME.kernel_redirect.bc"
   $CLANG $CXXFLAGS "$TEMP_NAME.camp.cpp" $CO "$TEMP_NAME.camp.s" -emit-llvm
   $CLANG $CXXFLAGS "$TEMP_NAME.camp.cpp" $CO "$TEMP_NAME.camp.o"
   objcopy -R .kernel "$TEMP_NAME.camp.o"


### PR DESCRIPTION
hc-kernel-assemble.in should use binary IR instead of text IR for the hc-kernel-assemble.in script. Since the build process should not be using .LL files (unless needing to dump IR). This was reveal in recent upstream merge which set limits on non-GlobalValue name lengths which only exists for text LL files.

This is a fix for an MIOpen build issue. When using text IR, the LLParser will truncate names that are larger than NonGlobalValueMaxNameSize, therefore multiple names may conflict due to multiple definitions of local value is not allowed.

The root issue is that recently LLVM upstream has a patch to set name size limit (<1024) on non-GlobalValue names. Therefore, for some of the MIOpen kernels, optimizations created variable names that are more than 1024 characters long which gets truncated into 1024 characters. The link-time passes will then complain in the LLParser that there are multiple definitions of the same local value name, since many names share similar prefix before truncated. We should be using binary IR in our build process.