### PR TITLE
mark all grid launch tests with XFAIL to ignore them

### DIFF
--- a/tests/Unit/Codegen/grid_launch_attribute.cpp
+++ b/tests/Unit/Codegen/grid_launch_attribute.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %cxxamp %s -emit-llvm -S -o -|%FileCheck %s
 
 // dummy grid_launch_parm type used to satisfy hc_grid_launch requirement

--- a/tests/Unit/GridLaunch/accelerator_view.cpp
+++ b/tests/Unit/GridLaunch/accelerator_view.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "grid_launch.hpp"

--- a/tests/Unit/GridLaunch/char_argument.cpp
+++ b/tests/Unit/GridLaunch/char_argument.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "grid_launch.hpp"

--- a/tests/Unit/GridLaunch/completion_future.cpp
+++ b/tests/Unit/GridLaunch/completion_future.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/customtype_byptr.cpp
+++ b/tests/Unit/GridLaunch/customtype_byptr.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/customtype_byval.cpp
+++ b/tests/Unit/GridLaunch/customtype_byval.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/customtype_byval_char.cpp
+++ b/tests/Unit/GridLaunch/customtype_byval_char.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "grid_launch.hpp"

--- a/tests/Unit/GridLaunch/glp_const.cpp
+++ b/tests/Unit/GridLaunch/glp_const.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/glp_first_arg.cpp
+++ b/tests/Unit/GridLaunch/glp_first_arg.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -c -o %t.out 2>&1 | %FileCheck %s
 
 #include "hc.hpp"

--- a/tests/Unit/GridLaunch/glp_ref_arg.cpp
+++ b/tests/Unit/GridLaunch/glp_ref_arg.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc -lhc_am %s -c -o %t.out 2>&1 | %FileCheck %s
 
 #include "hc.hpp"

--- a/tests/Unit/GridLaunch/glp_typedef.cpp
+++ b/tests/Unit/GridLaunch/glp_typedef.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/hc_attr.cpp
+++ b/tests/Unit/GridLaunch/hc_attr.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/hc_attr_cxx11.cpp
+++ b/tests/Unit/GridLaunch/hc_attr_cxx11.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 

--- a/tests/Unit/GridLaunch/hc_attr_cxx11_static_function.cpp
+++ b/tests/Unit/GridLaunch/hc_attr_cxx11_static_function.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 

--- a/tests/Unit/GridLaunch/hc_attr_in_struct.cpp
+++ b/tests/Unit/GridLaunch/hc_attr_in_struct.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "hc.hpp"

--- a/tests/Unit/GridLaunch/hc_attr_static_function.cpp
+++ b/tests/Unit/GridLaunch/hc_attr_static_function.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/linkobj.cpp
+++ b/tests/Unit/GridLaunch/linkobj.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc %s -DFILE_1 -c -o %t1.o && %hc %s -DFILE_2 -c -o %t2.o && %hc %t1.o %t2.o -lhc_am -o %t1.out && %t1.out
 // RUN: %hc -lhc_am %s -DFILE_1 -DFILE_2 -o %t2.out && %t2.out
 

--- a/tests/Unit/GridLaunch/rect_tiles.cpp
+++ b/tests/Unit/GridLaunch/rect_tiles.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 // FIXME: GridLaunch tests would hang HSA dGPU if executed in multi-thread

--- a/tests/Unit/GridLaunch/register-control.cpp
+++ b/tests/Unit/GridLaunch/register-control.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out -Xlinker -dump-llvm -Xlinker -dump-dir=%T %target_all_gpus
 // RUN: %llvm-dis %T/dump-gfx803.opt.bc -f -o - | %FileCheck %s
 // RUN: %t.out

--- a/tests/Unit/GridLaunch/short_kernarg.cpp
+++ b/tests/Unit/GridLaunch/short_kernarg.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "grid_launch.hpp"

--- a/tests/Unit/GridLaunch/short_vector_int4.cpp
+++ b/tests/Unit/GridLaunch/short_vector_int4.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 // RUN: %t.out
 

--- a/tests/Unit/GridLaunch/union.cpp
+++ b/tests/Unit/GridLaunch/union.cpp
@@ -1,4 +1,4 @@
-
+// XFAIL: *
 // RUN: %hc -lhc_am %s -o %t.out && %t.out
 
 #include "hc.hpp"


### PR DESCRIPTION
first step towards the removal of the grid launch mode