### PR TITLE
Detect invalid tiled_extent

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4651,6 +4651,11 @@ HSADispatch::setLaunchConfiguration(const int dims, size_t *globalDims, size_t *
           msg << "The extent of the tile (" << localDims[i] 
               << ") exceeds the device limit (" << workgroup_max_dim[i] << ").";
           throw Kalmar::runtime_exception(msg.str().c_str(), -1);
+        } else if (localDims[i] > globalDims[i]) {
+          std::stringstream msg;
+          msg << "The extent of the tile (" << localDims[i] 
+              << ") exceeds the compute grid extent (" << globalDims[i] << ").";
+          throw Kalmar::runtime_exception(msg.str().c_str(), -1);
         }
         workgroup_size[i] = localDims[i];
       }

--- a/tests/Unit/HC/wg_size_unsupported4.cpp
+++ b/tests/Unit/HC/wg_size_unsupported4.cpp
@@ -1,0 +1,35 @@
+// RUN: %hc %s -o %t.out && %t.out
+
+#include <hc.hpp>
+#include <string>
+#include <iostream>
+
+int main() {
+  bool pass = false;
+
+  try  {
+    hc::parallel_for_each(hc::extent<3>(16,16,16).tile(32,1,1), [](hc::tiled_index<3> i) [[hc]] {});
+  } catch (Kalmar::runtime_exception e) {
+    std::string err_str = e.what();
+    pass = err_str.find("The extent of the tile") != std::string::npos &&
+    err_str.find("exceeds the compute grid extent") != std::string::npos;
+  }
+
+  try  {
+    hc::parallel_for_each(hc::extent<3>(16,16,16).tile(1,32,1), [](hc::tiled_index<3> i) [[hc]] {});
+  } catch (Kalmar::runtime_exception e) {
+    std::string err_str = e.what();
+    pass = err_str.find("The extent of the tile") != std::string::npos &&
+    err_str.find("exceeds the compute grid extent") != std::string::npos;
+  }
+
+  try  {
+    hc::parallel_for_each(hc::extent<3>(16,16,16).tile(1,1,32), [](hc::tiled_index<3> i) [[hc]] {});
+  } catch (Kalmar::runtime_exception e) {
+    std::string err_str = e.what();
+    pass = err_str.find("The extent of the tile") != std::string::npos &&
+    err_str.find("exceeds the compute grid extent") != std::string::npos;
+  }
+
+  return pass==true?0:1;
+}


### PR DESCRIPTION
Launching a kernel with a group dimension
larger than the grid dimension
(ex: grid size 16x16 with a group size 32x1),
is invalid but currently the hcc runtime
doesn't detect this siutation.  This patch
adds the detection logic and would throw
an exception when this happens