### PR TITLE
fix opt level unit test

### DIFF
--- a/tests/Unit/Codegen/opt_level0.cpp
+++ b/tests/Unit/Codegen/opt_level0.cpp
@@ -39,4 +39,4 @@ int main(void)
     return 0;
 }
 
-// CHECK: clang-{{[0-9]}}.{{[0-9]}}: warning: -O0 is ignored in GPU compilation path
+// CHECK: clang-{{[0-9]}}{{(.[0-9])?}}: warning: -O0 is ignored in GPU compilation path

--- a/tests/Unit/Codegen/opt_level1.cpp
+++ b/tests/Unit/Codegen/opt_level1.cpp
@@ -39,4 +39,4 @@ int main(void)
     return 0;
 }
 
-// CHECK: clang-{{[0-9]}}.{{[0-9]}}: warning: -O1 is ignored in GPU compilation path
+// CHECK: clang-{{[0-9]}}{{(.[0-9])?}}: warning: -O1 is ignored in GPU compilation path


### PR DESCRIPTION
makes the clang minor version string optional in the warning message