### PR TITLE
Fix new gfx target naming convention

### DIFF
--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -131,42 +131,56 @@ namespace hc2
     constexpr const char Bundled_code_header::magic_string[];
 
     inline
-    hsa_isa_t triple_to_hsa_isa(const std::string& triple)
+    std::string transmogrify_triple(const std::string& triple)
     {
-      static constexpr const char OffloadKind[] = "hcc-";
-      hsa_isa_t Isa = {0};
+        static constexpr const char old_prefix[]{"hcc-amdgcn--amdhsa-gfx"};
+        static constexpr const char new_prefix[]{"hcc-amdgcn-amd-amdhsa--gfx"};
 
-      // Check that Triple larger than hcc- and the prefix matches hcc-
-      if ((triple.size() < sizeof(OffloadKind) - 1) || !std::equal(triple.c_str(),  triple.c_str() + sizeof(OffloadKind) - 1, OffloadKind)) {
-        return Isa;
-      }
-
-      std::string validatedTriple = triple.substr(sizeof(OffloadKind) - 1);
-      static constexpr const char newPrefix[] = "amdgcn-amd-amdhsa--gfx";
-
-      // Check if the target triple matches the new prefix
-      if ((validatedTriple.size() >= sizeof(newPrefix) - 1) && std::equal(validatedTriple.c_str(), validatedTriple.c_str() + sizeof(newPrefix) - 1, newPrefix)) {
-        if (HSA_STATUS_SUCCESS != hsa_isa_from_name(validatedTriple.c_str(), &Isa)) {
-          // If new prefix fails, try older prefix incase of older ROCR
-          // Supports backwards compatibility with old naming
-          Isa = {};
-          auto it = std::find_if(
-              validatedTriple.cbegin(),
-              validatedTriple.cend(),
-              [](char x) { return std::isdigit(x); });
-          if (std::equal(validatedTriple.cbegin(), it, newPrefix)) {
-            std::string tmp = "AMD:AMDGPU";
-            while (it != validatedTriple.cend()) {
-                tmp.push_back(':');
-                tmp.push_back(*it++);
-            }
-            if (HSA_STATUS_SUCCESS != hsa_isa_from_name(tmp.c_str(), &Isa)) {
-              // If it also fails, then unsupported target triple
-              Isa.handle = 0;
-            }
-          }
+        if (triple.find(old_prefix) == 0) {
+            return new_prefix + triple.substr(sizeof(old_prefix) - 1);
         }
-      }
-      return Isa;
+
+        return (triple.find(new_prefix) == 0) ? triple : "";
+    }
+
+    inline
+    std::string isa_name(std::string triple)
+    {
+        static constexpr const char offload_prefix[]{"hcc-"};
+
+        triple = transmogrify_triple(triple);
+        if (triple.empty()) return {};
+
+        triple.erase(0, sizeof(offload_prefix) - 1);
+
+        static hsa_isa_t tmp{};
+        static const bool is_old_rocr{
+            hsa_isa_from_name(triple.c_str(), &tmp) != HSA_STATUS_SUCCESS};
+
+        if (is_old_rocr) {
+             auto tmp{triple.substr(triple.rfind('x') + 1)};
+            triple.replace(0, std::string::npos, "AMD:AMDGPU");
+
+            for (auto&& x : tmp) {
+                triple.push_back(':');
+                triple.push_back(x);
+           }
+        }
+
+         return triple;
+    }
+
+    inline
+    hsa_isa_t triple_to_hsa_isa(std::string triple)
+    {
+        const auto isa{isa_name(std::move(triple))};
+
+        if (isa.empty()) return hsa_isa_t({});
+
+        hsa_isa_t r{};
+        throwing_hsa_result_check(
+            hsa_isa_from_name(isa.c_str(), &r), __FILE__, __func__, __LINE__);
+
+        return r;
     }
 }

--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -136,25 +136,37 @@ namespace hc2
       static constexpr const char OffloadKind[] = "hcc-";
       hsa_isa_t Isa = {0};
 
-      // Check that Triple larger than hcc- and the prefix is hcc-
+      // Check that Triple larger than hcc- and the prefix matches hcc-
       if ((triple.size() < sizeof(OffloadKind) - 1) || !std::equal(triple.c_str(),  triple.c_str() + sizeof(OffloadKind) - 1, OffloadKind)) {
         return Isa;
       }
 
       std::string validatedTriple = triple.substr(sizeof(OffloadKind) - 1);
-      static constexpr const char oldPrefix[] = "amdgcn--amdhsa-gfx";
       static constexpr const char newPrefix[] = "amdgcn-amd-amdhsa--gfx";
 
-      // Check triple size and if the triple matches the old prefix
-      if ((validatedTriple.size() >= sizeof(oldPrefix) - 1) && std::equal(validatedTriple.c_str(), validatedTriple.c_str() + sizeof(oldPrefix) - 1, oldPrefix)) {
-        // Support backwards compatibility with old naming.
-        validatedTriple = newPrefix + validatedTriple.substr(sizeof(oldPrefix) - 1);
+      // Check if the target triple matches the new prefix
+      if ((validatedTriple.size() >= sizeof(newPrefix) - 1) && std::equal(validatedTriple.c_str(), validatedTriple.c_str() + sizeof(newPrefix) - 1, newPrefix)) {
+        if (HSA_STATUS_SUCCESS != hsa_isa_from_name(validatedTriple.c_str(), &Isa)) {
+          // If new prefix fails, try older prefix incase of older ROCR
+          // Supports backwards compatibility with old naming
+          Isa = {};
+          auto it = std::find_if(
+              validatedTriple.cbegin(),
+              validatedTriple.cend(),
+              [](char x) { return std::isdigit(x); });
+          if (std::equal(validatedTriple.cbegin(), it, newPrefix)) {
+            std::string tmp = "AMD:AMDGPU";
+            while (it != validatedTriple.cend()) {
+                tmp.push_back(':');
+                tmp.push_back(*it++);
+            }
+            if (HSA_STATUS_SUCCESS != hsa_isa_from_name(tmp.c_str(), &Isa)) {
+              // If it also fails, then unsupported target triple
+              Isa.handle = 0;
+            }
+          }
+        }
       }
-
-      if (HSA_STATUS_SUCCESS != hsa_isa_from_name(validatedTriple.c_str(), &Isa)) {
-        Isa.handle = 0;
-      }
-
       return Isa;
     }
 }

--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -133,7 +133,7 @@ namespace hc2
     inline
     hsa_isa_t triple_to_hsa_isa(const std::string& triple)
     {
-        static constexpr const char gfxip[] = "hcc-amdgcn--amdhsa-gfx";
+        static constexpr const char gfxip[] = "amdgcn-amd-amdhsa--gfx";
 
         hsa_isa_t r = {};
 
@@ -142,9 +142,8 @@ namespace hc2
             triple.cend(),
             [](char x) { return std::isdigit(x); });
         if (std::equal(triple.cbegin(), it, gfxip)) {
-            std::string tmp = "AMD:AMDGPU";
+            std::string tmp = "amdgcn-amd-amdhsa--gfx";
             while (it != triple.cend()) {
-                tmp.push_back(':');
                 tmp.push_back(*it++);
             }
 

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -206,7 +206,7 @@ _thinlto_path() {
 
     # augment arguments to clang-offload-bundler
     CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$KERNEL-$AMDGPU_TARGET.hsaco"
-    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"
+    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn-amd-amdhsa--$AMDGPU_TARGET"
     i+=1
   done
 }
@@ -241,7 +241,7 @@ _default_path() {
 
     # augment arguments to clang-offload-bundler
     CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco"
-    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn--amdhsa-$AMDGPU_TARGET"
+    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn-amd-amdhsa--$AMDGPU_TARGET"
   done
 
   # collect all the error codes from forked processes

--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -100,8 +100,8 @@ else {
     }
 
     # Only process GPU targets, skip host targets
-    if ($Triple =~ /^hcc-amdgcn--amdhsa-/) {
-      my $asic_target = substr($Triple, 19); # hcc-amdgcn--amdhsa-
+    if ($Triple =~ /^hcc-amdgcn-amd-amdhsa--/) {
+      my $asic_target = substr($Triple, 19); # hcc-amdgcn-amd-amdhsa--
       #print("GPU target: " . $asic_target . "\n");
 
       # augment arguments for clang-offload-bundler

--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -101,7 +101,7 @@ else {
 
     # Only process GPU targets, skip host targets
     if ($Triple =~ /^hcc-amdgcn-amd-amdhsa--/) {
-      my $asic_target = substr($Triple, 19); # hcc-amdgcn-amd-amdhsa--
+      my $asic_target = substr($Triple, 23); # hcc-amdgcn-amd-amdhsa--
       #print("GPU target: " . $asic_target . "\n");
 
       # augment arguments for clang-offload-bundler

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -265,8 +265,8 @@ static inline uint64_t Read8byteIntegerFromBuffer(const char *data, size_t pos) 
 
 #define OFFLOAD_BUNDLER_MAGIC_STR "__CLANG_OFFLOAD_BUNDLE__"
 #define OFFLOAD_BUNDLER_MAGIC_STR_LENGTH (24)
-#define HCC_TRIPLE_PREFIX "hcc-amdgcn--amdhsa-"
-#define HCC_TRIPLE_PREFIX_LENGTH (19)
+#define HCC_TRIPLE_PREFIX "hcc-amdgcn-amd-amdhsa--"
+#define HCC_TRIPLE_PREFIX_LENGTH (23)
 
 // Try determine a compatible code object within kernel bundle for a queue
 // Returns true if a compatible code object is found, and returns its size and


### PR DESCRIPTION
This was introduced in recent xnack changes naming changes which affected our offload bundler. This patch will fix issues in HIP samples, ROCR tests, and others. Related to internal issues SWDEV-150756, SWDEV-149306.