### PR TITLE
Fix throwing exception for RT old target queries

### DIFF
--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -175,9 +175,9 @@ namespace hc2
     {
         const auto isa{isa_name(std::move(triple))};
 
-        if (isa.empty()) return hsa_isa_t({});
-
         hsa_isa_t r{};
+        if (isa.empty()) return r;
+
         if(HSA_STATUS_SUCCESS != hsa_isa_from_name(isa.c_str(), &r)) {
             r.handle = 0;
         }

--- a/hc2/headers/types/code_object_bundle.hpp
+++ b/hc2/headers/types/code_object_bundle.hpp
@@ -178,8 +178,9 @@ namespace hc2
         if (isa.empty()) return hsa_isa_t({});
 
         hsa_isa_t r{};
-        throwing_hsa_result_check(
-            hsa_isa_from_name(isa.c_str(), &r), __FILE__, __func__, __LINE__);
+        if(HSA_STATUS_SUCCESS != hsa_isa_from_name(isa.c_str(), &r)) {
+            r.handle = 0;
+        }
 
         return r;
     }


### PR DESCRIPTION
For backwards compatibility across different ROCm runtimes, we want to allow queries of older gfx targets instead of throwing an exception. It may be better to return a NULL isa_t. This is related to SWDEV-149306