### PR TITLE
Unpinned copy engine: wait for the dependent signal before entering the critical section

### DIFF
--- a/lib/hsa/unpinned_copy_engine.cpp
+++ b/lib/hsa/unpinned_copy_engine.cpp
@@ -154,47 +154,58 @@ UnpinnedCopyEngine::~UnpinnedCopyEngine()
 //IN: waitFor - hsaSignal to wait for - the copy will begin only when the specified dependency is resolved.  May be NULL indicating no dependency.
 void UnpinnedCopyEngine::CopyHostToDevicePinInPlace(void* dst, const void* src, size_t sizeBytes, const hsa_signal_t *waitFor)
 {
-    std::lock_guard<std::mutex> l (_copyLock);
-    DBOUTL (DB_COPY2, __func__ << DBPARM(dst) << "," << DBPARM(src) << "," << DBPARM(sizeBytes))
+    if (waitFor)
+        hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
-    const char *srcp = static_cast<const char*> (src);
-    char *dstp = static_cast<char*> (dst);
+    // Make sure we wait for the dependent signal to complete before entering the critical section
+    // to avoid potential dead lock
+    {
+        std::lock_guard<std::mutex> l(_copyLock);
+        DBOUTL(DB_COPY2, __func__ << DBPARM(dst) << "," << DBPARM(src) << "," << DBPARM(sizeBytes))
 
-    for (int i=0; i<_numBuffers; i++) {
-        hsa_signal_store_release(_completionSignal[i], 0);
+        const char *srcp = static_cast<const char *>(src);
+        char *dstp = static_cast<char *>(dst);
+
+        for (int i = 0; i < _numBuffers; i++)
+        {
+            hsa_signal_store_release(_completionSignal[i], 0);
+        }
+
+        if (sizeBytes >= UINT64_MAX / 2)
+        {
+            THROW_ERROR(hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+        }
+        int bufferIndex = 0;
+
+        size_t theseBytes = sizeBytes;
+        //tprintf (DB_COPY2, "H2D: waiting... on completion signal handle=%lu\n", _completionSignal[bufferIndex].handle);
+        //hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+
+        //void * masked_srcp = (void*) ((uintptr_t)srcp & (uintptr_t)(~0x3f)) ; // TODO
+        void *locked_srcp;
+        //hsa_status_t hsa_status = hsa_amd_memory_lock(masked_srcp, theseBytes, &_hsaAgent, 1, &locked_srcp);
+        hsa_status_t hsa_status = hsa_amd_memory_lock(const_cast<char *>(srcp), theseBytes, &_hsaAgent, 1, &locked_srcp);
+        //tprintf (DB_COPY2, "H2D: bytesRemaining=%zu: pin-in-place:%p+%zu bufferIndex[%d]\n", bytesRemaining, srcp, theseBytes, bufferIndex);
+        //printf ("status=%x srcp=%p, masked_srcp=%p, locked_srcp=%p\n", hsa_status, srcp, masked_srcp, locked_srcp);
+
+        if (hsa_status != HSA_STATUS_SUCCESS)
+        {
+            THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
+        }
+
+        hsa_signal_store_release(_completionSignal[bufferIndex], 1);
+
+        hsa_status = hsa_amd_memory_async_copy(dstp, _hsaAgent, locked_srcp, _hsaAgent, theseBytes, 0, nullptr, _completionSignal[bufferIndex]);
+        //tprintf (DB_COPY2, "H2D: bytesRemaining=%zu: async_copy %zu bytes %p to %p status=%x\n", bytesRemaining, theseBytes, _pinnedStagingBuffer[bufferIndex], dstp, hsa_status);
+
+        if (hsa_status != HSA_STATUS_SUCCESS)
+        {
+            THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
+        }
+        DBOUTL(DB_COPY2, "H2D: waiting... on completion signal handle=" << _completionSignal[bufferIndex].handle);
+        hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        hsa_amd_memory_unlock(const_cast<char *>(srcp));
     }
-
-    if (sizeBytes >= UINT64_MAX/2) {
-        THROW_ERROR (hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
-    }
-    int bufferIndex = 0;
-
-    size_t theseBytes= sizeBytes;
-    //tprintf (DB_COPY2, "H2D: waiting... on completion signal handle=%lu\n", _completionSignal[bufferIndex].handle);
-    //hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
-
-    //void * masked_srcp = (void*) ((uintptr_t)srcp & (uintptr_t)(~0x3f)) ; // TODO
-    void *locked_srcp;
-    //hsa_status_t hsa_status = hsa_amd_memory_lock(masked_srcp, theseBytes, &_hsaAgent, 1, &locked_srcp);
-    hsa_status_t hsa_status = hsa_amd_memory_lock(const_cast<char*> (srcp), theseBytes, &_hsaAgent, 1, &locked_srcp);
-    //tprintf (DB_COPY2, "H2D: bytesRemaining=%zu: pin-in-place:%p+%zu bufferIndex[%d]\n", bytesRemaining, srcp, theseBytes, bufferIndex);
-    //printf ("status=%x srcp=%p, masked_srcp=%p, locked_srcp=%p\n", hsa_status, srcp, masked_srcp, locked_srcp);
-
-    if (hsa_status != HSA_STATUS_SUCCESS) {
-        THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
-    }
-
-    hsa_signal_store_release(_completionSignal[bufferIndex], 1);
-
-    hsa_status = hsa_amd_memory_async_copy(dstp, _hsaAgent, locked_srcp, _hsaAgent, theseBytes, waitFor ? 1:0, waitFor, _completionSignal[bufferIndex]);
-    //tprintf (DB_COPY2, "H2D: bytesRemaining=%zu: async_copy %zu bytes %p to %p status=%x\n", bytesRemaining, theseBytes, _pinnedStagingBuffer[bufferIndex], dstp, hsa_status);
-
-    if (hsa_status != HSA_STATUS_SUCCESS) {
-        THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
-    }
-    DBOUTL (DB_COPY2, "H2D: waiting... on completion signal handle=" << _completionSignal[bufferIndex].handle);
-    hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
-    hsa_amd_memory_unlock(const_cast<char*> (srcp));
 }
 
 
@@ -253,6 +264,12 @@ void UnpinnedCopyEngine::CopyHostToDevice(UnpinnedCopyEngine::CopyMode copyMode,
 //IN: waitFor - hsaSignal to wait for - the copy will begin only when the specified dependency is resolved.  May be NULL indicating no dependency.
 void UnpinnedCopyEngine::CopyHostToDeviceStaging(void* dst, const void* src, size_t sizeBytes, const hsa_signal_t *waitFor)
 {
+    if (waitFor)
+        hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+  
+    // Make sure we wait for the dependent signal to complete before entering the critical section
+    // to avoid potential dead lock
+    {
         std::lock_guard<std::mutex> l (_copyLock);
         DBOUTL (DB_COPY2, __func__ << DBPARM(dst) << "," << DBPARM(src) << "," << DBPARM(sizeBytes))
 
@@ -266,9 +283,6 @@ void UnpinnedCopyEngine::CopyHostToDeviceStaging(void* dst, const void* src, siz
         if (sizeBytes >= UINT64_MAX/2) {
             THROW_ERROR (hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
         }
-
-        if (waitFor)
-          hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
         int bufferIndex = 0;
         for (int64_t bytesRemaining=sizeBytes; bytesRemaining>0 ;  bytesRemaining -= _bufferSize) {
@@ -303,44 +317,56 @@ void UnpinnedCopyEngine::CopyHostToDeviceStaging(void* dst, const void* src, siz
         for (int i=0; i<_numBuffers; i++) {
             hsa_signal_wait_acquire(_completionSignal[i], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
         }
+    }
 }
 
 
 void UnpinnedCopyEngine::CopyDeviceToHostPinInPlace(void* dst, const void* src, size_t sizeBytes, const hsa_signal_t *waitFor)
 {
-    std::lock_guard<std::mutex> l (_copyLock);
+    if (waitFor)
+        hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+        
+    // Make sure we wait for the dependent signal to complete before entering the critical section
+    // to avoid potential dead lock
+    {
+        std::lock_guard<std::mutex> l(_copyLock);
 
-    const char *srcp = static_cast<const char*> (src);
-    char *dstp = static_cast<char*> (dst);
+        const char *srcp = static_cast<const char *>(src);
+        char *dstp = static_cast<char *>(dst);
 
-    for (int i=0; i<_numBuffers; i++) {
-        hsa_signal_store_release(_completionSignal[i], 0);
+        for (int i = 0; i < _numBuffers; i++)
+        {
+            hsa_signal_store_release(_completionSignal[i], 0);
+        }
+
+        if (sizeBytes >= UINT64_MAX / 2)
+        {
+            THROW_ERROR(hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+        }
+        int bufferIndex = 0;
+        size_t theseBytes = sizeBytes;
+        void *locked_destp;
+
+        hsa_status_t hsa_status = hsa_amd_memory_lock(const_cast<char *>(dstp), theseBytes, &_hsaAgent, 1, &locked_destp);
+
+        if (hsa_status != HSA_STATUS_SUCCESS)
+        {
+            THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
+        }
+
+        hsa_signal_store_release(_completionSignal[bufferIndex], 1);
+
+        hsa_status = hsa_amd_memory_async_copy(locked_destp, _hsaAgent, srcp, _hsaAgent, theseBytes, 0, nullptr, _completionSignal[bufferIndex]);
+
+        if (hsa_status != HSA_STATUS_SUCCESS)
+        {
+            THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
+        }
+        DBOUTL(DB_COPY2, "D2H: waiting... on completion signal handle=\n"
+                             << _completionSignal[bufferIndex].handle);
+        hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        hsa_amd_memory_unlock(const_cast<char *>(dstp));
     }
-
-    if (sizeBytes >= UINT64_MAX/2) {
-        THROW_ERROR (hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
-    }
-    int bufferIndex = 0;
-    size_t theseBytes= sizeBytes;
-    void *locked_destp;
-
-    hsa_status_t hsa_status = hsa_amd_memory_lock(const_cast<char*> (dstp), theseBytes, &_hsaAgent, 1, &locked_destp);
-
-
-    if (hsa_status != HSA_STATUS_SUCCESS) {
-        THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
-    }
-
-    hsa_signal_store_release(_completionSignal[bufferIndex], 1);
-
-    hsa_status = hsa_amd_memory_async_copy(locked_destp,_hsaAgent , srcp, _hsaAgent, theseBytes, waitFor ? 1:0, waitFor, _completionSignal[bufferIndex]);
-
-    if (hsa_status != HSA_STATUS_SUCCESS) {
-        THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
-    }
-    DBOUTL (DB_COPY2, "D2H: waiting... on completion signal handle=\n" << _completionSignal[bufferIndex].handle);
-    hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
-    hsa_amd_memory_unlock(const_cast<char*> (dstp));
 }
 
 
@@ -377,60 +403,69 @@ void UnpinnedCopyEngine::CopyDeviceToHost(CopyMode copyMode ,void* dst, const vo
 //IN: waitFor - hsaSignal to wait for - the copy will begin only when the specified dependency is resolved.  May be NULL indicating no dependency.
 void UnpinnedCopyEngine::CopyDeviceToHostStaging(void* dst, const void* src, size_t sizeBytes, const hsa_signal_t *waitFor)
 {
-        std::lock_guard<std::mutex> l (_copyLock);
+    if (waitFor)
+        hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
-        const char *srcp0 = static_cast<const char*> (src);
-        char *dstp1 = static_cast<char*> (dst);
+    // Make sure we wait for the dependent signal to complete before entering the critical section
+    // to avoid potential dead lock
+    {
 
-        for (int i=0; i<_numBuffers; i++) {
+        std::lock_guard<std::mutex> l(_copyLock);
+
+        const char *srcp0 = static_cast<const char *>(src);
+        char *dstp1 = static_cast<char *>(dst);
+
+        for (int i = 0; i < _numBuffers; i++)
+        {
             hsa_signal_store_release(_completionSignal[i], 0);
         }
 
-        if (sizeBytes >= UINT64_MAX/2) {
-            THROW_ERROR (hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+        if (sizeBytes >= UINT64_MAX / 2)
+        {
+            THROW_ERROR(hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
         }
 
         int64_t bytesRemaining0 = sizeBytes; // bytes to copy from dest into staging buffer.
         int64_t bytesRemaining1 = sizeBytes; // bytes to copy from staging buffer into final dest
 
-        if (waitFor)
-          hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
-
         while (bytesRemaining1 > 0)
         {
             // First launch the async copies to copy from dest to host
-            for (int bufferIndex = 0; (bytesRemaining0>0) && (bufferIndex < _numBuffers);  bytesRemaining0 -= _bufferSize, bufferIndex++) {
+            for (int bufferIndex = 0; (bytesRemaining0 > 0) && (bufferIndex < _numBuffers); bytesRemaining0 -= _bufferSize, bufferIndex++)
+            {
 
                 size_t theseBytes = (bytesRemaining0 > _bufferSize) ? _bufferSize : bytesRemaining0;
 
-                DBOUTL (DB_COPY2, "D2H: bytesRemaining0=" << bytesRemaining0 << ": copy " << theseBytes << " bytes " 
-                        << static_cast<const void*>(srcp0) << " to stagingBuf[" << bufferIndex << "]:" << static_cast<void*>(_pinnedStagingBuffer[bufferIndex])); 
+                DBOUTL(DB_COPY2, "D2H: bytesRemaining0=" << bytesRemaining0 << ": copy " << theseBytes << " bytes "
+                                                         << static_cast<const void *>(srcp0) << " to stagingBuf[" << bufferIndex << "]:" << static_cast<void *>(_pinnedStagingBuffer[bufferIndex]));
                 hsa_signal_store_release(_completionSignal[bufferIndex], 1);
                 hsa_status_t hsa_status = hsa_amd_memory_async_copy(_pinnedStagingBuffer[bufferIndex], _hsaAgent, srcp0, _hsaAgent, theseBytes, 0, nullptr, _completionSignal[bufferIndex]);
-                if (hsa_status != HSA_STATUS_SUCCESS) {
-                    THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
+                if (hsa_status != HSA_STATUS_SUCCESS)
+                {
+                    THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
                 }
 
                 srcp0 += theseBytes;
             }
 
             // Now unload the staging buffers:
-            for (int bufferIndex=0; (bytesRemaining1>0) && (bufferIndex < _numBuffers);  bytesRemaining1 -= _bufferSize, bufferIndex++) {
+            for (int bufferIndex = 0; (bytesRemaining1 > 0) && (bufferIndex < _numBuffers); bytesRemaining1 -= _bufferSize, bufferIndex++)
+            {
 
                 size_t theseBytes = (bytesRemaining1 > _bufferSize) ? _bufferSize : bytesRemaining1;
 
-                DBOUTL (DB_COPY2, "D2H: wait_completion[" << bufferIndex << "] bytesRemaining=" << bytesRemaining1);
+                DBOUTL(DB_COPY2, "D2H: wait_completion[" << bufferIndex << "] bytesRemaining=" << bytesRemaining1);
                 hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
 
-                DBOUTL (DB_COPY2, "D2H: bytesRemaining1=" << bytesRemaining1 << ": copy " << theseBytes << " bytes " 
-                        << " stagingBuf[" << bufferIndex << "]:" << static_cast<void*>(_pinnedStagingBuffer[bufferIndex]) << " to dst " << static_cast<void*>(dstp1)); 
+                DBOUTL(DB_COPY2, "D2H: bytesRemaining1=" << bytesRemaining1 << ": copy " << theseBytes << " bytes "
+                                                         << " stagingBuf[" << bufferIndex << "]:" << static_cast<void *>(_pinnedStagingBuffer[bufferIndex]) << " to dst " << static_cast<void *>(dstp1));
                 memcpy(dstp1, _pinnedStagingBuffer[bufferIndex], theseBytes);
 
                 dstp1 += theseBytes;
             }
         }
+    }
 }
-
 
 //---
 //Copies sizeBytes from src to dst, using either a copy to a staging buffer or a staged pin-in-place strategy
@@ -439,79 +474,91 @@ void UnpinnedCopyEngine::CopyDeviceToHostStaging(void* dst, const void* src, siz
 //IN: waitFor - hsaSignal to wait for - the copy will begin only when the specified dependency is resolved.  May be NULL indicating no dependency.
 void UnpinnedCopyEngine::CopyPeerToPeer(void* dst, hsa_agent_t dstAgent, const void* src, hsa_agent_t srcAgent, size_t sizeBytes, const hsa_signal_t *waitFor)
 {
-    std::lock_guard<std::mutex> l (_copyLock);
-
-    const char *srcp0 = static_cast<const char*> (src);
-    char *dstp1 = static_cast<char*> (dst);
-
-    for (int i=0; i<_numBuffers; i++) {
-        hsa_signal_store_release(_completionSignal[i], 0);
-        hsa_signal_store_release(_completionSignal2[i], 0);
-    }
-
-    if (sizeBytes >= UINT64_MAX/2) {
-        THROW_ERROR (hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
-    }
-
-    int64_t bytesRemaining0 = sizeBytes; // bytes to copy from dest into staging buffer.
-    int64_t bytesRemaining1 = sizeBytes; // bytes to copy from staging buffer into final dest
-
     if (waitFor)
-      hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+        hsa_signal_wait_scacquire(*waitFor, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
-    // TODO - can we run this all on the GPU, without host sync?
+    // Make sure we wait for the dependent signal to complete before entering the critical section
+    // to avoid potential dead lock
+    {
 
-    while (bytesRemaining1 > 0) {
-        // First launch the async copies to copy from dest to host
-        for (int bufferIndex = 0; (bytesRemaining0>0) && (bufferIndex < _numBuffers);  bytesRemaining0 -= _bufferSize, bufferIndex++) {
+        std::lock_guard<std::mutex> l(_copyLock);
 
-            size_t theseBytes = (bytesRemaining0 > _bufferSize) ? _bufferSize : bytesRemaining0;
+        const char *srcp0 = static_cast<const char *>(src);
+        char *dstp1 = static_cast<char *>(dst);
 
-            // Wait to make sure we are not overwriting a buffer before it has been drained:
-            hsa_signal_wait_acquire(_completionSignal2[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
-
-            DBOUTL (DB_COPY2, "P2P: bytesRemaining0=" << bytesRemaining0 << ": async_copy " << theseBytes << " bytes " 
-                    << static_cast<const void*>(srcp0) << " to stagingBuf[" << bufferIndex << "]:" << static_cast<void*>(_pinnedStagingBuffer[bufferIndex])); 
-            hsa_signal_store_release(_completionSignal[bufferIndex], 1);
-            // Select CPU-agent here to ensure Runtime picks the H2D blit kernel.  Makes a 5X-10X difference in performance.
-            hsa_status_t hsa_status = hsa_amd_memory_async_copy(_pinnedStagingBuffer[bufferIndex], _cpuAgent, srcp0, srcAgent, theseBytes, 0, nullptr, _completionSignal[bufferIndex]);
-            if (hsa_status != HSA_STATUS_SUCCESS) {
-                THROW_ERROR (hipErrorRuntimeMemory, hsa_status);
-            }
-
-            srcp0 += theseBytes;
+        for (int i = 0; i < _numBuffers; i++)
+        {
+            hsa_signal_store_release(_completionSignal[i], 0);
+            hsa_signal_store_release(_completionSignal2[i], 0);
         }
 
-        // Now unload the staging buffers:
-        for (int bufferIndex=0; (bytesRemaining1>0) && (bufferIndex < _numBuffers);  bytesRemaining1 -= _bufferSize, bufferIndex++) {
+        if (sizeBytes >= UINT64_MAX / 2)
+        {
+            THROW_ERROR(hipErrorInvalidValue, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+        }
 
-            size_t theseBytes = (bytesRemaining1 > _bufferSize) ? _bufferSize : bytesRemaining1;
+        int64_t bytesRemaining0 = sizeBytes; // bytes to copy from dest into staging buffer.
+        int64_t bytesRemaining1 = sizeBytes; // bytes to copy from staging buffer into final dest
 
-            DBOUTL (DB_COPY2, "P2P: wait_completion[" << bufferIndex << "] bytesRemaining=" << bytesRemaining1);
+        // TODO - can we run this all on the GPU, without host sync?
 
-            bool hostWait = 0; // TODO - remove me
+        while (bytesRemaining1 > 0)
+        {
+            // First launch the async copies to copy from dest to host
+            for (int bufferIndex = 0; (bytesRemaining0 > 0) && (bufferIndex < _numBuffers); bytesRemaining0 -= _bufferSize, bufferIndex++)
+            {
 
-            if (hostWait) {
-                // Host-side wait, should not be necessary:
-                hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+                size_t theseBytes = (bytesRemaining0 > _bufferSize) ? _bufferSize : bytesRemaining0;
+
+                // Wait to make sure we are not overwriting a buffer before it has been drained:
+                hsa_signal_wait_acquire(_completionSignal2[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+
+                DBOUTL(DB_COPY2, "P2P: bytesRemaining0=" << bytesRemaining0 << ": async_copy " << theseBytes << " bytes "
+                                                         << static_cast<const void *>(srcp0) << " to stagingBuf[" << bufferIndex << "]:" << static_cast<void *>(_pinnedStagingBuffer[bufferIndex]));
+                hsa_signal_store_release(_completionSignal[bufferIndex], 1);
+                // Select CPU-agent here to ensure Runtime picks the H2D blit kernel.  Makes a 5X-10X difference in performance.
+                hsa_status_t hsa_status = hsa_amd_memory_async_copy(_pinnedStagingBuffer[bufferIndex], _cpuAgent, srcp0, srcAgent, theseBytes, 0, nullptr, _completionSignal[bufferIndex]);
+                if (hsa_status != HSA_STATUS_SUCCESS)
+                {
+                    THROW_ERROR(hipErrorRuntimeMemory, hsa_status);
+                }
+
+                srcp0 += theseBytes;
             }
 
-            DBOUTL (DB_COPY2, "P2P: bytesRemaining1=" << bytesRemaining1 << ": copy " << theseBytes << " bytes " 
-                    << " stagingBuf[" << bufferIndex << "]:" << static_cast<void*>(_pinnedStagingBuffer[bufferIndex]) << " to dst " << static_cast<void*>(dstp1)); 
-            hsa_signal_store_release(_completionSignal2[bufferIndex], 1);
-            // Select CPU-agent here to ensure Runtime picks the H2D blit kernel.  Makes a 5X-10X difference in performance.
-            hsa_status_t hsa_status = hsa_amd_memory_async_copy(dstp1, dstAgent, _pinnedStagingBuffer[bufferIndex], _cpuAgent, theseBytes,
-                                      hostWait ? 0:1, hostWait ? NULL : &_completionSignal[bufferIndex],
-                                      _completionSignal2[bufferIndex]);
+            // Now unload the staging buffers:
+            for (int bufferIndex = 0; (bytesRemaining1 > 0) && (bufferIndex < _numBuffers); bytesRemaining1 -= _bufferSize, bufferIndex++)
+            {
 
-            dstp1 += theseBytes;
+                size_t theseBytes = (bytesRemaining1 > _bufferSize) ? _bufferSize : bytesRemaining1;
+
+                DBOUTL(DB_COPY2, "P2P: wait_completion[" << bufferIndex << "] bytesRemaining=" << bytesRemaining1);
+
+                bool hostWait = 0; // TODO - remove me
+
+                if (hostWait)
+                {
+                    // Host-side wait, should not be necessary:
+                    hsa_signal_wait_acquire(_completionSignal[bufferIndex], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+                }
+
+                DBOUTL(DB_COPY2, "P2P: bytesRemaining1=" << bytesRemaining1 << ": copy " << theseBytes << " bytes "
+                                                         << " stagingBuf[" << bufferIndex << "]:" << static_cast<void *>(_pinnedStagingBuffer[bufferIndex]) << " to dst " << static_cast<void *>(dstp1));
+                hsa_signal_store_release(_completionSignal2[bufferIndex], 1);
+                // Select CPU-agent here to ensure Runtime picks the H2D blit kernel.  Makes a 5X-10X difference in performance.
+                hsa_status_t hsa_status = hsa_amd_memory_async_copy(dstp1, dstAgent, _pinnedStagingBuffer[bufferIndex], _cpuAgent, theseBytes,
+                                                                    hostWait ? 0 : 1, hostWait ? NULL : &_completionSignal[bufferIndex],
+                                                                    _completionSignal2[bufferIndex]);
+
+                dstp1 += theseBytes;
+            }
         }
-    }
 
-
-    // Wait for the staging-buffer to dest copies to complete:
-    for (int i=0; i<_numBuffers; i++) {
-        hsa_signal_wait_acquire(_completionSignal2[i], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        // Wait for the staging-buffer to dest copies to complete:
+        for (int i = 0; i < _numBuffers; i++)
+        {
+            hsa_signal_wait_acquire(_completionSignal2[i], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        }
     }
 }
 


### PR DESCRIPTION
This change is make all copy routines in unpinned copy engine to wait on the dependent HSA signal before acquiring the lock and entering into the critical section.  This will prevent potential deadlocks where a thread acquires the lock and then wait on a HSA signal from another thread trying to acquire the same lock to perform a copy.
