### PR TITLE
Remove deprecated hsa_signal_store_release func

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3462,7 +3462,7 @@ public:
             signalPoolMutex.lock();
 
             // restore signal to the initial value 1
-            hsa_signal_store_release(signal, 1);
+            hsa_signal_store_screlease(signal, 1);
 
             // mark the signal pointed by signalIndex as available
             signalPoolFlag[signalIndex] = false;


### PR DESCRIPTION
New hsa_signal_store uses function hsa_signal_store_screlease.