### PR TITLE
Removing more deprecated functions

### DIFF
--- a/benchmarks/benchEmptyKernel/hsacodelib.CPP
+++ b/benchmarks/benchEmptyKernel/hsacodelib.CPP
@@ -39,7 +39,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
         assert(status == HSA_STATUS_SUCCESS);
 
         hsa_executable_t hsaExecutable;
-        status = hsa_executable_create(HSA_PROFILE_FULL, HSA_EXECUTABLE_STATE_UNFROZEN,
+        status = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
                                        NULL, &hsaExecutable);
         assert(status == HSA_STATUS_SUCCESS);
 

--- a/benchmarks/benchEmptyKernel/hsacodelib.CPP
+++ b/benchmarks/benchEmptyKernel/hsacodelib.CPP
@@ -54,7 +54,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 
         // Get symbol handle.
         hsa_executable_symbol_t kernelSymbol;
-        status = hsa_executable_get_symbol(hsaExecutable, NULL, kernelName, hsaAgent, 0, &kernelSymbol);
+        status = hsa_executable_get_symbol_by_name(hsaExecutable, kernelName, const_cast<hsa_agent_t*>(&hsaAgent), &kernelSymbol);
         assert(status == HSA_STATUS_SUCCESS);
 
         Kernel k;

--- a/hc2/headers/functions/hsa_interfaces.hpp
+++ b/hc2/headers/functions/hsa_interfaces.hpp
@@ -82,10 +82,10 @@ namespace hc2
     std::string to_string(const hsa_isa_t& x)
     {
         std::size_t sz = 0u;
-        hsa_isa_get_info(x, HSA_ISA_INFO_NAME_LENGTH, 0u, &sz);
+        hsa_isa_get_info_alt(x, HSA_ISA_INFO_NAME_LENGTH, &sz);
 
         std::string r(sz, '\0');
-        hsa_isa_get_info(x, HSA_ISA_INFO_NAME, 0u, &r.front());
+        hsa_isa_get_info_alt(x, HSA_ISA_INFO_NAME, &r.front());
 
         return r;
     }

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -593,7 +593,7 @@ public:
         // get symbol
         hsa_executable_symbol_t symbol;
         hsa_agent_t agent;
-        status = hsa_executable_get_symbol(hsaExecutable, NULL, symbolName, agent, 0, &symbol);
+        status = hsa_executable_get_symbol_by_name(hsaExecutable, symbolName, const_cast<hsa_agent_t*>(&agent), &symbol);
         STATUS_CHECK_SYMBOL(status, symbolName, __LINE__);
 
         // get address of symbol
@@ -2800,7 +2800,7 @@ public:
                     // Get symbol handle.
                     hsa_status_t status;
                     hsa_executable_symbol_t kernelSymbol;
-                    status = hsa_executable_get_symbol(executable->hsaExecutable, NULL, fun, agent, 0, &kernelSymbol);
+                    status = hsa_executable_get_symbol_by_name(executable->hsaExecutable, fun, const_cast<hsa_agent_t*>(&agent), &kernelSymbol);
                     if (status == HSA_STATUS_SUCCESS) {
                         // Get code handle.
                         uint64_t kernelCodeHandle;
@@ -3129,7 +3129,7 @@ public:
 
                 // get symbol
                 hsa_executable_symbol_t symbol;
-                status = hsa_executable_get_symbol(executable->hsaExecutable, NULL, symbolName, agent, 0, &symbol);
+                status = hsa_executable_get_symbol_by_name(executable->hsaExecutable, symbolName, const_cast<hsa_agent_t*>(&agent), &symbol);
                 //STATUS_CHECK_SYMBOL(status, symbolName, __LINE__);
 
                 if (status == HSA_STATUS_SUCCESS) {

--- a/tests/Unit/DispatchAql/hsacodelib.CPP
+++ b/tests/Unit/DispatchAql/hsacodelib.CPP
@@ -53,7 +53,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 
         // Get symbol handle.
         hsa_executable_symbol_t kernelSymbol;
-        status = hsa_executable_get_symbol(hsaExecutable, NULL, kernelName, hsaAgent, 0, &kernelSymbol);
+        status = hsa_executable_get_symbol_by_name(hsaExecutable, kernelName, const_cast<hsa_agent_t*>(&hsaAgent), &kernelSymbol);
         assert(status == HSA_STATUS_SUCCESS);
 
         Kernel k;

--- a/tests/Unit/DispatchAql/hsacodelib.CPP
+++ b/tests/Unit/DispatchAql/hsacodelib.CPP
@@ -38,7 +38,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
         assert(status == HSA_STATUS_SUCCESS);
 
         hsa_executable_t hsaExecutable;
-        status = hsa_executable_create(HSA_PROFILE_FULL, HSA_EXECUTABLE_STATE_UNFROZEN,
+        status = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
                                        NULL, &hsaExecutable);
         assert(status == HSA_STATUS_SUCCESS);
 


### PR DESCRIPTION
Removing hsa_isa_get_info, hsa_executable_get_symbol and hsa_executable_create. 

Although replacement for hsa_executable_get_symbol is hsa_executable_get_symbol_by_linker_name, it is not yet implemented, so we will use less deprecated hsa_executable_get_symbol_by_name for now.