### PR TITLE
Remove depr hsa_code_object_t - find ISA from ELF

### DIFF
--- a/benchmarks/benchEmptyKernel/hsacodelib.CPP
+++ b/benchmarks/benchEmptyKernel/hsacodelib.CPP
@@ -12,7 +12,7 @@
 
 
 
-// Load HSACO 
+// Load HSACO
 Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *kernelName)
 {
     hsa_region_t systemRegion = *(hsa_region_t*)av->get_hsa_am_system_region();
@@ -34,8 +34,8 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 
         hsa_status_t status;
 
-        hsa_code_object_t code_object = {0};
-        status = hsa_code_object_deserialize(&buffer[0], fsize, NULL, &code_object);
+        hsa_code_object_reader_t co_reader = {};
+        status = hsa_code_object_reader_create_from_memory(&buffer[0], fsize, &co_reader);
         assert(status == HSA_STATUS_SUCCESS);
 
         hsa_executable_t hsaExecutable;
@@ -43,8 +43,8 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
                                        NULL, &hsaExecutable);
         assert(status == HSA_STATUS_SUCCESS);
 
-        // Load the code object.
-        status = hsa_executable_load_code_object(hsaExecutable, hsaAgent, code_object, NULL);
+        // Load the agent code object.
+        status = hsa_executable_load_agent_code_object(hsaExecutable, hsaAgent, co_reader, NULL, NULL);
         assert(status == HSA_STATUS_SUCCESS);
 
         // Freeze the executable.
@@ -82,7 +82,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 }
 
 
-// Dispatch a GL packet - 
+// Dispatch a GL packet -
 // Convert to AQL and call dispatch_hsa_kernel
 void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize, bool systemScope)
 {
@@ -106,7 +106,7 @@ void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args
     aql.header =   (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE);
 
     //aql.header |=   (1 << HSA_PACKET_HEADER_BARRIER);
- 
+
     if (systemScope) {
       aql.header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
                     (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);

--- a/hc2/external/elfio/elfio.hpp
+++ b/hc2/external/elfio/elfio.hpp
@@ -45,6 +45,7 @@ THE SOFTWARE.
 #include "elfio_section.hpp"
 #include "elfio_segment.hpp"
 #include "elfio_strings.hpp"
+#include "elfio_amdgpu.hpp"
 
 #define ELFIO_HEADER_ACCESS_GET( TYPE, FNAME ) \
 TYPE                                           \

--- a/hc2/external/elfio/elfio_amdgpu.hpp
+++ b/hc2/external/elfio/elfio_amdgpu.hpp
@@ -10,6 +10,8 @@
 
 namespace hc {
 
+// AMDGPU e_flags mirroring from llvm/include/llvm/BinaryFormat/ELF.h
+
 // AMDGPU specific e_flags.
 enum : unsigned {
   // Processor selection mask for EF_AMDGPU_MACH_* values.

--- a/hc2/external/elfio/elfio_amdgpu.hpp
+++ b/hc2/external/elfio/elfio_amdgpu.hpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ELFIO_AMDGPU_HPP
+#define ELFIO_AMDGPU_HPP
+
+namespace hc {
+
+// AMDGPU specific e_flags.
+enum : unsigned {
+  // Processor selection mask for EF_AMDGPU_MACH_* values.
+  EF_AMDGPU_MACH = 0x0ff,
+
+  // Not specified processor.
+  EF_AMDGPU_MACH_NONE = 0x000,
+
+  // R600-based processors.
+
+  // Radeon HD 2000/3000 Series (R600).
+  EF_AMDGPU_MACH_R600_R600 = 0x001,
+  EF_AMDGPU_MACH_R600_R630 = 0x002,
+  EF_AMDGPU_MACH_R600_RS880 = 0x003,
+  EF_AMDGPU_MACH_R600_RV670 = 0x004,
+  // Radeon HD 4000 Series (R700).
+  EF_AMDGPU_MACH_R600_RV710 = 0x005,
+  EF_AMDGPU_MACH_R600_RV730 = 0x006,
+  EF_AMDGPU_MACH_R600_RV770 = 0x007,
+  // Radeon HD 5000 Series (Evergreen).
+  EF_AMDGPU_MACH_R600_CEDAR = 0x008,
+  EF_AMDGPU_MACH_R600_CYPRESS = 0x009,
+  EF_AMDGPU_MACH_R600_JUNIPER = 0x00a,
+  EF_AMDGPU_MACH_R600_REDWOOD = 0x00b,
+  EF_AMDGPU_MACH_R600_SUMO = 0x00c,
+  // Radeon HD 6000 Series (Northern Islands).
+  EF_AMDGPU_MACH_R600_BARTS = 0x00d,
+  EF_AMDGPU_MACH_R600_CAICOS = 0x00e,
+  EF_AMDGPU_MACH_R600_CAYMAN = 0x00f,
+  EF_AMDGPU_MACH_R600_TURKS = 0x010,
+
+  // Reserved for R600-based processors.
+  EF_AMDGPU_MACH_R600_RESERVED_FIRST = 0x011,
+  EF_AMDGPU_MACH_R600_RESERVED_LAST = 0x01f,
+
+  // First/last R600-based processors.
+  EF_AMDGPU_MACH_R600_FIRST = EF_AMDGPU_MACH_R600_R600,
+  EF_AMDGPU_MACH_R600_LAST = EF_AMDGPU_MACH_R600_TURKS,
+
+  // AMDGCN-based processors.
+
+  // AMDGCN GFX6.
+  EF_AMDGPU_MACH_AMDGCN_GFX600 = 0x020,
+  EF_AMDGPU_MACH_AMDGCN_GFX601 = 0x021,
+  // AMDGCN GFX7.
+  EF_AMDGPU_MACH_AMDGCN_GFX700 = 0x022,
+  EF_AMDGPU_MACH_AMDGCN_GFX701 = 0x023,
+  EF_AMDGPU_MACH_AMDGCN_GFX702 = 0x024,
+  EF_AMDGPU_MACH_AMDGCN_GFX703 = 0x025,
+  EF_AMDGPU_MACH_AMDGCN_GFX704 = 0x026,
+  // AMDGCN GFX8.
+  EF_AMDGPU_MACH_AMDGCN_GFX801 = 0x028,
+  EF_AMDGPU_MACH_AMDGCN_GFX802 = 0x029,
+  EF_AMDGPU_MACH_AMDGCN_GFX803 = 0x02a,
+  EF_AMDGPU_MACH_AMDGCN_GFX810 = 0x02b,
+  // AMDGCN GFX9.
+  EF_AMDGPU_MACH_AMDGCN_GFX900 = 0x02c,
+  EF_AMDGPU_MACH_AMDGCN_GFX902 = 0x02d,
+  EF_AMDGPU_MACH_AMDGCN_GFX904 = 0x02e,
+  EF_AMDGPU_MACH_AMDGCN_GFX906 = 0x02f,
+
+  // Reserved for AMDGCN-based processors.
+  EF_AMDGPU_MACH_AMDGCN_RESERVED0 = 0x027,
+  EF_AMDGPU_MACH_AMDGCN_RESERVED1 = 0x030,
+
+  // First/last AMDGCN-based processors.
+  EF_AMDGPU_MACH_AMDGCN_FIRST = EF_AMDGPU_MACH_AMDGCN_GFX600,
+  EF_AMDGPU_MACH_AMDGCN_LAST = EF_AMDGPU_MACH_AMDGCN_GFX906,
+
+  // Indicates if the xnack target feature is enabled for all code contained in
+  // the object.
+  EF_AMDGPU_XNACK = 0x100,
+};
+
+} // namespace ELFIO
+
+#endif // ELFIO_AMDGPU_HPP

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2707,12 +2707,12 @@ public:
 
         // Get ISA from ELF header
         std::string triple = "amdgcn-amd-amdhsa--gfx";
-        unsigned MACH = reader.get_flags() & 0x000000ff;
+        unsigned MACH = reader.get_flags() & hc::EF_AMDGPU_MACH;
 
         switch(MACH) {
-            case 0x023 : triple.append("701"); break;
-            case 0x02a : triple.append("803"); break;
-            case 0x02c : triple.append("900"); break;
+            case hc::EF_AMDGPU_MACH_AMDGCN_GFX701 : triple.append("701"); break;
+            case hc::EF_AMDGPU_MACH_AMDGCN_GFX803 : triple.append("803"); break;
+            case hc::EF_AMDGPU_MACH_AMDGCN_GFX900 : triple.append("900"); break;
         }
 
         const auto isa{get_isa_name_from_triple(std::move(triple))};

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2713,6 +2713,7 @@ public:
             case hc::EF_AMDGPU_MACH_AMDGCN_GFX701 : triple.append("701"); break;
             case hc::EF_AMDGPU_MACH_AMDGCN_GFX803 : triple.append("803"); break;
             case hc::EF_AMDGPU_MACH_AMDGCN_GFX900 : triple.append("900"); break;
+            case hc::EF_AMDGPU_MACH_AMDGCN_GFX906 : triple.append("906"); break;
         }
 
         const auto isa{get_isa_name_from_triple(std::move(triple))};

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2666,7 +2666,30 @@ public:
         }
     }
 
+    inline
+    std::string get_isa_name_from_triple(std::string triple)
+    {
+        static hsa_isa_t tmp{};
+        static const bool is_old_rocr{
+            hsa_isa_from_name(triple.c_str(), &tmp) != HSA_STATUS_SUCCESS};
+
+        if (is_old_rocr) {
+            auto tmp {triple.substr(triple.rfind('x') + 1)};
+            triple.replace(0, std::string::npos, "AMD:AMDGPU");
+
+            for (auto&& x : tmp) {
+                triple.push_back(':');
+                triple.push_back(x);
+            }
+        }
+
+        return triple;
+    }
+
     bool IsCompatibleKernel(void* size, void* source) override {
+        using namespace ELFIO;
+        using namespace std;
+
         hsa_status_t status;
 
         // Allocate memory for kernel source
@@ -2675,24 +2698,32 @@ public:
         memcpy(kernel_source, source, kernel_size);
         kernel_source[kernel_size] = '\0';
 
-        // Deserialize code object.
-        hsa_code_object_t code_object = {0};
-        status = hsa_code_object_deserialize(kernel_source, kernel_size, NULL, &code_object);
-        STATUS_CHECK(status, __LINE__);
-        assert(0 != code_object.handle);
+        // Set up ELF header reader
+        elfio reader;
+        istringstream kern_stream{string{
+            kernel_source,
+            kernel_source + kernel_size}};
+        reader.load(kern_stream);
 
-        // Get ISA of the code object
-        hsa_isa_t code_object_isa;
-        status = hsa_code_object_get_info(code_object, HSA_CODE_OBJECT_INFO_ISA, &code_object_isa);
+        // Get ISA from ELF header
+        std::string triple = "amdgcn-amd-amdhsa--gfx";
+        unsigned MACH = reader.get_flags() & 0x000000ff;
+
+        switch(MACH) {
+            case 0x023 : triple.append("701"); break;
+            case 0x02a : triple.append("803"); break;
+            case 0x02c : triple.append("900"); break;
+        }
+
+        const auto isa{get_isa_name_from_triple(std::move(triple))};
+
+        hsa_isa_t co_isa{};
+        status = hsa_isa_from_name(isa.c_str(), &co_isa);
         STATUS_CHECK(status, __LINE__);
 
         // Check if the code object is compatible with ISA of the agent
         bool isCompatible = false;
-        status = hsa_isa_compatible(code_object_isa, agentISA, &isCompatible);
-        STATUS_CHECK(status, __LINE__);
-
-        // Destroy code object
-        status = hsa_code_object_destroy(code_object);
+        status = hsa_isa_compatible(co_isa, agentISA, &isCompatible);
         STATUS_CHECK(status, __LINE__);
 
         // release allocated memory

--- a/tests/Unit/DispatchAql/hsacodelib.CPP
+++ b/tests/Unit/DispatchAql/hsacodelib.CPP
@@ -12,7 +12,7 @@
 
 
 
-// Load HSACO 
+// Load HSACO
 Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *kernelName)
 {
     hsa_region_t systemRegion = *(hsa_region_t*)av->get_hsa_am_system_region();
@@ -33,8 +33,8 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 
         hsa_status_t status;
 
-        hsa_code_object_t code_object = {0};
-        status = hsa_code_object_deserialize(&buffer[0], fsize, NULL, &code_object);
+        hsa_code_object_reader_t co_reader = {};
+        status = hsa_code_object_reader_create_from_memory(&buffer[0], fsize, &co_reader);
         assert(status == HSA_STATUS_SUCCESS);
 
         hsa_executable_t hsaExecutable;
@@ -42,8 +42,8 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
                                        NULL, &hsaExecutable);
         assert(status == HSA_STATUS_SUCCESS);
 
-        // Load the code object.
-        status = hsa_executable_load_code_object(hsaExecutable, hsaAgent, code_object, NULL);
+        // Load the agent code object.
+        status = hsa_executable_load_agent_code_object(hsaExecutable, hsaAgent, co_reader, NULL, NULL);
         assert(status == HSA_STATUS_SUCCESS);
 
         // Freeze the executable.
@@ -81,7 +81,7 @@ Kernel load_hsaco(hc::accelerator_view *av, const char * fileName, const char *k
 }
 
 
-// Dispatch a GL packet - 
+// Dispatch a GL packet -
 // Convert to AQL and call dispatch_hsa_kernel
 void dispatch_glp_kernel(const grid_launch_parm *lp, const Kernel &k, void *args, int argSize)
 {


### PR DESCRIPTION
Required to use new hsa_code_object_reader_t for previous usage of hsa_code_object_t. Remove deprecated functions hsa_code_object_deserialize and hsa_executable_load_code_object. Also isCompatible ISA should find the target from ELF header to make decision. Remove code_object from ISA verification.