### PR TITLE
Pointers passed / captured to / by a kernel can only point to global,…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ install(PROGRAMS $<TARGET_FILE:LLVMAMDGPUDesc>
                  $<TARGET_FILE:LLVMSupport>
                  $<TARGET_FILE:LLVMCpuRename>
                  $<TARGET_FILE:LLVMSelectAcceleratorCode>
+                 $<TARGET_FILE:LLVMPromotePointerKernArgsToGlobal>
                  $<TARGET_FILE:LLVMHello>
                  $<TARGET_FILE:LLVMTileUniform>
         DESTINATION lib

--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -180,12 +180,14 @@ if [ "$HCC_TILECHECK" == "ON" ]; then
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -dce -globaldce -always-inline -tile_uniform < $2.linked.bc -o $2.selected.bc
+    -infer-address-spaces -dce -globaldce -always-inline -tile_uniform \
+    < $2.linked.bc -o $2.selected.bc
 else
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -dce -globaldce -always-inline < $2.linked.bc -o $2.selected.bc
+    -infer-address-spaces -dce -globaldce -always-inline \
+    < $2.linked.bc -o $2.selected.bc
 fi
 
 # error handling for HCC-specific opt passes
@@ -201,7 +203,7 @@ fi
 
 # Optimization notes:
 #  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
-$OPT -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -infer-address-spaces -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify $2.selected.bc -o $2.opt.bc
+$OPT -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify $2.selected.bc -o $2.opt.bc
 
 # error handling for opt
 RETVAL=$?

--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -177,11 +177,15 @@ fi
 
 # Invoke HCC-specific opt passes
 if [ "$HCC_TILECHECK" == "ON" ]; then
-    $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-        -select-accelerator-code -dce -globaldce -always-inline -tile_uniform < $2.linked.bc -o $2.selected.bc
+  $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
+    -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
+    -select-accelerator-code -promote-pointer-kernargs-to-global \
+    -dce -globaldce -always-inline -tile_uniform < $2.linked.bc -o $2.selected.bc
 else
-    $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-        -select-accelerator-code -dce -globaldce -always-inline < $2.linked.bc -o $2.selected.bc
+  $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
+    -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
+    -select-accelerator-code -promote-pointer-kernargs-to-global \
+    -dce -globaldce -always-inline < $2.linked.bc -o $2.selected.bc
 fi
 
 # error handling for HCC-specific opt passes

--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -180,13 +180,13 @@ if [ "$HCC_TILECHECK" == "ON" ]; then
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -infer-address-spaces -dce -globaldce -always-inline -tile_uniform \
+    -dce -globaldce -always-inline -infer-address-spaces -tile_uniform \
     < $2.linked.bc -o $2.selected.bc
 else
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -infer-address-spaces -dce -globaldce -always-inline \
+    -dce -globaldce -always-inline -infer-address-spaces \
     < $2.linked.bc -o $2.selected.bc
 fi
 


### PR DESCRIPTION
… so promote them from generic to the global address space. This is dependent on https://github.com/RadeonOpenCompute/llvm/pull/145.