### PR TITLE
getSignal() should tell the command launching paths to wait the queue for signals when hsa_signal_create failed

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3405,7 +3405,8 @@ public:
         DBOUT(DB_SIG,  " pre-allocate " << HCC_SIGNAL_POOL_SIZE << " signals\n");
         for (int i = 0; i < HCC_SIGNAL_POOL_SIZE; ++i) {
           hsa_signal_t signal;
-          status = hsa_signal_create(1, 0, NULL, &signal);
+          status = hsa_amd_signal_create(
+              1, 0, nullptr, HSA_AMD_SIGNAL_IPC, &signal);
           STATUS_CHECK(status, __LINE__);
           signalPool.push_back(signal);
           signalPoolFlag.push_back(false);
@@ -3492,7 +3493,8 @@ public:
                 // increase signal pool on demand for another HCC_SIGNAL_POOL_SIZE
                 for (int i = 0; i < HCC_SIGNAL_POOL_SIZE; ++i) {
                     hsa_signal_t signal;
-                    status = hsa_signal_create(1, 0, NULL, &signal);
+                    status = hsa_amd_signal_create(
+                        1, 0, nullptr, HSA_AMD_SIGNAL_IPC, &signal);
                     STATUS_CHECK(status, __LINE__);
                     signalPool.push_back(signal);
                     signalPoolFlag.push_back(false);
@@ -3919,7 +3921,8 @@ HSAQueue::HSAQueue(KalmarDevice* pDev, hsa_agent_t agent, execute_order order) :
 
     youngestCommandKind = hcCommandInvalid;
 
-    hsa_status_t status= hsa_signal_create(1, 1, &agent, &sync_copy_signal);
+    hsa_status_t status = hsa_amd_signal_create(
+        1, 1, &agent, HSA_AMD_SIGNAL_IPC, &sync_copy_signal);
     STATUS_CHECK(status, __LINE__);
 }
 

--- a/lib/hsa/unpinned_copy_engine.cpp
+++ b/lib/hsa/unpinned_copy_engine.cpp
@@ -125,8 +125,10 @@ UnpinnedCopyEngine::UnpinnedCopyEngine(hsa_agent_t hsaAgent, hsa_agent_t cpuAgen
         err = hsa_amd_agents_allow_access(agents.size(), agentBlock, NULL, _pinnedStagingBuffer[i]);
         ErrorCheck(err);
 
-        hsa_signal_create(0, 0, NULL, &_completionSignal[i]);
-        hsa_signal_create(0, 0, NULL, &_completionSignal2[i]);
+        hsa_amd_signal_create(
+            0, 0, nullptr, HSA_AMD_SIGNAL_IPC, &_completionSignal[i]);
+        hsa_amd_signal_create(
+            0, 0, nullptr, HSA_AMD_SIGNAL_IPC, &_completionSignal2[i]);
     }
 
 };


### PR DESCRIPTION
The modification is to file hcc/lib/hsa/mcwamp_hsa.cpp.  The thought here is that,  in function getSignal(), when hsa_signal_create() returned with failure(caused by unavailable signal events from the kernel driver), getSignal() should return an "NULL" signal handle as indication of failing allocation, rather than call abort() directly.  And with all command launching paths where getSignal() are called, a checking should be done so that when "NULL" signal handle is returned , "hsaQueue()->wait()" is called to flush the queue

[hcc_mcwamp_hsa_cpp.diff.txt](https://github.com/RadeonOpenCompute/hcc/files/2025640/hcc_mcwamp_hsa_cpp.diff.txt)

