### PR TITLE
disable lit pipefail by default

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -10,6 +10,9 @@ import lit.formats
 # name: The name of this test suite.
 config.name = 'HCC'
 
+# disable pipefail by default
+config.pipefail = False
+
 # testFormat: The test format to use to interpret tests.
 #
 # For now we require '&&' between commands, until they get globally killed and


### PR DESCRIPTION
LLVM upstream has a change that enables pipefail by default, in utils/lit/lit/TestRunner.py.  But pulling this upstream change into the HCC branch causes many unit tests to fail. This is because these HCC unit tests rely on pipefail being disabled.  So we need to ensure pipefail is disabled for HCC unit tests, before we merge the upstream change - which HCC needs to pass all LLVM lit tests.