### PR TITLE
add git reference in GitSCM command for the submodules too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node( 'hcctest' )
       $class: 'GitSCM',
       branches: scm.branches,
       doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
-      extensions: scm.extensions + [[$class: 'CloneOption', reference: '/var/gitcache/hcc.git'], [$class: 'CleanCheckout'], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', timeout: 60, trackingSubmodules: false]],
+      extensions: scm.extensions + [[$class: 'CloneOption', reference: '/var/gitcache/hcc.git'], [$class: 'CleanCheckout'], [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '/var/gitcache/hcc.git', timeout: 60, trackingSubmodules: false]],
       userRemoteConfigs: scm.userRemoteConfigs
     ])
   }


### PR DESCRIPTION
We added git references for the root HCC repo, but we didn't for the submodules.  Without this the git submodule update still clones the submodules from scratch.