### PR TITLE
fix get_group_segment_sizes test 

### DIFF
--- a/tests/Unit/HC/get_group_segment_sizes.cpp
+++ b/tests/Unit/HC/get_group_segment_sizes.cpp
@@ -37,7 +37,7 @@ bool test() {
     e, 
     [=](hc::index<1> idx) __HC__ {
       // create a tile_static array
-      tile_static int group[groupSize];
+      tile_static volatile int group[groupSize];
       group[idx[0]] = 0;
 
       // av_a stores the size of group segment


### PR DESCRIPTION
Now that we have enabled promote-ponter-kernargs-to-global pass, we can just add volatile to the group declaration.