### PR TITLE
move LLD to amd-common branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "lld"]
 	path = lld
 	url = https://github.com/RadeonOpenCompute/lld.git
-	branch = amd-hcc
+	branch = amd-common
 [submodule "clang"]
 	path = clang
 	url = https://github.com/RadeonOpenCompute/hcc-clang-upgrade.git


### PR DESCRIPTION
This PR moves HCC's LLD submodule to the amd-common branch in https://github.com/RadeonOpenCompute/lld .

I successfully built HCC and ran all HCC unit tests