### PR TITLE
fix missing system scope release for some situations

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -5247,6 +5247,10 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
     // HSA memory copy requires a system-scope acquire before the next kernel command - set flag here so we remember:
     hsaQueue()->setNextKernelNeedsSysAcquire(true);
 
+    // If it's a device to device, the next system sync will need a release
+    if (copyKind ==  Kalmar::hcMemcpyDeviceToDevice)
+      hsaQueue()->setNextSyncNeedsSysRelease(true);
+
     return status;
 }
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1313,8 +1313,14 @@ public:
     bool nextKernelNeedsSysAcquire() const { return _nextKernelNeedsSysAcquire; };
     void setNextKernelNeedsSysAcquire(bool r) { _nextKernelNeedsSysAcquire = r; };
 
-    bool nextSyncNeedsSysRelease() const { return _nextSyncNeedsSysRelease; };
-    void setNextSyncNeedsSysRelease(bool r) { _nextSyncNeedsSysRelease = r; };
+    bool nextSyncNeedsSysRelease() const { 
+      DBOUT( DB_CMD2, "  HSAQueue::nextSyncNeedsSysRelease(): " <<  _nextSyncNeedsSysRelease << "\n");
+      return _nextSyncNeedsSysRelease; 
+    };
+    void setNextSyncNeedsSysRelease(bool r) {
+      DBOUT( DB_CMD2, "  HSAQueue::setNextSyncNeedsSysRelease(" <<  r << ")\n");
+      _nextSyncNeedsSysRelease = r; 
+    };
 
     uint64_t getSeqNum() const { return queueSeqNum; };
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -5298,7 +5298,7 @@ HSACopy::enqueueAsyncCopyCommand(const Kalmar::HSADevice *copyDevice, const hc::
 
 
         int depSignalCnt = 0;
-        hsa_signal_t depSignal;
+        hsa_signal_t depSignal = { .handle = 0x0 };
         setCommandKind (resolveMemcpyDirection(srcPtrInfo._isInDeviceMem, dstPtrInfo._isInDeviceMem));
 
         if (!hsaQueue()->nextSyncNeedsSysRelease()) {
@@ -5306,13 +5306,16 @@ HSACopy::enqueueAsyncCopyCommand(const Kalmar::HSADevice *copyDevice, const hc::
         }
 
         auto fenceScope = (hsaQueue()->nextSyncNeedsSysRelease()) ? hc::system_scope : hc::no_scope;
+
         depAsyncOp = std::static_pointer_cast<HSAOp> (hsaQueue()->detectStreamDeps(this->getCommandKind(), this));
+        if (depAsyncOp) {
+            depSignal = * (static_cast <hsa_signal_t*> (depAsyncOp->getNativeHandle()));
+        }
 
         // We need to ensure the copy waits for preceding commands the HCC queue to complete, if those commands exist.
         // The copy has to be set so that it depends on the completion_signal of the youngest command in the queue.
-        if (depAsyncOp) {
-            depSignal = * (static_cast <hsa_signal_t*> (depAsyncOp->getNativeHandle()));
-
+        if (depAsyncOp || fenceScope != hc::no_scope) {
+        
             // Normally we can use the input signal to hsa_amd_memory_async_copy to ensure the copy waits for youngest op.
             // However, two cases require special handling:
             //    - the youngest op may not have a completion signal - this is optional for kernel launch commands.
@@ -5320,7 +5323,7 @@ HSACopy::enqueueAsyncCopyCommand(const Kalmar::HSADevice *copyDevice, const hc::
             //      in streams that we depend on.
             // For both of these cases, we create an additional barrier packet in the source, and attach the desired fence.
             // Then we make the copy depend on the signal written by this command.
-            if ((depSignal.handle == 0x0) || (fenceScope != hc::no_scope)) {
+            if ((depAsyncOp && depSignal.handle == 0x0) || (fenceScope != hc::no_scope)) {
                 DBOUT( DB_CMD2, "  asyncCopy adding marker for needed dependency or release\n");
 
                 // Set depAsyncOp for use by the async copy below:


### PR DESCRIPTION
- after a device to device memory copy, signal that the next sync needs a system release
- before a copy, even when there's no dependent async op, if the queue indicates that the next sync needs a system release, enqueue a marker with system scope release
- add extra debug message to getter/setter for the nextSyncNeedsSysRelease flag 