### PR TITLE
set failing tests as expected fails

### DIFF
--- a/tests/Unit/AMDGPU/register-control.cpp
+++ b/tests/Unit/AMDGPU/register-control.cpp
@@ -1,7 +1,6 @@
 // RUN: %hc %s -o %t.out -Xlinker -dump-llvm -Xlinker -dump-dir=%T %target_all_gpus
 // RUN: %llvm-dis %T/dump-gfx803.opt.bc -f -o - | %FileCheck %s
 // RUN: %t.out
-// XFAIL: *
 
 #include <hc.hpp>
 #include <vector>

--- a/tests/Unit/AMDGPU/register-control.cpp
+++ b/tests/Unit/AMDGPU/register-control.cpp
@@ -1,6 +1,7 @@
 // RUN: %hc %s -o %t.out -Xlinker -dump-llvm -Xlinker -dump-dir=%T %target_all_gpus
 // RUN: %llvm-dis %T/dump-gfx803.opt.bc -f -o - | %FileCheck %s
 // RUN: %t.out
+// XFAIL: *
 
 #include <hc.hpp>
 #include <vector>

--- a/tests/Unit/AmpShortVectors/amp_short_vectors_2files.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_2files.cpp
@@ -1,6 +1,7 @@
 // RUN: %cxxamp -DFILE_1 -c %s -o %t.1.o
 // RUN: %cxxamp -DFILE_2 -c %s -o %t.2.o
 // RUN: %cxxamp %t.1.o %t.2.o -o %t.out
+// XFAIL: *
 
 // this test try to link 2 files which use C++AMP short vectors API in one
 // executable.  so it tests if short vector APIs would violate ODR rule

--- a/tests/Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
@@ -1,6 +1,7 @@
 // RUN: %cxxamp -DFILE_1 -c %s -o %t.1.o
 // RUN: %cxxamp -DFILE_2 -c %s -o %t.2.o
 // RUN: %cxxamp %t.1.o %t.2.o -o %t.out
+// XFAIL: *
 
 // this test try to link 2 files which use C++AMP short vectors API in one
 // executable.  so it tests if short vector APIs would violate ODR rule

--- a/tests/Unit/Codegen/deser_def_body_compound_support_inheritclass.cpp
+++ b/tests/Unit/Codegen/deser_def_body_compound_support_inheritclass.cpp
@@ -1,5 +1,6 @@
 // RUN: %amp_device -D__KALMAR_ACCELERATOR__=1 %s -c -o %t.device.o
 // RUN: %gtest_amp %s %t.device.o -o %t && %t
+// XFAIL: *
 
 #include <stdlib.h>
 #ifndef __KALMAR_ACCELERATOR__ //gtest requires rtti, but amp_device forbids rtti

--- a/tests/known_failures
+++ b/tests/known_failures
@@ -29,7 +29,6 @@
     CPPAMP :: Unit/HC/accelerator_get_all_views_mt.cpp
 
 # Disable these test TEMPORARILY (as of June 22nd, 2018) until we get fixes for them:
-    CPPAMP :: Unit/AMDGPU/register-control.cpp
     CPPAMP :: Unit/AmpShortVectors/amp_short_vectors_2files.cpp
     CPPAMP :: Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
     CPPAMP :: Unit/Codegen/deser_def_body_compound_support_inheritclass.cpp


### PR DESCRIPTION
Adding XFAIL for the following tests, so they are counted as expected fails.

  HCC :: Unit/AMDGPU/register-control.cpp
    HCC :: Unit/AmpShortVectors/amp_short_vectors_2files.cpp
    HCC :: Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
    HCC :: Unit/Codegen/deser_def_body_compound_support_inheritclass.cpp
