### PR TITLE
initial protyping for std/hc vector

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -194,7 +194,7 @@ public:
      * the parent accelerator.
      */
     // FIXME: dummy implementation now
-    bool get_is_debug() const { return 0; } 
+    bool get_is_debug() const { return 0; }
 
     /**
      * Performs a blocking wait for completion of all commands submitted to the
@@ -205,8 +205,8 @@ public:
      *                     hcWaitModeActive would be used to reduce latency with
      *                     the expense of using one CPU core for active waiting.
      */
-    void wait(hcWaitMode waitMode = hcWaitModeBlocked) { 
-      pQueue->wait(waitMode); 
+    void wait(hcWaitMode waitMode = hcWaitModeBlocked) {
+      pQueue->wait(waitMode);
       Kalmar::getContext()->flushPrintfBuffer();
     }
 
@@ -217,10 +217,10 @@ public:
      * An accelerator_view internally maintains a buffer of commands such as
      * data transfers between the host memory and device buffers, and kernel
      * invocations (parallel_for_each calls). This member function sends the
-     * commands to the device for processing. Normally, these commands 
+     * commands to the device for processing. Normally, these commands
      * to the GPU automatically whenever the runtime determines that they need
-     * to be, such as when the command buffer is full or when waiting for 
-     * transfer of data from the device buffers to host memory. The flush 
+     * to be, such as when the command buffer is full or when waiting for
+     * transfer of data from the device buffers to host memory. The flush
      * member function will send the commands manually to the device.
      *
      * Calling this member function incurs an overhead and must be used with
@@ -246,7 +246,7 @@ public:
      * commands that were submitted prior to the marker event creation have
      * completed, the future is ready.
      *
-     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order),
      * the marker always ensures older commands complete before the returned completion_future
      * is marked ready.   Thus, markers provide a mechanism to enforce order between
      * commands in an execute_any_order accelerator_view.
@@ -269,7 +269,7 @@ public:
      * dependent event and all commands submitted prior to the marker event
      * creation have been completed, the future is ready.
      *
-     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order),
      * the marker always ensures older commands complete before the returned completion_future
      * is marked ready.   Thus, markers provide a mechanism to enforce order between
      * commands in an execute_any_order accelerator_view.
@@ -280,7 +280,7 @@ public:
      *   - system_scope: Memory is acquired from and released to system scope (all accelerators including CPUs)
      *
      * dependent_futures may be recorded in another queue or another accelerator.  If in another accelerator,
-     * the runtime performs cross-accelerator sychronization.  
+     * the runtime performs cross-accelerator sychronization.
      *
      * @return A future which can be waited on, and will block until the
      *         current batch of commands, plus the dependent event have
@@ -296,7 +296,7 @@ public:
      * dependent events and all commands submitted prior to the marker event
      * creation have been completed, the completion_future is ready.
      *
-     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order),
      * the marker always ensures older commands complete before the returned completion_future
      * is marked ready.   Thus, markers provide a mechanism to enforce order between
      * commands in an execute_any_order accelerator_view.
@@ -321,7 +321,7 @@ public:
      * dependent events and all commands submitted prior to the marker event
      * creation have been completed, the completion_future is ready.
      *
-     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order), 
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order),
      * the marker always ensures older commands complete before the returned completion_future
      * is marked ready.   Thus, markers provide a mechanism to enforce order between
      * commands in an execute_any_order accelerator_view.
@@ -334,8 +334,8 @@ public:
     completion_future create_blocking_marker(InputIterator first, InputIterator last, memory_scope scope) const;
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
      * Note the src is the first parameter and dst is second, following C++ convention.
      * The copy command will execute after any commands already inserted into the accelerator_view finish.
      * This is a synchronous copy command, and the copy operation complete before this call returns.
@@ -346,15 +346,15 @@ public:
 
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
      * Note the src is the first parameter and dst is second, following C++ convention.
      * The copy command will execute after any commands already inserted into the accelerator_view finish.
      * This is a synchronous copy command, and the copy operation complete before this call returns.
      * The copy_ext flavor allows caller to provide additional information about each pointer, which can improve performance by eliminating replicated lookups.
      * This interface is intended for language runtimes such as HIP.
-    
-     @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice. 
+
+     @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice.
      @p forceUnpinnedCopy : Force copy to be performed with host involvement rather than with accelerator copy engines.
      */
     void copy_ext(const void *src, void *dst, size_t size_bytes, hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, const hc::accelerator *copyAcc, bool forceUnpinnedCopy);
@@ -364,9 +364,9 @@ public:
     void copy_ext(const void *src, void *dst, size_t size_bytes, hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, bool forceUnpinnedCopy) ;
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
-     * Note the src is the first parameter and dst is second, following C++ convention.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
+     * Note the src is the first parameter and dst is second, following C++ convention.
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
      * If the source or dest is host memory, the memory must be pinned or a runtime exception will be thrown.
      * Pinned memory can be created with am_alloc with flag=amHostPinned flag.
@@ -381,9 +381,9 @@ public:
 
 
     /**
-     * Copies size_bytes bytes from src to dst.  
-     * Src and dst must not overlap.  
-     * Note the src is the first parameter and dst is second, following C++ convention.  
+     * Copies size_bytes bytes from src to dst.
+     * Src and dst must not overlap.
+     * Note the src is the first parameter and dst is second, following C++ convention.
      * This is an asynchronous copy command, and this call may return before the copy operation completes.
      * If the source or dest is host memory, the memory must be pinned or a runtime exception will be thrown.
      * Pinned memory can be created with am_alloc with flag=amHostPinned flag.
@@ -394,18 +394,18 @@ public:
      *   The copyAcc determines where the copy is executed and does not affect the ordering.
      *
      * The copy_async_ext flavor allows caller to provide additional information about each pointer, which can improve performance by eliminating replicated lookups,
-     * and also allow control over which device performs the copy.  
+     * and also allow control over which device performs the copy.
      * This interface is intended for language runtimes such as HIP.
      *
-     *  @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice. 
+     *  @p copyDir : Specify direction of copy.  Must be hcMemcpyHostToHost, hcMemcpyHostToDevice, hcMemcpyDeviceToHost, or hcMemcpyDeviceToDevice.
      *  @p copyAcc : Specify which accelerator performs the copy operation.  The specified accelerator must have access to the source and dest pointers - either
      *               because the memory is allocated on those devices or because the accelerator has peer access to the memory.
      *               If copyAcc is nullptr, then the copy will be performed by the host.  In this case, the host accelerator must have access to both pointers.
-     *               The copy operation will be performed by the specified engine but is not synchronized with respect to any operations on that device.  
+     *               The copy operation will be performed by the specified engine but is not synchronized with respect to any operations on that device.
      *
      */
-    completion_future copy_async_ext(const void *src, void *dst, size_t size_bytes, 
-                                     hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, 
+    completion_future copy_async_ext(const void *src, void *dst, size_t size_bytes,
+                                     hcCommandKind copyDir, const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo,
                                      const hc::accelerator *copyAcc);
 
     /**
@@ -481,7 +481,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM region on the HSA agent.
-     * This region can be used to allocate accelerator memory which is accessible from the 
+     * This region can be used to allocate accelerator memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -494,7 +494,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate system memory which is accessible from the 
+     * This region can be used to allocate system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -506,7 +506,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * This region can be used to allocate finegrained system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -537,34 +537,34 @@ public:
     /**
      * Dispatch a kernel into the accelerator_view.
      *
-     * This function is intended to provide a gateway to dispatch code objects, with 
+     * This function is intended to provide a gateway to dispatch code objects, with
      * some assistance from HCC.  Kernels are specified in the standard code object
-     * format, and can be created from a varety of compiler tools including the 
+     * format, and can be created from a varety of compiler tools including the
      * assembler, offline cl compilers, or other tools.    The caller also
-     * specifies the execution configuration and kernel arguments.    HCC 
+     * specifies the execution configuration and kernel arguments.    HCC
      * will copy the kernel arguments into an appropriate segment and insert
-     * the packet into the queue.   HCC will also automatically handle signal 
+     * the packet into the queue.   HCC will also automatically handle signal
      * and kernarg allocation and deallocation for the command.
      *
-     *  The kernel is dispatched asynchronously, and thus this API may return before the 
+     *  The kernel is dispatched asynchronously, and thus this API may return before the
      *  kernel finishes executing.
-     
+
      *  Kernels dispatched with this API may be interleaved with other copy and kernel
-     *  commands generated from copy or parallel_for_each commands.  
-     *  The kernel honors the execute_order associated with the accelerator_view.  
+     *  commands generated from copy or parallel_for_each commands.
+     *  The kernel honors the execute_order associated with the accelerator_view.
      *  Specifically, if execute_order is execute_in_order, then the kernel
      *  will wait for older data and kernel commands in the same queue before
-     *  beginning execution.  If execute_order is execute_any_order, then the 
-     *  kernel may begin executing without regards to the state of older kernels.  
-     *  This call honors the packer barrier bit (1 << HSA_PACKET_HEADER_BARRIER) 
+     *  beginning execution.  If execute_order is execute_any_order, then the
+     *  kernel may begin executing without regards to the state of older kernels.
+     *  This call honors the packer barrier bit (1 << HSA_PACKET_HEADER_BARRIER)
      *  if set in the aql.header field.  If set, this provides the same synchronization
      *  behaviora as execute_in_order for the command generated by this API.
      *
-     * @p aql is an HSA-format "AQL" packet. The following fields must 
+     * @p aql is an HSA-format "AQL" packet. The following fields must
      * be set by the caller:
-     *  aql.kernel_object 
+     *  aql.kernel_object
      *  aql.group_segment_size : includes static + dynamic group size
-     *  aql.private_segment_size 
+     *  aql.private_segment_size
      *  aql.grid_size_x, aql.grid_size_y, aql.grid_size_z
      *  aql.group_size_x, aql.group_size_y, aql.group_size_z
      *  aql.setup :  The 2 bits at HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS.
@@ -574,19 +574,19 @@ public:
                  (1 << HSA_PACKET_HEADER_BARRIER);
 
      * The following fields are ignored.  The API will will set up these fields before dispatching the AQL packet:
-     *  aql.completion_signal 
-     *  aql.kernarg 
-     * 
+     *  aql.completion_signal
+     *  aql.kernarg
+     *
      * @p args : Pointer to kernel arguments with the size and aligment expected by the kernel.  The args are copied and then passed directly to the kernel.   After this function returns, the args memory may be deallocated.
      * @p argSz : Size of the arguments.
      * @p cf : Written with a completion_future that can be used to track the status
-     *          of the dispatch.  May be NULL, in which case no completion_future is 
-     *          returned and the caller must use other synchronization techniqueues 
+     *          of the dispatch.  May be NULL, in which case no completion_future is
+     *          returned and the caller must use other synchronization techniqueues
      *          such as calling accelerator_view::wait() or waiting on a younger command
      *          in the same queue.
-     * @p kernel_name : Optionally specify the name of the kernel for debug and profiling.  
+     * @p kernel_name : Optionally specify the name of the kernel for debug and profiling.
      * May be null.  If specified, the caller is responsible for ensuring the memory for the name remains allocated until the kernel completes.
-     *        
+     *
      *
      * The dispatch_hsa_kernel call will perform the following operations:
      *    - Efficiently allocate a kernarg region and copy the arguments.
@@ -594,17 +594,17 @@ public:
      *    - Dispatch the command into the queue and flush it to the GPU.
      *    - Kernargs and signals are automatically reclaimed by the HCC runtime.
      */
-    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql, 
+    void dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql,
                            const void * args, size_t argsize,
-                           hc::completion_future *cf=nullptr, const char *kernel_name = nullptr) 
+                           hc::completion_future *cf=nullptr, const char *kernel_name = nullptr)
     {
         pQueue->dispatch_hsa_kernel(aql, args, argsize, cf, kernel_name);
     }
 
     /**
-     * Set a CU affinity to specific command queues. 
+     * Set a CU affinity to specific command queues.
      * The setting is permanent until the queue is destroyed or CU affinity is
-     * set again. This setting is "atomic", it won't affect the dispatch in flight. 
+     * set again. This setting is "atomic", it won't affect the dispatch in flight.
      *
      * @param cu_mask a bool vector to indicate what CUs you want to use. True
      *        represents using the cu. The first 32 elements represents the first
@@ -630,7 +630,7 @@ private:
     friend class accelerator;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Kernel> friend
         void* Kalmar::mcw_cxxamp_get_kernel(const std::shared_ptr<Kalmar::KalmarQueue>&, const Kernel&);
     template<typename Kernel, int dim_ext> friend
@@ -641,7 +641,7 @@ private:
         void Kalmar::mcw_cxxamp_launch_kernel(const std::shared_ptr<Kalmar::KalmarQueue>&, size_t *, size_t *, const Kernel&);
     template<typename Kernel, int dim_ext> friend
         std::shared_ptr<Kalmar::KalmarAsyncOp> Kalmar::mcw_cxxamp_launch_kernel_async(const std::shared_ptr<Kalmar::KalmarQueue>&, size_t *, size_t *, const Kernel&);
-  
+
 #if __KALMAR_ACCELERATOR__ == 2 || __KALMAR_CPU__ == 2
     template <typename Kernel, int N> friend
         completion_future launch_cpu_task_async(const std::shared_ptr<Kalmar::KalmarQueue>&, Kernel const&, extent<N> const&);
@@ -651,27 +651,27 @@ private:
     // generic version
     template <int N, typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<N>&, const Kernel&);
-  
+
     // 1D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<1>&, const Kernel&);
-  
+
     // 2D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<2>&, const Kernel&);
-  
+
     // 3D specialization
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const extent<3>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 3D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<3>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 2D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<2>&, const Kernel&);
-  
+
     // tiled parallel_for_each, 1D version
     template <typename Kernel> friend
         completion_future parallel_for_each(const accelerator_view&, const tiled_extent<1>&, const Kernel&);
@@ -702,7 +702,7 @@ class accelerator
 public:
     /**
      * Constructs a new accelerator object that represents the default
-     * accelerator. This is equivalent to calling the constructor 
+     * accelerator. This is equivalent to calling the constructor
      * @code{.cpp}
      * accelerator(accelerator::default_accelerator)
      * @endcode
@@ -825,7 +825,7 @@ public:
         pQueue->set_mode(mode);
         return pQueue;
     }
-  
+
     /**
      * Compares "this" accelerator with the passed accelerator object to
      * determine if they represent the same underlying device.
@@ -854,9 +854,9 @@ public:
      * this this accelerator.
      *
      * This method only succeeds if the default_cpu_access_type for the
-     * accelerator has not already been overriden by a previous call to this 
-     * method and the runtime selected default_cpu_access_type for this 
-     * accelerator has not yet been used for allocating an array or for an 
+     * accelerator has not already been overriden by a previous call to this
+     * method and the runtime selected default_cpu_access_type for this
+     * accelerator has not yet been used for allocating an array or for an
      * implicit array_view memory allocation on this accelerator.
      *
      * @param[in] default_cpu_access_type The default cpu access_type to be used
@@ -944,8 +944,8 @@ public:
      * Get the default cpu access_type for buffers created on this accelerator
      */
     access_type get_default_cpu_access_type() const { return pDev->get_access(); }
-  
-  
+
+
     /**
      * Returns the maximum size of tile static area available on this
      * accelerator.
@@ -953,7 +953,7 @@ public:
     size_t get_max_tile_static_size() {
       return get_default_view().get_max_tile_static_size();
     }
-  
+
     /**
      * Returns a vector of all accelerator_view associated with this accelerator.
      */
@@ -968,7 +968,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM region on the HSA agent.
-     * This region can be used to allocate accelerator memory which is accessible from the 
+     * This region can be used to allocate accelerator memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -980,7 +980,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate system memory which is accessible from the 
+     * This region can be used to allocate system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -992,7 +992,7 @@ public:
 
     /**
      * Returns an opaque handle which points to the AM system region on the HSA agent.
-     * This region can be used to allocate finegrained system memory which is accessible from the 
+     * This region can be used to allocate finegrained system memory which is accessible from the
      * specified accelerator.
      *
      * @return An opaque handle of the region, if the accelerator is based
@@ -1061,9 +1061,9 @@ public:
     bool get_is_peer(const accelerator& other) const {
         return pDev->is_peer(other.pDev);
     }
-      
+
     /**
-     * Return a std::vector of this accelerator's peers. peer is other accelerator which can access this 
+     * Return a std::vector of this accelerator's peers. peer is other accelerator which can access this
      * accelerator's device memory using map_to_peer family of APIs.
      *
      */
@@ -1107,7 +1107,7 @@ public:
         return pDev->has_cpu_accessible_am();
     };
 
-    Kalmar::KalmarDevice *get_dev_ptr() const { return pDev; }; 
+    Kalmar::KalmarDevice *get_dev_ptr() const { return pDev; };
 
 private:
     accelerator(Kalmar::KalmarDevice* pDev) : pDev(pDev) {}
@@ -1236,7 +1236,7 @@ public:
         if (this->valid()) {
             if (__asyncOp != nullptr) {
                 __asyncOp->setWaitMode(mode);
-            }   
+            }
             //TODO-ASYNC - need to reclaim older AsyncOps here.
             __amp_future.wait();
         }
@@ -1296,7 +1296,7 @@ public:
      * purpose.
      * Applications should retain the parent completion_future to ensure
      * the native handle is not deallocated by the HCC runtime.  The completion_future
-     * pointer to the native handle is reference counted, so a copy of 
+     * pointer to the native handle is reference counted, so a copy of
      * the completion_future is sufficient to retain the native_handle.
      */
     void* get_native_handle() const {
@@ -1368,7 +1368,7 @@ public:
       }
       delete __thread_then;
       __thread_then = nullptr;
-      
+
       if (__asyncOp != nullptr) {
         __asyncOp = nullptr;
       }
@@ -1391,7 +1391,7 @@ private:
         : __amp_future(__future), __thread_then(nullptr), __asyncOp(nullptr) {}
 
     friend class Kalmar::HSAQueue;
-    
+
     // non-tiled parallel_for_each
     // generic version
     template <int N, typename Kernel> friend
@@ -1462,7 +1462,7 @@ accelerator_view::get_accelerator() const { return pQueue->getDev(); }
 
 inline completion_future
 accelerator_view::create_marker(memory_scope scope) const {
-    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[1]; 
+    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[1];
     // If necessary create an explicit dependency on previous command
     // This is necessary for example if copy command is followed by marker - we need the marker to wait for the copy to complete.
     std::shared_ptr<Kalmar::KalmarAsyncOp> depOp = pQueue->detectStreamDeps(hcCommandMarker, nullptr);
@@ -1478,7 +1478,7 @@ accelerator_view::create_marker(memory_scope scope) const {
 inline unsigned int accelerator_view::get_version() const { return get_accelerator().get_version(); }
 
 inline completion_future accelerator_view::create_blocking_marker(completion_future& dependent_future, memory_scope scope) const {
-    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[2]; 
+    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[2];
 
     // If necessary create an explicit dependency on previous command
     // This is necessary for example if copy command is followed by marker - we need the marker to wait for the copy to complete.
@@ -1491,8 +1491,8 @@ inline completion_future accelerator_view::create_blocking_marker(completion_fut
 
     if (dependent_future.__asyncOp) {
         deps[cnt++] = dependent_future.__asyncOp; // retrieve async op associated with completion_future
-    } 
-    
+    }
+
     return completion_future(pQueue->EnqueueMarkerWithDependency(cnt, deps, scope));
 }
 
@@ -1555,8 +1555,8 @@ accelerator_view::copy_async(const void *src, void *dst, size_t size_bytes) {
 
 inline completion_future
 accelerator_view::copy_async_ext(const void *src, void *dst, size_t size_bytes,
-                             hcCommandKind copyDir, 
-                             const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo, 
+                             hcCommandKind copyDir,
+                             const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo,
                              const hc::accelerator *copyAcc)
 {
     return completion_future(pQueue->EnqueueAsyncCopyExt(src, dst, size_bytes, copyDir, srcInfo, dstInfo, copyAcc ? copyAcc->pDev : nullptr));
@@ -1996,12 +1996,12 @@ template <int N>
 class tiled_extent : public extent<N> {
 public:
     static const int rank = N;
-  
+
     /**
      * Tile size for each dimension.
      */
     int tile_dim[N];
-  
+
     /**
      * Default constructor. The origin and extent is default-constructed and
      * thus zero.
@@ -2084,7 +2084,7 @@ public:
      * @param[in] ext The extent of this tiled_extent
      * @param[in] t0 Size of tile.
      */
-    tiled_extent(const extent<1>& ext, int t0) __CPU__ __HC__ : extent(ext), dynamic_group_segment_size(0), tile_dim{t0} {} 
+    tiled_extent(const extent<1>& ext, int t0) __CPU__ __HC__ : extent(ext), dynamic_group_segment_size(0), tile_dim{t0} {}
 
     /**
      * Constructs a tiled_extent<N> with the extent "ext".
@@ -2371,7 +2371,7 @@ tiled_extent<3> extent<N>::tile_with_dynamic(int t0, int t1, int t2, int dynamic
  * @return The size of a wavefront.
  */
 #define __HSA_WAVEFRONT_SIZE__ (64)
-extern "C" unsigned int __wavesize() __HC__; 
+extern "C" unsigned int __wavesize() __HC__;
 
 
 #if __hcc_backend__==HCC_BACKEND_AMDGPU
@@ -2904,15 +2904,15 @@ inline float __amdgcn_ds_swizzle(float src, int pattern) [[hc]] {
 /**
  * move DPP intrinsic
  */
-extern "C" int __amdgcn_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl) [[hc]]; 
+extern "C" int __amdgcn_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl) [[hc]];
 
 /**
- * Shift the value of src to the right by one thread within a wavefront.  
- * 
+ * Shift the value of src to the right by one thread within a wavefront.
+ *
  * @param[in] src variable being shifted
  * @param[in] bound_ctrl When set to true, a zero will be shifted into thread 0; otherwise, the original value will be returned for thread 0
- * @return value of src being shifted into from the neighboring lane 
- * 
+ * @return value of src being shifted into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_sr1(int src, bool bound_ctrl) [[hc]];
 inline unsigned int __amdgcn_wave_sr1(unsigned int src, bool bound_ctrl) [[hc]] {
@@ -2927,14 +2927,14 @@ inline float __amdgcn_wave_sr1(float src, bool bound_ctrl) [[hc]] {
 }
 
 /**
- * Shift the value of src to the left by one thread within a wavefront.  
- * 
+ * Shift the value of src to the left by one thread within a wavefront.
+ *
  * @param[in] src variable being shifted
  * @param[in] bound_ctrl When set to true, a zero will be shifted into thread 63; otherwise, the original value will be returned for thread 63
- * @return value of src being shifted into from the neighboring lane 
- * 
+ * @return value of src being shifted into from the neighboring lane
+ *
  */
-extern "C" int __amdgcn_wave_sl1(int src, bool bound_ctrl) [[hc]];  
+extern "C" int __amdgcn_wave_sl1(int src, bool bound_ctrl) [[hc]];
 inline unsigned int __amdgcn_wave_sl1(unsigned int src, bool bound_ctrl) [[hc]] {
   __u tmp; tmp.u = src;
   tmp.i = __amdgcn_wave_sl1(tmp.i, bound_ctrl);
@@ -2948,11 +2948,11 @@ inline float __amdgcn_wave_sl1(float src, bool bound_ctrl) [[hc]] {
 
 
 /**
- * Rotate the value of src to the right by one thread within a wavefront.  
- * 
+ * Rotate the value of src to the right by one thread within a wavefront.
+ *
  * @param[in] src variable being rotated
- * @return value of src being rotated into from the neighboring lane 
- * 
+ * @return value of src being rotated into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_rr1(int src) [[hc]];
 inline unsigned int __amdgcn_wave_rr1(unsigned int src) [[hc]] {
@@ -2967,11 +2967,11 @@ inline float __amdgcn_wave_rr1(float src) [[hc]] {
 }
 
 /**
- * Rotate the value of src to the left by one thread within a wavefront.  
- * 
+ * Rotate the value of src to the left by one thread within a wavefront.
+ *
  * @param[in] src variable being rotated
- * @return value of src being rotated into from the neighboring lane 
- * 
+ * @return value of src being rotated into from the neighboring lane
+ *
  */
 extern "C" int __amdgcn_wave_rl1(int src) [[hc]];
 inline unsigned int __amdgcn_wave_rl1(unsigned int src) [[hc]] {
@@ -2987,7 +2987,7 @@ inline float __amdgcn_wave_rl1(float src) [[hc]] {
 
 #endif
 
-/* definition to expand macro then apply to pragma message 
+/* definition to expand macro then apply to pragma message
 #define VALUE_TO_STRING(x) #x
 #define VALUE(x) VALUE_TO_STRING(x)
 #define VAR_NAME_VALUE(var) #var "="  VALUE(var)
@@ -3962,12 +3962,14 @@ struct projection_helper
     }
 };
 
+template <typename T, int N = 1>
+class vector;
+
 template <typename T>
 struct projection_helper<T, 1>
 {
-    // array_view<T,1>
-    //      T& operator[](int i) const __CPU__ __HC__;
     typedef T& result_type;
+
     static result_type project(array_view<T, 1>& now, int i) __CPU__ __HC__ {
 #if __KALMAR_ACCELERATOR__ != 1
         now.cache.get_cpu_access(true);
@@ -3976,6 +3978,21 @@ struct projection_helper<T, 1>
         return *ptr;
     }
     static result_type project(const array_view<T, 1>& now, int i) __CPU__ __HC__ {
+#if __KALMAR_ACCELERATOR__ != 1
+        now.cache.get_cpu_access(true);
+#endif
+        T *ptr = reinterpret_cast<T *>(now.cache.get() + i + now.offset + now.index_base[0]);
+        return *ptr;
+    }
+
+    static result_type project(vector<T, 1>& now, int i) __CPU__ __HC__ {
+#if __KALMAR_ACCELERATOR__ != 1
+        now.cache.get_cpu_access(true);
+#endif
+        T *ptr = reinterpret_cast<T *>(now.cache.get() + i + now.offset + now.index_base[0]);
+        return *ptr;
+    }
+    static result_type project(const vector<T, 1>& now, int i) __CPU__ __HC__ {
 #if __KALMAR_ACCELERATOR__ != 1
         now.cache.get_cpu_access(true);
 #endif
@@ -4077,7 +4094,6 @@ struct __is_container
     using _T = typename std::remove_reference<T>::type;
     static const bool value = __has_size<_T>::value && __has_data<_T>::value;
 };
-
 
 // ------------------------------------------------------------------------
 // utility helper classes for array
@@ -4196,6 +4212,75 @@ template <typename OutputIter, typename T, int N>
 void copy(const array<T, N> &src, OutputIter destBegin);
 
 // ------------------------------------------------------------------------
+// vector
+// ------------------------------------------------------------------------
+
+template <typename T, int N>
+class vector : public std::vector<T> {
+#if __KALMAR_ACCELERATOR__ == 1
+    typedef Kalmar::_data<T> acc_buffer_t;
+#else
+    typedef Kalmar::_data_host<T> acc_buffer_t;
+#endif
+ public:
+  static const int rank = N;
+  typedef T value_type;
+
+  vector(vector&& that)  __CPU__ __HC__
+    : std::vector<T>(that), offset(that.offset){
+    if(this != &that){
+      this->cache = acc_buffer_t(that.size(), that.data());
+      extent = hc::extent<N>(that.size());
+      extent_base = extent;
+    }
+  }
+  vector(vector& that) __CPU__ __HC__
+    : std::vector<T>(that), offset(that.offset){
+    if(this != &that){
+      this->cache = acc_buffer_t(that.size(), that.data());
+      extent = hc::extent<N>(that.size());
+      extent_base = extent;
+    }
+  }
+  vector(){}
+  ~vector() __CPU__ __HC__ {}
+
+  T& operator[] (const index<N>& idx) const __CPU__ __HC__ {
+#if __KALMAR_ACCELERATOR__ != 1
+      cache.get_cpu_access(true);
+#endif
+      T *ptr = reinterpret_cast<T*>(cache.get() + offset);
+      return ptr[Kalmar::amp_helper<N, index<N>, hc::extent<N>>::flatten(idx + index_base, extent_base)];
+  }
+
+  vector& operator=(const vector&& other) __CPU__ __HC__  = delete;
+  vector& operator=(const vector& other) __CPU__ __HC__ = delete;
+
+  typename projection_helper<T, N>::result_type
+  operator[] (int i) const  __HC__ {
+      return projection_helper<T, N>::project(*this, i);
+  }
+
+  const T&
+  operator[] (int i) const __CPU__  {
+      return std::vector<T>::operator[](i);
+  }
+  T&
+  operator[] (int i)  __CPU__  {
+      return std::vector<T>::operator[](i);
+  }
+
+ private:
+  template <typename K, int Q> friend struct projection_helper;
+
+  int offset = 0;
+  acc_buffer_t cache;
+  hc::extent<N> extent;
+  hc::extent<N> extent_base;
+  index<N> index_base;
+};
+
+// ------------------------------------------------------------------------
 // array
 // ------------------------------------------------------------------------
 
@@ -4230,7 +4315,7 @@ public:
      * There is no default constructor for array<T,N>.
      */
     array() = delete;
- 
+
     /**
      * Copy constructor. Constructs a new array<T,N> from the supplied argument
      * other. The new array is located on the same accelerator_view as the
@@ -4310,7 +4395,7 @@ public:
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
-     * @param[in] srcBegin A beginning iterator into the source container. 
+     * @param[in] srcBegin A beginning iterator into the source container.
      * @param[in] srcEnd An ending iterator into the source container.
      */
     template <typename InputIter>
@@ -4412,7 +4497,7 @@ public:
     /** @{ */
     /**
      * Equivalent to construction using
-     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".   
+     * "array(extent<N>(e0 [, e1 [, e2 ]]), av, cpu_access_type)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
      *                     this array.
@@ -4480,7 +4565,7 @@ public:
      *
      * Users can optionally specify the type of CPU access desired for "this"
      * array thus requesting creation of an array that is accessible both on
-     * the specified accelerator_view "av" as well as the CPU (with the 
+     * the specified accelerator_view "av" as well as the CPU (with the
      * specified CPU access_type). If a value other than access_type_auto or
      * access_type_none is specified for the cpu_access_type parameter and the
      * accelerator corresponding to the accelerator_view “av” does not support
@@ -4555,7 +4640,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to construction using 
+     * Equivalent to construction using
      * "array(extent<N>(e0 [, e1 [, e2 ]]), av, associated_av)".
      *
      * @param[in] e0,e1,e2 The component values that will form the extent of
@@ -4678,7 +4763,7 @@ public:
      * This property returns the CPU "access_type" allowed for this array.
      */
     access_type get_cpu_access_type() const { return m_device.get_access(); }
-  
+
     /**
      * Assigns the contents of the array "other" to this array, using a deep
      * copy.
@@ -4724,7 +4809,7 @@ public:
         *this = std::move(arr);
         return *this;
     }
-  
+
     /**
      * Copies the contents of this array to the array given by "dest", as
      * if by calling "copy(*this, dest)".
@@ -5628,7 +5713,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -5714,7 +5799,7 @@ private:
     template <typename K, int Q> friend struct array_projection_helper;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Q, int K> friend
         bool is_flat(const array_view<Q, K>&) noexcept;
     template <typename Q, int K> friend
@@ -5727,7 +5812,7 @@ private:
         void copy(const array_view<Q, K>&, OutputIter);
     template <typename Q, int K> friend
         void copy(const array_view<const Q, K>& src, const array_view<Q, K>& dest);
-  
+
     // used by view_as and reinterpret_as
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext,
                int offset) __CPU__ __HC__
@@ -5739,7 +5824,7 @@ private:
                const index<N>& idx_b, int off) __CPU__ __HC__
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b),
         offset(off) {}
-  
+
     acc_buffer_t cache;
     hc::extent<N> extent;
     hc::extent<N> extent_base;
@@ -5924,7 +6009,7 @@ public:
         offset = other.offset;
         return *this;
     }
-  
+
     array_view& operator=(const array_view& other) __CPU__ __HC__ {
         if (this != &other) {
             cache = other.cache;
@@ -6124,7 +6209,7 @@ public:
         static_assert(N == 1, "const T& array_view::operator()(int) is only permissible on array_view<T, 1>");
         return (*this)[index<1>(i0)];
     }
-  
+
     const T& operator()(int i0, int i1) const __CPU__ __HC__ {
         static_assert(N == 2, "const T& array_view::operator()(int,int) is only permissible on array_view<T, 2>");
         return (*this)[index<2>(i0, i1)];
@@ -6209,7 +6294,7 @@ public:
 
     /** @{ */
     /**
-     * Equivalent to 
+     * Equivalent to
      * "section(index<N>(i0 [, i1 [, i2 ]]), extent<N>(e0 [, e1 [, e2 ]]))".
      *
      * @param[in] i0,i1,i2 The component values that will form the origin of
@@ -6293,7 +6378,7 @@ private:
     template <typename K, int Q> friend struct array_projection_helper;
     template <typename Q, int K> friend class array;
     template <typename Q, int K> friend class array_view;
-  
+
     template<typename Q, int K> friend
         bool is_flat(const array_view<Q, K>&) noexcept;
     template <typename Q, int K> friend
@@ -6306,19 +6391,19 @@ private:
         void copy(const array_view<Q, K>&, OutputIter);
     template <typename Q, int K> friend
         void copy(const array_view<const Q, K>& src, const array_view<Q, K>& dest);
-  
+
     // used by view_as and reinterpret_as
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext,
                int offset) __CPU__ __HC__
         : cache(cache), extent(ext), extent_base(ext), offset(offset) {}
-  
+
     // used by section and projection
     array_view(const acc_buffer_t& cache, const hc::extent<N>& ext_now,
                const extent<N>& ext_b,
                const index<N>& idx_b, int off) __CPU__ __HC__
         : cache(cache), extent(ext_now), extent_base(ext_b), index_base(idx_b),
         offset(off) {}
-  
+
     acc_buffer_t cache;
     hc::extent<N> extent;
     hc::extent<N> extent_base;
@@ -7472,7 +7557,7 @@ extern unsigned int atomic_fetch_dec(unsigned int * _Dest) __CPU__ __HC__;
  * - stores the result back to the address
  *
  * @return The original value retrieved from address pointer.
- * 
+ *
  * Please refer to <a href="http://www.hsafoundation.com/html/HSA_Library.htm#PRM/Topics/06_Memory/atomic.htm">atomic_wrapinc in HSA PRM 6.6</a> for more detailed specification of the function.
  */
 extern "C" unsigned int __atomic_wrapinc(unsigned int* address, unsigned int val) __HC__;
@@ -7484,7 +7569,7 @@ extern "C" unsigned int __atomic_wrapinc(unsigned int* address, unsigned int val
  * - stores the result back to the address
  *
  * @return The original value retrieved from address pointer.
- * 
+ *
  * Please refer to <a href="http://www.hsafoundation.com/html/HSA_Library.htm#PRM/Topics/06_Memory/atomic.htm">atomic_wrapdec in HSA PRM 6.6</a> for more detailed specification of the function.
  */
 extern "C" unsigned int __atomic_wrapdec(unsigned int* address, unsigned int val) __HC__;

--- a/include/kalmar_buffer.h
+++ b/include/kalmar_buffer.h
@@ -17,7 +17,7 @@ namespace Kalmar {
 template <typename T>
 class _data {
 public:
-    _data() = delete;
+    _data(){}
     _data(int count) : p_(nullptr) {}
     _data(const _data& d) restrict(cpu, amp)
         : p_(d.p_) {}
@@ -68,6 +68,7 @@ public:
         : mm(std::make_shared<rw_info>(av, stage, count*sizeof(T), device_pointer, mode)), isArray(true) {}
 
     _data_host(const _data_host& other) : mm(other.mm), isArray(false) {}
+    _data_host() : isArray(false) {}
 
     template <typename U>
         _data_host(const _data_host<U>& other) : mm(other.mm), isArray(false) {}


### PR DESCRIPTION
works with [this example](https://gist.github.com/Dekken/92cfcc313e539e1446f669f5c3cd5324)

my text editor is set up to remove trailing white spaces so sorry about that

I don't specifically like the way this is done as _data/_data_host require a default constructor which may not be the best idea