### PR TITLE
Fix reduction unit tests

### DIFF
--- a/tests/Unit/HC/reduction_hc.cpp
+++ b/tests/Unit/HC/reduction_hc.cpp
@@ -1,6 +1,3 @@
-// XFAIL: *
-// JIRA SWDEV-129742
-
 // RUN: %hc %s -o %t.out && %t.out
 
 //----------------------------------------------------------------------------
@@ -83,7 +80,7 @@ float reduction_simple_1(const std::vector<float>& source)
     // Each thread reduces two elements.
     for (unsigned s = element_count / 2; s > 0; s /= 2)
     {
-        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) __attribute((hc))
+        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) [[hc]]
         {
             a[idx] = a[idx] + a[idx + s];
 
@@ -130,7 +127,7 @@ float reduction_simple_2(const std::vector<float>& source)
     unsigned prev_s = element_count;
     for (unsigned s = element_count / window_width; s > 0; s /= window_width)
     {
-        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) __attribute((hc))
+        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) [[hc]]
         {
             float sum = 0.f;
             for(unsigned i = 0; i < window_width; i++)
@@ -194,7 +191,8 @@ float reduction_tiled_1(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -265,7 +263,8 @@ float reduction_tiled_2(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -335,7 +334,7 @@ float reduction_tiled_3(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) [[hc]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -407,7 +406,8 @@ float reduction_tiled_4(const std::vector<float>& source)
     while (element_count >= _tile_size
         && (element_count % (_tile_size * 2)) == 0)
     {
-        parallel_for_each(extent<1>(element_count / 2).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count / 2).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -483,7 +483,8 @@ float reduction_cascade(const std::vector<float>& source)
     array<float, 1> a(element_count, source.begin());
     array<float, 1> a_partial_result(_tile_count);
 
-    parallel_for_each(extent<1>(_tile_count * _tile_size).tile(_tile_size), [=, &a, &a_partial_result] (tiled_index<1> tidx) __attribute((hc))
+    parallel_for_each(extent<1>(_tile_count * _tile_size).tile(_tile_size),
+                     [=, &a, &a_partial_result] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
     {
         // Use tile_static as a scratchpad memory.
         tile_static float tile_data[_tile_size];

--- a/tests/Unit/HC/reduction_tile_static.cpp
+++ b/tests/Unit/HC/reduction_tile_static.cpp
@@ -1,6 +1,3 @@
-// XFAIL: *
-// JIRA SWDEV-129742
-
 // RUN: %hc %s -o %t.out && %t.out
 
 //----------------------------------------------------------------------------
@@ -88,7 +85,8 @@ float reduction_tiled_1(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -159,7 +157,8 @@ float reduction_tiled_2(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -229,7 +228,8 @@ float reduction_tiled_3(const std::vector<float>& source)
     // is evenly divisable to the number of threads in the tile.
     while ((element_count % _tile_size) == 0)
     {
-        parallel_for_each(extent<1>(element_count).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -301,7 +301,8 @@ float reduction_tiled_4(const std::vector<float>& source)
     while (element_count >= _tile_size
         && (element_count % (_tile_size * 2)) == 0)
     {
-        parallel_for_each(extent<1>(element_count / 2).tile(_tile_size), [=] (tiled_index<1> tidx) __attribute((hc))
+        parallel_for_each(extent<1>(element_count / 2).tile(_tile_size),
+                          [=] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
         {
             // Use tile_static as a scratchpad memory.
             tile_static float tile_data[_tile_size];
@@ -377,7 +378,8 @@ float reduction_cascade(const std::vector<float>& source)
     array<float, 1> a(element_count, source.begin());
     array<float, 1> a_partial_result(_tile_count);
 
-    parallel_for_each(extent<1>(_tile_count * _tile_size).tile(_tile_size), [=, &a, &a_partial_result] (tiled_index<1> tidx) __attribute((hc))
+    parallel_for_each(extent<1>(_tile_count * _tile_size).tile(_tile_size),
+                      [=, &a, &a_partial_result] (tiled_index<1> tidx) [[hc]] [[hc_flat_workgroup_size(_tile_size)]]
     {
         // Use tile_static as a scratchpad memory.
         tile_static float tile_data[_tile_size];


### PR DESCRIPTION
These tests launch kernels that require group size larger than
the default max size of 256.  An hc_flat_workgroup_size attribute
is required in order to generate correct code.

Change-Id: I1a8784053c556dcb73004301756fa5a38d28f248