### PR TITLE
Revert "After a device-to-device copy, set the nextSyncNeedsSysReleas…

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -5254,10 +5254,6 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
     // HSA memory copy requires a system-scope acquire before the next kernel command - set flag here so we remember:
     hsaQueue()->setNextKernelNeedsSysAcquire(true);
 
-    // If it's a device to device, the next system sync will need a release
-    if (copyKind ==  Kalmar::hcMemcpyDeviceToDevice)
-      hsaQueue()->setNextSyncNeedsSysRelease(true);
-
     return status;
 }
 


### PR DESCRIPTION
…e flag to true"

This setting of the need sys release flag in the original patch was incorrect and unnecessary, in fact, it causes a regression in one of the HIP stream copy tests.