### PR TITLE
fix symlink to libclang-rt.builtins library in packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,10 +502,20 @@ set(DEBIAN_EXTRA_SCRIPT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/packaging/debian")
 set(DEBIAN_EXTRA_SCRIPT_DEST_DIR "${PROJECT_BINARY_DIR}/packaging/debian")
 file(MAKE_DIRECTORY ${DEBIAN_EXTRA_SCRIPT_DEST_DIR})
 
-execute_process(COMMAND ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/process_packaging_script.bsh ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/postinst.in  ${DEBIAN_EXTRA_SCRIPT_DEST_DIR}/postinst ${CPACK_PACKAGE_NAME} ${HCC_PACKAGE_INSTALL_PREFIX} ${CMAKE_INSTALL_LIBDIR}
+execute_process(COMMAND ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/process_packaging_script.bsh ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/postinst.in
+                                                                                       ${DEBIAN_EXTRA_SCRIPT_DEST_DIR}/postinst
+                                                                                       ${CPACK_PACKAGE_NAME}
+                                                                                       ${HCC_PACKAGE_INSTALL_PREFIX}
+                                                                                       ${CMAKE_INSTALL_LIBDIR}
+                                                                                       ${CMAKE_SYSTEM_PROCESSOR}
                 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
-execute_process(COMMAND ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/process_packaging_script.bsh ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/prerm.in  ${DEBIAN_EXTRA_SCRIPT_DEST_DIR}/prerm ${CPACK_PACKAGE_NAME} ${HCC_PACKAGE_INSTALL_PREFIX} ${CMAKE_INSTALL_LIBDIR}
+execute_process(COMMAND ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/process_packaging_script.bsh ${DEBIAN_EXTRA_SCRIPT_SOURCE_DIR}/prerm.in
+                                                                                       ${DEBIAN_EXTRA_SCRIPT_DEST_DIR}/prerm
+                                                                                       ${CPACK_PACKAGE_NAME}
+                                                                                       ${HCC_PACKAGE_INSTALL_PREFIX}
+                                                                                       ${CMAKE_INSTALL_LIBDIR}
+                                                                                       ${CMAKE_SYSTEM_PROCESSOR}
                 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
 set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc")

--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -5,6 +5,7 @@ set -e
 PACKAGE_NAME=@PACKAGE_NAME@
 INSTALL_PATH=@INSTALL_PATH@
 LIBRARY_DIR=@LIBRARY_DIR@
+PROCESSOR=@PROCESSOR@
 
 ROCM_PATH="/opt/rocm"
 
@@ -20,7 +21,7 @@ SOFTLINKS=(
   "$LIBRARY_DIR" "lib" "libmcwamp_atomic.a"
   "$LIBRARY_DIR" "lib" "libmcwamp_cpu.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_hsa.so"
-  "$LIBRARY_DIR" "lib" "libclang_rt.builtins-@CMAKE_SYSTEM_PROCESSOR@.a"
+  "$LIBRARY_DIR" "lib" "libclang_rt.builtins-${PROCESSOR}.a"
 )
 
 do_softlinks() {

--- a/packaging/debian/prerm.in
+++ b/packaging/debian/prerm.in
@@ -5,6 +5,7 @@ set -e
 PACKAGE_NAME=@PACKAGE_NAME@
 INSTALL_PATH=@INSTALL_PATH@
 LIBRARY_DIR=@LIBRARY_DIR@
+PROCESSOR=@PROCESSOR@
 
 ROCM_PATH="/opt/rocm"
 
@@ -20,7 +21,7 @@ SOFTLINKS=(
   "$LIBRARY_DIR" "lib" "libmcwamp_atomic.a"
   "$LIBRARY_DIR" "lib" "libmcwamp_cpu.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_hsa.so"
-  "$LIBRARY_DIR" "lib" "libclang_rt.builtins-@CMAKE_SYSTEM_PROCESSOR@.a"
+  "$LIBRARY_DIR" "lib" "libclang_rt.builtins-${PROCESSOR}.a"
 )
 
 do_softlinks() {

--- a/packaging/debian/process_packaging_script.bsh
+++ b/packaging/debian/process_packaging_script.bsh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # This is a script to generate the postinst and postrm scripts for the Debian package
-# Usage: process_package_script <script_template> <script output> <package name> <installation path> <library dir>
+# Usage: process_package_script <script_template> <script output> <package name> <installation path> <library dir> <processor>
 
 input=$1; shift
 output=$1; shift
 package_name=$1; shift
 install_path=$1; shift
 library_dir=$1; shift
+processor=$1; shift
 
-sed "s|@PACKAGE_NAME@|\"$package_name\"|g;s|@INSTALL_PATH@|\"$install_path\"|g;s|@LIBRARY_DIR@|\"$library_dir\"|g;" <$input >$output
+sed "s|@PACKAGE_NAME@|\"$package_name\"|g;s|@INSTALL_PATH@|\"$install_path\"|g;s|@LIBRARY_DIR@|\"$library_dir\"|g;s|@PROCESSOR@|\"$processor\"|g" <$input >$output


### PR DESCRIPTION
fix symlink to libclang-rt.builtins library in packaging