### PR TITLE
Add custom timers to profile HCC runtime

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -45,6 +45,7 @@
 #include "hc_printf.hpp"
 
 #include <time.h>
+#include <sys/time.h>
 #include <iomanip>
 
 #define CHECK_OLDER_COMPLETE 0
@@ -126,6 +127,8 @@ int HCC_PROFILE=0;
 #define HCC_PROFILE_VERBOSE_OPSEQNUM                (1 << 2)   // 0x4
 #define HCC_PROFILE_VERBOSE_TID                     (1 << 3)   // 0x8
 #define HCC_PROFILE_VERBOSE_BARRIER                 (1 << 4)   // 0x10
+#define HCC_PROFILE_VERBOSE_TIME_REF                (1 << 5)   // 0x20
+#define HCC_PROFILE_VERBOSE_API                     (1 << 6)   // 0x40
 int HCC_PROFILE_VERBOSE=0x1F;
 
 
@@ -1145,7 +1148,24 @@ pool_iterator::pool_iterator()
 ///
 namespace Kalmar {
 
+suseconds_t get_host_timestamp() {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return tv.tv_sec * 1e6 + tv.tv_usec;
+}
 
+void print_hcc_runtime_profile(
+    std::string prof_name,
+    suseconds_t ts,
+    suseconds_t time) {
+  if (time > 0) {
+    std::stringstream ss;
+    ss << "hcc-profile, prof_name " << prof_name <<
+      ", ts " << ts <<
+      ", time " << time << std::endl;
+    std::cerr << ss.str();
+  }
+}
 
 // Small wrapper around the hsa hardware queue (ie returned from hsa_queue_create(...).
 // This allows us to see which accelerator_view owns the hsa queue, and
@@ -1537,6 +1557,10 @@ public:
         // Ensures younger ops have chance to complete before older ops reclaim their resources
         //
 
+        suseconds_t start;
+        if (HCC_PROFILE_VERBOSE & HCC_PROFILE_VERBOSE_API) {
+            start = get_host_timestamp();
+        }
 
         if (HCC_OPT_FLUSH && nextSyncNeedsSysRelease()) {
 
@@ -1584,6 +1608,11 @@ public:
         }
         else {
             asyncOps.clear();
+        }
+
+        if (HCC_PROFILE_VERBOSE & HCC_PROFILE_VERBOSE_API) {
+            suseconds_t time = get_host_timestamp() - start;
+            print_hcc_runtime_profile("wait", start, time);
         }
 
         drainingQueue_ = false;
@@ -3437,6 +3466,16 @@ public:
         initPrintfBuffer();
 
         init_success = true;
+
+        // print gpu and host time reference
+        if (HCC_PROFILE_VERBOSE & HCC_PROFILE_VERBOSE_TIME_REF) {
+          uint64_t gpu_time = getSystemTicks();
+          suseconds_t host_time = get_host_timestamp();
+          std::stringstream ss;
+          ss << "hcc-ts-ref, prof_name gpu_host_ts, unix_ts " << host_time <<
+            ", gpu_ts " << gpu_time << std::endl;
+          std::cerr << ss.str();
+        }
     }
 
     void releaseSignal(hsa_signal_t signal, int signalIndex) {


### PR DESCRIPTION
A prototype for printing HCC runtime profiles.  Changes are as
follows:
1) Add get_host_timestamp() to get Unix timestamp in microseconds.
2) Add print_hcc_runtime_profile() to print the HCC runtime profiles
   in a specific format.
3) Print host time and GPU time for host time and GPU time conversion
   in HSAContext's constructor
4) Print profile of HSAQueue::wait()
5) Add HCC_PROFILE_VERBOSE masks to print profiles

Note that this PR is per @whchung request.