### PR TITLE
[Config] move compiler/llvm reference to amd-common

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -179,14 +179,14 @@ fi
 if [ "$HCC_TILECHECK" == "ON" ]; then
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-    -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -dce -globaldce -always-inline -infer-address-spaces -tile_uniform \
+    -select-accelerator-code \
+    -dce -globaldce -always-inline -infer-address-spaces -promote-pointer-kernargs-to-global -tile_uniform \
     < $2.linked.bc -o $2.selected.bc
 else
   $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
     -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-    -select-accelerator-code -promote-pointer-kernargs-to-global \
-    -dce -globaldce -always-inline -infer-address-spaces \
+    -select-accelerator-code \
+    -dce -globaldce -always-inline -infer-address-spaces -promote-pointer-kernargs-to-global \
     < $2.linked.bc -o $2.selected.bc
 fi
 


### PR DESCRIPTION
HCC customizations were merged into amd-common branch.  Updating the reference for HCC build