### PR TITLE
Use llvm-objdump to generate the ISA dump

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -63,7 +63,7 @@ LLC=$BINDIR/llc
 LINK=$BINDIR/llvm-link
 LIB=$BINDIR/../lib
 LLD=$BINDIR/ld.lld
-
+OBJDUMP=$BINDIR/llvm-objdump
 
 ################
 # Determine the ROCm device libs path
@@ -236,8 +236,7 @@ if [ $KMDUMPISA == "1" ]; then
   else
     cp $2.isabin ./dump-$AMDGPU_TARGET.isabin
   fi
-  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -filetype=asm -o $2.isa $2.opt.bc
-  mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
+  $OBJDUMP -disassemble -t -all-headers -line-numbers -mcpu=$AMDGPU_TARGET ./dump-$AMDGPU_TARGET.isabin  >${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
 fi
 
 # ThinLTO does not performs LLD here inside clamp-device.in.

--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -146,7 +146,7 @@ else {
       my $isa_file_name = "$input_file-$asic_target.isa";
 
       # use llvm-objdump to dump out GCN ISA
-      system("$llvm_objdump -disassemble -mcpu=$asic_target $hsaco_file_name > $isa_file_name") == 0 or die("Fail to disassemble AMDGPU ISA for target" . $asic_target);
+      system("$llvm_objdump -disassemble -t -all-headers -line-numbers -mcpu=$asic_target $hsaco_file_name > $isa_file_name") == 0 or die("Fail to disassemble AMDGPU ISA for target" . $asic_target);
       print("Generated GCN ISA for " . $asic_target . " at: " . $isa_file_name . "\n");
     }
   } else {


### PR DESCRIPTION
- When generating an ISA dump, use llvm-objdump to disassemble
  the binary instead of inoking the backend to recompile the IR
  to ASM text
- Update extractkernel to match the llvm-objdump switches used
  for the ISA dump
