### PR TITLE
Combine the opt invocations in clamp-device and clamp-link

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -176,26 +176,15 @@ if [ $KMDUMPLLVM == "1" ]; then
 fi
 
 # Invoke HCC-specific opt passes
-$OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
+# Optimization notes:
+#  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
+$OPT -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET \
+   -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
   -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
   -select-accelerator-code -promote-pointer-kernargs-to-global \
   -dce -globaldce -always-inline -infer-address-spaces \
-  < $2.linked.bc -o $2.selected.bc
-
-# error handling for HCC-specific opt passes
-RETVAL=$?
-if [ $RETVAL != 0 ]; then
-  echo "Generating AMD GCN kernel failed in HCC-specific opt passes for target: $AMDGPU_TARGET"
-  exit $RETVAL
-fi
-
-if [ $KMDUMPLLVM == "1" ]; then
-  cp $2.selected.bc ${KMDUMPDIR}/dump.selected.bc
-fi
-
-# Optimization notes:
-#  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
-$OPT -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify $2.selected.bc -o $2.opt.bc
+  -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify \
+  < $2.linked.bc -o $2.opt.bc
 
 # error handling for opt
 RETVAL=$?

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -215,13 +215,7 @@ _thinlto_path() {
 _default_path() {
 
   # combine kernel sections together
-  $LINK "${LINK_KERNEL_ARGS[@]}"  -o $TEMP_DIR/combined.bc
-  ret=$?
-  if [ $ret != 0 ]; then
-    exit $ret
-  fi
-
-  $OPT -always-inline $TEMP_DIR/combined.bc -o $TEMP_DIR/kernel.bc
+  $LINK "${LINK_KERNEL_ARGS[@]}"  -o $TEMP_DIR/kernel.bc
   ret=$?
   if [ $ret != 0 ]; then
     exit $ret


### PR DESCRIPTION
For historical reason, we had to invoke opt load a customized pass
to fix up the address spaces for global pointers before invoking
opt again for general optimizations on the "fixed" IR.  This
is no longer needed and therefore there's no reason why there
should be 2 separate opt invocations