### PR TITLE
add --device=/dev/dri to docker run in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ node( 'hcctest' )
   }
 
 // JENKINS-33510: the jenkinsfile dir() command is not workin well with docker.inside()
-  hcc_build_image.inside( '--privileged --device=/dev/kfd --group-add video' )
+  hcc_build_image.inside( '--privileged --device=/dev/kfd --device=/dev/dri --group-add video' )
   {
     stage('hcc-lc release')
     {


### PR DESCRIPTION
Adding --device=/dev/dri to docker run in Jenkinsfile to ensure accelerator device is included in container.