### PR TITLE
Implement queue priority for accelerator::create_view()

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -157,6 +157,11 @@ public:
     execute_order get_execute_order() const { return pQueue->get_execute_order(); }
 
     /**
+     * Returns the queue priority of this accelerator_view.
+     */
+    queue_priority get_queue_priority() const { return pQueue->get_queue_priority(); }
+
+    /**
      * Returns a boolean value indicating whether the accelerator view when
      * passed to a parallel_for_each would result in automatic selection of an
      * appropriate execution target by the runtime. In other words, this is the
@@ -820,8 +825,8 @@ public:
      *                  See "Queuing Mode". The default value would be
      *                  queueing_mdoe_automatic if not specified.
      */
-    accelerator_view create_view(execute_order order = execute_in_order, queuing_mode mode = queuing_mode_automatic) {
-        auto pQueue = pDev->createQueue(order);
+    accelerator_view create_view(execute_order order = execute_in_order, queuing_mode mode = queuing_mode_automatic, queue_priority priority = priority_normal) {
+        auto pQueue = pDev->createQueue(order, priority);
         pQueue->set_mode(mode);
         return pQueue;
     }

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -37,6 +37,8 @@ enum execute_order
     execute_any_order
 };
 
+/// NOTE: This enum is used for indexing into an array.
+/// So any modifications to this need to be done with caution.
 enum queue_priority
 {
     priority_high = 0,

--- a/lib/cpu/mcwamp_cpu.cpp
+++ b/lib/cpu/mcwamp_cpu.cpp
@@ -68,7 +68,7 @@ public:
     void release(void *device, struct rw_info* /* not used */ ) override { 
         kalmar_aligned_free(device);
     }
-    std::shared_ptr<KalmarQueue> createQueue(execute_order order = execute_in_order) override {
+    std::shared_ptr<KalmarQueue> createQueue(execute_order order = execute_in_order, queue_priority priority = priority_normal) override {
         return std::shared_ptr<KalmarQueue>(new CPUFallbackQueue(this));
     }
 };

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2255,9 +2255,9 @@ public:
 
         this->rocrQueuesMutex.lock();
 
-        // TODO: Do we want the max queues for each priority to be different?
         // Allocate a new queue when we are below the HCC_MAX_QUEUES limit
-        if (rocrQueues[priority].size() < HCC_MAX_QUEUES) {
+        auto rqSize = rocrQueues[0].size()+rocrQueues[1].size()+rocrQueues[2].size();
+        if (rqSize < HCC_MAX_QUEUES) {
             foundRQ = new RocrQueue(agent, this->queue_size, thief, priority);
             rocrQueues[priority].push_back(foundRQ);
             DBOUT(DB_QUEUE, "Create new rocrQueue=" << foundRQ << " for thief=" << thief << "\n")

--- a/tests/Unit/HC/queue_priority.cpp
+++ b/tests/Unit/HC/queue_priority.cpp
@@ -2,6 +2,9 @@
 // RUN: %hc %s -o %t.out && %t.out
 
 #include <hc.hpp>
+#include <iostream>
+
+#define DATA_LEN 7
 
 // test new enumeration in hc::accelerator_view : queue_priority
 int main() {
@@ -20,15 +23,46 @@ int main() {
   // create one accelerator_view with priority high
   accelerator_view av_high_priority = acc.create_view(execute_in_order, queuing_mode_automatic, priority_high);
 
+  hc::extent<1> e(DATA_LEN);
+
   // test dispatch a kernel to av
-  parallel_for_each(av, extent<1>(1), []() [[hc]] {});
+  hc::array_view<unsigned int, 1> data1(DATA_LEN);
+  parallel_for_each(av, e, [=](hc::index<1> i) [[hc]] {
+    unsigned int flat_id = i[0];
+    data1[flat_id] = flat_id;
+  });
 
   // test dispatch a kernel to av_normal_priority
-  parallel_for_each(av_normal_priority, extent<1>(1), []() [[hc]] {});
+  hc::array_view<unsigned int, 1> data2(DATA_LEN);
+  parallel_for_each(av_normal_priority, e, [=](hc::index<1> i) [[hc]] {
+    unsigned int flat_id = i[0];
+    data2[flat_id] = flat_id;
+  });
 
   // test dispatch a kernel to av_high_priority
-  parallel_for_each(av_high_priority, extent<1>(1), []() [[hc]] {});
+  hc::array_view<unsigned int, 1> data3(DATA_LEN);
+  parallel_for_each(av_high_priority, e, [=](hc::index<1> i) [[hc]] {
+    unsigned int flat_id = i[0];
+    data3[flat_id] = flat_id;
+  });
 
-  return 0;
+  // verify data
+  int errors = 0;
+  for (int i = 0; i < DATA_LEN; ++i) {
+    if (data1[i] != i) {
+      ++errors;
+      std::cerr << "Error data1[" << i << "], expected " << i << ", actual " << data1[i] << std::endl;
+    }
+    if (data2[i] != i) {
+      ++errors;
+      std::cerr << "Error data2[" << i << "], expected " << i << ", actual " << data2[i] << std::endl;
+    }
+    if (data3[i] != i) {
+      ++errors;
+      std::cerr << "Error data3[" << i << "], expected " << i << ", actual " << data3[i] << std::endl;
+    }
+  }
+
+  return errors==0?0:1;
 }
 

--- a/tests/Unit/HC/queue_priority.cpp
+++ b/tests/Unit/HC/queue_priority.cpp
@@ -1,0 +1,34 @@
+
+// RUN: %hc %s -o %t.out && %t.out
+
+#include <hc.hpp>
+
+// test new enumeration in hc::accelerator_view : queue_priority
+int main() {
+  using namespace hc;
+
+  // get the default accelerator
+  accelerator acc = accelerator();
+
+  // create one accelerator_view without specifying queue priority
+  // by default is shall be priority_normal
+  accelerator_view av = acc.create_view();
+
+  // create one accelerator_view with priority normal
+  accelerator_view av_normal_priority = acc.create_view(execute_in_order, queuing_mode_automatic, priority_normal);
+
+  // create one accelerator_view with priority high
+  accelerator_view av_high_priority = acc.create_view(execute_in_order, queuing_mode_automatic, priority_high);
+
+  // test dispatch a kernel to av
+  parallel_for_each(av, extent<1>(1), []() [[hc]] {});
+
+  // test dispatch a kernel to av_normal_priority
+  parallel_for_each(av_normal_priority, extent<1>(1), []() [[hc]] {});
+
+  // test dispatch a kernel to av_high_priority
+  parallel_for_each(av_high_priority, extent<1>(1), []() [[hc]] {});
+
+  return 0;
+}
+


### PR DESCRIPTION
queue_priority in accelerator_view is mapped to hsa_amd_queue_priority_t. Requires ROCm 1.9 or higher.

TODO:
* In this patch, I enforce the same limit for the max hsa queues we can allocate for in each priority. Do we want to have finer control over it i.e. different limits for each priority?
* The same rocrQueuesMutex is used irrespective of the queue priority. Do we want to use a different mutex for each priority? We will need to modify HSAQueue::dispose in that case.
* In this patch, the decision to hard or soft remove a rocrQueue is based on comparing number of hcc queues with the sum of the rocr queues across all priorities. Do we want to track hcc queues per priority as well? Alternatively we could modify queue stealing to steal an unused rocrQueue from another priority pool and change the priority as required.