### PR TITLE
-Werror ignoring return value of function

### DIFF
--- a/include/kalmar_aligned_alloc.h
+++ b/include/kalmar_aligned_alloc.h
@@ -27,7 +27,8 @@ inline void* kalmar_aligned_alloc(std::size_t alignment, std::size_t size) noexc
     }
     void* memptr = NULL;
     // posix_memalign shall return 0 upon successfully allocate aligned memory
-    posix_memalign(&memptr, alignment, size);
+    auto ignore = posix_memalign(&memptr, alignment, size);
+    (void) ignore;
     assert(memptr);
 
     return memptr;


### PR DESCRIPTION
hcc/include/kalmar_aligned_alloc.h:30:5: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
    posix_memalign(&memptr, alignment, size);