### PR TITLE
Remove deprecated hsa isa compatible call

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2695,8 +2695,10 @@ public:
                 agent,
                 [](hsa_isa_t agent_isa, void* data) {
                     isa_comp_data* co_data = static_cast<isa_comp_data*>(data);
-                    if (agent_isa == co_data->isa_type)
+                    if (agent_isa == co_data->isa_type) {
                         co_data->is_compatible = true;
+                        return HSA_STATUS_INFO_BREAK;
+                    }
                     return HSA_STATUS_SUCCESS;
                 },
                 &co_data);


### PR DESCRIPTION
Required to use the hsa_agent_iterate_isas for previous deprecated hsa_isa_compatible. Since an agent will allow multiple ISAs from now on, we need to check if code object is compatible with any of them. We leverage passing a struct into the callback function for checking isa handles.