### PR TITLE
[CMAKE] add dependencies to the cmake-test

### DIFF
--- a/cmake-tests/CMakeLists.txt
+++ b/cmake-tests/CMakeLists.txt
@@ -4,6 +4,7 @@ if(NOT CMAKE_CXX_COMPILER MATCHES ".*hcc")
 endif()
 
 add_executable(cmake-test cmake-test.cpp)
+add_dependencies(cmake-test hc_am mcwamp_hsa mcwamp)
 
 # Explicitly set the GPU architecture so that
 # cmake_test could be cross-compiled on a system

--- a/cmake-tests/CMakeLists.txt
+++ b/cmake-tests/CMakeLists.txt
@@ -4,7 +4,6 @@ if(NOT CMAKE_CXX_COMPILER MATCHES ".*hcc")
 endif()
 
 add_executable(cmake-test cmake-test.cpp)
-add_dependencies(cmake-test hc_am mcwamp_hsa mcwamp)
 
 # Explicitly set the GPU architecture so that
 # cmake_test could be cross-compiled on a system
@@ -18,7 +17,7 @@ endif()
 set_target_properties(cmake-test PROPERTIES LINK_FLAGS ${new_cmake_test_link_flags})
 
 if(TARGET hccrt)
-    add_dependencies(cmake-test clang_links rocdl_links)
+    add_dependencies(cmake-test clang_links rocdl_links mcwamp_hsa mcwamp)
     target_link_libraries(cmake-test hccrt hc_am)
 else()
     # Append default hcc installation


### PR DESCRIPTION
make sure that cmake-test only starts after the compiler and runtime has been built