### PR TITLE
allow amp_short_vectors_2files tests to pass

### DIFF
--- a/tests/Unit/AmpShortVectors/amp_short_vectors_2files.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_2files.cpp
@@ -1,7 +1,6 @@
 // RUN: %cxxamp -DFILE_1 -c %s -o %t.1.o
 // RUN: %cxxamp -DFILE_2 -c %s -o %t.2.o
 // RUN: %cxxamp %t.1.o %t.2.o -o %t.out
-// XFAIL: *
 
 // this test try to link 2 files which use C++AMP short vectors API in one
 // executable.  so it tests if short vector APIs would violate ODR rule

--- a/tests/Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
@@ -1,7 +1,6 @@
 // RUN: %cxxamp -DFILE_1 -c %s -o %t.1.o
 // RUN: %cxxamp -DFILE_2 -c %s -o %t.2.o
 // RUN: %cxxamp %t.1.o %t.2.o -o %t.out
-// XFAIL: *
 
 // this test try to link 2 files which use C++AMP short vectors API in one
 // executable.  so it tests if short vector APIs would violate ODR rule

--- a/tests/known_failures
+++ b/tests/known_failures
@@ -29,6 +29,4 @@
     CPPAMP :: Unit/HC/accelerator_get_all_views_mt.cpp
 
 # Disable these test TEMPORARILY (as of June 22nd, 2018) until we get fixes for them:
-    CPPAMP :: Unit/AmpShortVectors/amp_short_vectors_2files.cpp
-    CPPAMP :: Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
     CPPAMP :: Unit/Codegen/deser_def_body_compound_support_inheritclass.cpp


### PR DESCRIPTION
fix these passing tests:

Unexpected Passing Tests (2):
    HCC :: Unit/AmpShortVectors/amp_short_vectors_2files.cpp
    HCC :: Unit/AmpShortVectors/amp_short_vectors_2files_1.cpp
