### PR TITLE
Early finalization support in HCC runtime

### DIFF
--- a/hc2/headers/types/program_state.hpp
+++ b/hc2/headers/types/program_state.hpp
@@ -153,10 +153,21 @@ namespace hc2
             std::call_once(f, []() {
                 std::vector<std::vector<char>> ks;
                 dl_iterate_phdr(copy_kernel_sections_<>, &ks);
-
                 for (auto&& x : ks) {
-                    Bundled_code_header tmp{x};
-                    if (valid(tmp)) r.push_back(std::move(tmp));
+                    size_t offset = 0;
+                    while(offset < x.size()) {
+                        size_t read_bundle_size = 0;
+                        Bundled_code_header tmp{x.cbegin()+offset,
+                                                x.cend(), 
+                                                &read_bundle_size};
+                        if (valid(tmp)) {
+                            r.push_back(std::move(tmp));
+                            offset+=read_bundle_size;
+                        }
+                        else {
+                            break;
+                        }
+                    }
                 }
             });
 

--- a/hc2/headers/types/program_state.hpp
+++ b/hc2/headers/types/program_state.hpp
@@ -156,13 +156,11 @@ namespace hc2
                 for (auto&& x : ks) {
                     size_t offset = 0;
                     while(offset < x.size()) {
-                        size_t read_bundle_size = 0;
                         Bundled_code_header tmp{x.cbegin()+offset,
-                                                x.cend(), 
-                                                &read_bundle_size};
+                                                x.cend()};
                         if (valid(tmp)) {
                             r.push_back(std::move(tmp));
-                            offset+=read_bundle_size;
+                            offset+=tmp.size();
                         }
                         else {
                             break;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,7 +15,7 @@ set( CONFIG_PACKAGE_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/hcc )
 ####################
 # C++AMP runtime (mcwamp)
 ####################
-add_mcwamp_library(mcwamp mcwamp.cpp)
+add_mcwamp_shared_library(mcwamp mcwamp.cpp)
 add_mcwamp_library(mcwamp_atomic mcwamp_atomic.cpp)
 
 # Library interface to use runtime

--- a/lib/clamp-assemble.in
+++ b/lib/clamp-assemble.in
@@ -1,6 +1,13 @@
 #!/bin/bash
 # clamp-assemble kernel-bitcode kernel-object
 
+# enable bash debugging
+KMDBSCRIPT="${KMDBSCRIPT:=0}"
+if [ $KMDBSCRIPT == "1" ]
+then
+  set -x
+fi
+
 BINDIR=$(dirname $0)
 EMBED=$BINDIR/clamp-embed
 

--- a/lib/clamp-assemble.in
+++ b/lib/clamp-assemble.in
@@ -11,8 +11,8 @@ fi
 BINDIR=$(dirname $0)
 EMBED=$BINDIR/clamp-embed
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 kernel-bitcode object" >&2
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 kernel-bitcode object elf_section_name" >&2
   exit 1
 fi
 
@@ -23,10 +23,10 @@ fi
 
 if [ -f "$2" ]; then
   mv "$2" "$2.host.o"
-  $EMBED "$1" "$2.kernel.o"
+  $EMBED "$1" "$2.kernel.o" "$3"
   ld -r "$2.kernel.o" "$2.host.o" -o "$2"
   rm "$2.kernel.o" "$2.host.o"
 else
-  $EMBED "$1" "$2"
+  $EMBED "$1" "$2" "$3"
 fi
 

--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -56,7 +56,6 @@ if [ ! -f $1 ]; then
 fi
 
 BINDIR=$(dirname $0)
-EMBED=$BINDIR/clamp-embed
 AS=$BINDIR/llvm-as
 OPT=$BINDIR/opt
 LLC=$BINDIR/llc

--- a/lib/clamp-embed.in
+++ b/lib/clamp-embed.in
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# enable bash debugging
+KMDBSCRIPT="${KMDBSCRIPT:=0}"
+if [ $KMDBSCRIPT == "1" ]
+then
+  set -x
+fi
+
 # check command line arguments
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 input_object output_kernel" >&2
@@ -12,11 +19,11 @@ if [ ! -f "$1" ]; then
 fi
 
 if [[ "@CMAKE_SYSTEM_PROCESSOR@" == "x86_64" ]]; then
-  objcopy -B i386:x86-64 -I binary -O elf64-x86-64 --rename-section .data=.kernel "$1" "$2"
+  objcopy -B i386:x86-64 -I binary -O elf64-x86-64 --rename-section .data=.kernel --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "aarch64" ]]; then
-  objcopy -B aarch64 -I binary -O elf64-littleaarch64 --rename-section .data=.kernel "$1" "$2"
+  objcopy -B aarch64 -I binary -O elf64-littleaarch64 --rename-section .data=.kernel --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "ppc64" ]]; then
-  objcopy -B ppc64 -I binary -O elf64-powerpc --rename-section .data=.kernel "$1" "$2"
+  objcopy -B ppc64 -I binary -O elf64-powerpc --rename-section .data=.kernel --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "ppc64le" ]]; then
-  objcopy -B powerpc -I binary -O elf64-powerpcle --rename-section .data=.kernel "$1" "$2"
+  objcopy -B powerpc -I binary -O elf64-powerpcle --rename-section .data=.kernel --weaken "$1" "$2"
 fi

--- a/lib/clamp-embed.in
+++ b/lib/clamp-embed.in
@@ -8,8 +8,8 @@ then
 fi
 
 # check command line arguments
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 input_object output_kernel" >&2
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 input_object output_kernel elf_section_name" >&2
   exit 1
 fi
 
@@ -19,11 +19,11 @@ if [ ! -f "$1" ]; then
 fi
 
 if [[ "@CMAKE_SYSTEM_PROCESSOR@" == "x86_64" ]]; then
-  objcopy -B i386:x86-64 -I binary -O elf64-x86-64 --rename-section .data=.kernel --weaken "$1" "$2"
+  objcopy -B i386:x86-64 -I binary -O elf64-x86-64 --rename-section .data="$3" --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "aarch64" ]]; then
-  objcopy -B aarch64 -I binary -O elf64-littleaarch64 --rename-section .data=.kernel --weaken "$1" "$2"
+  objcopy -B aarch64 -I binary -O elf64-littleaarch64 --rename-section .data="$3" --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "ppc64" ]]; then
-  objcopy -B ppc64 -I binary -O elf64-powerpc --rename-section .data=.kernel --weaken "$1" "$2"
+  objcopy -B ppc64 -I binary -O elf64-powerpc --rename-section .data="$3" --weaken "$1" "$2"
 elif [[ "@CMAKE_SYSTEM_PROCESSOR@" == "ppc64le" ]]; then
-  objcopy -B powerpc -I binary -O elf64-powerpcle --rename-section .data=.kernel --weaken "$1" "$2"
+  objcopy -B powerpc -I binary -O elf64-powerpcle --rename-section .data="$3" --weaken "$1" "$2"
 fi

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -571,16 +571,16 @@ fi
 # linker return value
 ret=0
 
+# touch an empty object for host part, to accomodate rule required by
+# clang-offload-bundler
+touch $TEMP_DIR/__empty.o
+
+# invoke clang-offload-bundler to create kernel bundle
+CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS="-inputs=$TEMP_DIR/__empty.o"
+CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS="-targets=host-@CMAKE_SYSTEM_PROCESSOR@-unknown-linux"
+
 # only do kernel lowering if there are objects given
 if [ ${#LINK_KERNEL_ARGS[@]} != 0 ]; then
-
-  # touch an empty object for host part, to accomodate rule required by
-  # clang-offload-bundler
-  touch $TEMP_DIR/__empty.o
-
-  # invoke clang-offload-bundler to create kernel bundle
-  CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS="-inputs=$TEMP_DIR/__empty.o"
-  CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS="-targets=host-@CMAKE_SYSTEM_PROCESSOR@-unknown-linux"
 
   if [ $KMTHINLTO == "1" ]; then
     _thinlto_path
@@ -591,31 +591,30 @@ if [ ${#LINK_KERNEL_ARGS[@]} != 0 ]; then
   if [ $VERBOSE != 0 ]; then
     echo "Finished generation of AMD GCN kernels"
   fi
+fi
 
-  # invoke clang-offload-bundler
-  $CLANG_OFFLOAD_BUNDLER -type=o $CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS $CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS -outputs=$TEMP_DIR/kernel.bundle
+# invoke clang-offload-bundler
+$CLANG_OFFLOAD_BUNDLER -type=o $CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS $CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS -outputs=$TEMP_DIR/kernel.bundle
 
-  # error handling
-  ret=$?
-  if [ $ret != 0 ]; then
-    exit $ret
-  fi
+# error handling
+ret=$?
+if [ $ret != 0 ]; then
+  exit $ret
+fi
 
-  if [ $KMDUMPBUNDLE == "1" ]; then
-    cp $TEMP_DIR/kernel.bundle ./dump.bundle
-  fi
+if [ $KMDUMPBUNDLE == "1" ]; then
+  cp $TEMP_DIR/kernel.bundle ./dump.bundle
+fi
 
-  # build a new kernel object
-  pushd . > /dev/null
-  cd $TEMP_DIR
-  $CLAMP_EMBED kernel.bundle kernel_hsa.o "$KERNEL_SECTION"
-  popd > /dev/null
+# build a new kernel object
+pushd . > /dev/null
+cd $TEMP_DIR
+$CLAMP_EMBED kernel.bundle kernel_hsa.o "$KERNEL_SECTION"
+popd > /dev/null
 
-  # link everything together
-  ld --allow-multiple-definition $TEMP_DIR/kernel_hsa.o "${LINK_HOST_ARGS[@]}" "${LINK_CPU_ARG[@]}" "${LINK_OTHER_ARGS[@]}"
-  ret=$?
-
-fi # if [ -n $LINK_KERNEL_ARGS ];
+# link everything together
+ld --allow-multiple-definition $TEMP_DIR/kernel_hsa.o "${LINK_HOST_ARGS[@]}" "${LINK_CPU_ARG[@]}" "${LINK_OTHER_ARGS[@]}"
+ret=$?
 
 # remove temp files
 if [ -e $TEMP_DIR/kernel_hsa.o ]; then

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -322,6 +322,9 @@ do
 
   OBJS_TO_PROCESS=()
 
+  # ELF section names for IR and ISA
+  KERNEL_IR_SECTION=".kernel_ir"
+  KERNEL_SECTION=".kernel"
 
   if [[ "$ARG" =~ [^[:space:]]+\.cpu$ ]]; then
 
@@ -410,11 +413,11 @@ do
         echo "processing static library $DETECTED_STATIC_LIBRARY"
       fi
 
-      # detect whether the objects in the static library contain a .kernel section
-      KERNEL_UNDETECTED=`objdump -t "$DETECTED_STATIC_LIBRARY" 2> /dev/null | grep -q "\.kernel"; echo $?`
+      # detect whether the objects in the static library contain a .kernel_ir section
+      KERNEL_UNDETECTED=`objdump -t "$DETECTED_STATIC_LIBRARY" 2> /dev/null | grep -q "$KERNEL_IR_SECTION"; echo $?`
       if [[ $KERNEL_UNDETECTED == "0" ]]; then
 
-        # .kernel section detected, extract the objects from the archieve
+        # .kernel_ir section detected, extract the objects from the archieve
 
         if [ $VERBOSE == 2 ]; then
           echo "kernel detected in $DETECTED_STATIC_LIBRARY"
@@ -479,8 +482,8 @@ do
       echo "processing $OBJ"
     fi
 
-    # detect whether the objects in the static library contain a .kernel section
-    KERNEL_UNDETECTED=`objdump -t "$OBJ" 2> /dev/null | grep -q "\.kernel"; echo $?`
+    # detect whether the objects in the static library contain a .kernel_ir section
+    KERNEL_UNDETECTED=`objdump -t "$OBJ" 2> /dev/null | grep -q "$KERNEL_IR_SECTION"; echo $?`
     if [[ $KERNEL_UNDETECTED == "0" ]]; then
 
       FILE=`basename "$OBJ"` # remove path
@@ -489,14 +492,14 @@ do
       HOST_FILE="$TEMP_DIR/$FILENAME.host.o"
 
       # extract kernel section
-      objcopy -O binary -j .kernel "$OBJ" "$KERNEL_FILE"
+      objcopy -O binary -j "$KERNEL_IR_SECTION" "$OBJ" "$KERNEL_FILE"
       ret=$?
       if [ $ret != 0 ]; then
         exit $ret
       fi
 
       # extract host section
-      objcopy -R .kernel "$OBJ" "$HOST_FILE"
+      objcopy -R "$KERNEL_IR_SECTION" "$OBJ" "$HOST_FILE"
       ret=$?
       if [ $ret != 0 ]; then
         exit $ret
@@ -605,7 +608,7 @@ if [ ${#LINK_KERNEL_ARGS[@]} != 0 ]; then
   # build a new kernel object
   pushd . > /dev/null
   cd $TEMP_DIR
-  $CLAMP_EMBED kernel.bundle kernel_hsa.o
+  $CLAMP_EMBED kernel.bundle kernel_hsa.o "$KERNEL_SECTION"
   popd > /dev/null
 
   # link everything together

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -8,6 +8,8 @@ KMDBSCRIPT="${KMDBSCRIPT:=0}"
 # dump the LLVM bitcode
 KMDUMPLLVM="${KMDUMPLLVM:=0}"
 
+AMDGPU_OBJ_CODEGEN="${AMDGPU_OBJ_CODEGEN:=0}"
+
 if [ $KMDBSCRIPT == "1" ]
 then
   set -x
@@ -63,7 +65,6 @@ if [ "$#" -lt 2 ]; then
 fi
 
 AMDGPU_TARGET_ARRAY=()
-EARLY_FINALIZATION=0
 for ARG in "$@"
 do
   case $ARG in
@@ -75,7 +76,7 @@ do
     continue
     ;;
     --early_finalize)
-    EARLY_FINALIZATION=1
+    AMDGPU_OBJ_CODEGEN=1
     continue
     ;;
   esac
@@ -115,7 +116,7 @@ if [ $KMDUMPLLVM == "1" ]; then
   cp "$TEMP_NAME.ll" ./dump.kernel_input.ll
 fi
 
-if [ $EARLY_FINALIZATION == 1 ]; then
+if [ $AMDGPU_OBJ_CODEGEN == 1 ]; then
   # invoke the backend to finalize the IR
 
   # touch an empty object for host part, to accomodate rule required by

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -138,6 +138,7 @@ if [ $EARLY_FINALIZATION == 1 ]; then
 
   # collect all the error codes from forked processes
   # error handling
+  ret=0
   for pid in ${pids[*]}; do
     wait $pid || ret=$((ret+$?))
   done

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -100,6 +100,10 @@ TEMP_DIR=`mktemp -d`
 BASENAME=`basename "$2"`
 TEMP_NAME="$TEMP_DIR/$BASENAME"
 
+# ELF section names for IR and ISA
+KERNEL_IR_SECTION=".kernel_ir"
+KERNEL_SECTION=".kernel"
+
 # hip-kernel-assemble goes after hip-host-assemble, so attempt to link object from host
 if [ -f "$2" ]; then
   mv "$2" "$TEMP_DIR/$BASENAME.tmp.o"
@@ -150,11 +154,11 @@ if [ $EARLY_FINALIZATION == 1 ]; then
 
   OLD_PWD=$PWD
   cd $TEMP_DIR
-  $CLAMP_ASM "kernel.bundle" "$TEMP_NAME.camp.o"
+  $CLAMP_ASM "kernel.bundle" "$TEMP_NAME.camp.o" "$KERNEL_SECTION"
   cd $OLD_PWD
 else
   ln -s "$KERNEL_INPUT" "$1.bc"
-  $CLAMP_ASM "$1.bc" "$TEMP_NAME.camp.o"
+  $CLAMP_ASM "$1.bc" "$TEMP_NAME.camp.o" "$KERNEL_IR_SECTION"
 fi
 
 if [ -f "$TEMP_DIR/$BASENAME.tmp.o" ]; then

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -113,7 +113,6 @@ fi
 
 if [ $EARLY_FINALIZATION == 1 ]; then
   # invoke the backend to finalize the IR
-  echo "do early finalization"
 
   # touch an empty object for host part, to accomodate rule required by
   # clang-offload-bundler

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -17,10 +17,12 @@ BINDIR=$(dirname "$0")
 CLANG=$BINDIR/hcc
 LLVM_LINK=$BINDIR/llvm-link
 OPT=$BINDIR/opt
+CLAMP_DEVICE=$BINDIR/clamp-device
 LLVM_AS=$BINDIR/llvm-as
 LLVM_DIS=$BINDIR/llvm-dis
 CLAMP_ASM=$BINDIR/clamp-assemble
 LIBPATH=$BINDIR/../lib
+CLANG_OFFLOAD_BUNDLER=$BINDIR/clang-offload-bundler
 
 # At build directory, HCC compiler tools are placed under compiler/bin/, and
 # header files are placed under include/. At install directory, HCC compiler
@@ -55,10 +57,29 @@ case $CMAKE_BUILD_TYPE in
     CXXFLAGS=$CXXFLAGS
 esac
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 2 ]; then
   echo "Usage: $0 kernel-bitcode object" >&2
   exit 1
 fi
+
+AMDGPU_TARGET_ARRAY=()
+EARLY_FINALIZATION=0
+for ARG in "$@"
+do
+  case $ARG in
+    ######################
+    # Parse AMDGPU target
+    ######################
+    --amdgpu-target=*)
+    AMDGPU_TARGET_ARRAY+=("${ARG#*=}")
+    continue
+    ;;
+    --early_finalize)
+    EARLY_FINALIZATION=1
+    continue
+    ;;
+  esac
+done
 
 # inject a new GPU IR to replace the IR from the FE
 HC_REPLACE_GPU_FE_LLVM="${HC_REPLACE_GPU_FE_LLVM:=0}"
@@ -90,8 +111,51 @@ if [ $KMDUMPLLVM == "1" ]; then
   cp "$TEMP_NAME.ll" ./dump.kernel_input.ll
 fi
 
-ln -s "$KERNEL_INPUT" "$1.bc"
-$CLAMP_ASM "$1.bc" "$TEMP_NAME.camp.o"
+if [ $EARLY_FINALIZATION == 1 ]; then
+  # invoke the backend to finalize the IR
+  echo "do early finalization"
+
+  # touch an empty object for host part, to accomodate rule required by
+  # clang-offload-bundler
+  touch $TEMP_DIR/__empty.o
+
+  # invoke clang-offload-bundler to create kernel bundle
+  CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS="-inputs=$TEMP_DIR/__empty.o"
+  CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS="-targets=host-@CMAKE_SYSTEM_PROCESSOR@-unknown-linux"
+
+  declare -a pids
+  # for each GPU target, lower to GCN ISA in HSACO format
+  for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}; do
+    { $CLAMP_DEVICE "$KERNEL_INPUT" "$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco" --amdgpu-target=$AMDGPU_TARGET; } &
+
+    # error handling
+    pids+=("${pids[@]}" "$!")
+
+    # augment arguments to clang-offload-bundler
+    CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS+=",$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco"
+    CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS+=",hcc-amdgcn-amd-amdhsa--$AMDGPU_TARGET"
+  done
+
+  # collect all the error codes from forked processes
+  # error handling
+  for pid in ${pids[*]}; do
+    wait $pid || ret=$((ret+$?))
+  done
+  if [ $ret != 0 ]; then
+    exit $ret
+  fi
+
+  # invoke clang-offload-bundler
+  $CLANG_OFFLOAD_BUNDLER -type=o $CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS $CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS -outputs=$TEMP_DIR/kernel.bundle
+
+  OLD_PWD=$PWD
+  cd $TEMP_DIR
+  $CLAMP_ASM "kernel.bundle" "$TEMP_NAME.camp.o"
+  cd $OLD_PWD
+else
+  ln -s "$KERNEL_INPUT" "$1.bc"
+  $CLAMP_ASM "$1.bc" "$TEMP_NAME.camp.o"
+fi
 
 if [ -f "$TEMP_DIR/$BASENAME.tmp.o" ]; then
   ld -r --allow-multiple-definition "$TEMP_DIR/$BASENAME.tmp.o" "$TEMP_NAME.camp.o" -o "$2"

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -10,6 +10,9 @@ KMDUMPLLVM="${KMDUMPLLVM:=0}"
 
 AMDGPU_OBJ_CODEGEN="${AMDGPU_OBJ_CODEGEN:=0}"
 
+# inject additional GPU archs through an env var
+HCC_EXTRA_GPU_ARCH="${HCC_EXTRA_GPU_ARCH:=0}"
+
 if [ $KMDBSCRIPT == "1" ]
 then
   set -x
@@ -65,6 +68,12 @@ if [ "$#" -lt 2 ]; then
 fi
 
 AMDGPU_TARGET_ARRAY=()
+if [ $HCC_EXTRA_GPU_ARCH != "0" ]
+ then
+  AMDGPU_TARGET_ARRAY+=("$HCC_EXTRA_GPU_ARCH")
+fi
+
+
 for ARG in "$@"
 do
   case $ARG in

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -336,20 +336,10 @@ static void read_code_bundles(std::vector<_code_bundle>& bundles) {
 
 
 void LoadInMemoryProgram(KalmarQueue* pQueue) {
-  static std::vector<_code_bundle> bundles;
 
-#if 0
-  // NOTE: To investigate, this seems to cause a crash
-  // when linking this libray with g++
+  static std::vector<_code_bundle> bundles;
   static std::once_flag f;
   std::call_once(f, [&](){ read_code_bundles(bundles); });
-#else
-  static bool done = false;
-  if (!done) {
-    read_code_bundles(bundles);
-    done = true;
-  }
-#endif
 
   for (auto&& b : bundles) {
     if (pQueue->getDev()->IsCompatibleKernel((void*) b.size, (void*) b.device_binary)) {

--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -264,8 +264,6 @@ struct _code_bundle {
 
 static void read_code_bundles(std::vector<_code_bundle>& bundles) {
 
-  //std::cout << "read_code_bundles..." << std::endl;
-
   const char* bundles_data_start = (const char *)kernel_bundle_source;
 
   while (1) {
@@ -273,7 +271,6 @@ static void read_code_bundles(std::vector<_code_bundle>& bundles) {
     constexpr char OFFLOAD_BUNDLER_MAGIC_STR[] = "__CLANG_OFFLOAD_BUNDLE__";
     constexpr size_t OFFLOAD_BUNDLER_MAGIC_STR_LENGTH = sizeof(OFFLOAD_BUNDLER_MAGIC_STR)-1;
     auto detect_bundle_magic = [&](const char* b) {
-      //std::cout << "detecting magic string..." << std::endl;
       for (int i = 0; i < OFFLOAD_BUNDLER_MAGIC_STR_LENGTH; ++i) {
         if (b[i] != OFFLOAD_BUNDLER_MAGIC_STR[i])
           return false;
@@ -282,8 +279,6 @@ static void read_code_bundles(std::vector<_code_bundle>& bundles) {
     };
 
     if (detect_bundle_magic(bundles_data_start)) {
-
-      //std::cout << "bundles detected!" << std::endl;
 
       auto read_uint64 = [](const char* p) {
         return *reinterpret_cast<const uint64_t*>(p);
@@ -325,9 +320,6 @@ static void read_code_bundles(std::vector<_code_bundle>& bundles) {
       bundles_data_start += bundle_end;
     }
     else {
-      
-      //std::cout << "no more device code objects" << std::endl;
-
       // no more device code objects, exit
       break;
     }
@@ -343,7 +335,6 @@ void LoadInMemoryProgram(KalmarQueue* pQueue) {
 
   for (auto&& b : bundles) {
     if (pQueue->getDev()->IsCompatibleKernel((void*) b.size, (void*) b.device_binary)) {
-      //std::cout << "build program, size=" << b.size << std::endl;
       pQueue->getDev()->BuildProgram((void*) b.size, (void*) b.device_binary);
     }
   }

--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -18,6 +18,7 @@ SOFTLINKS=(
   "bin" "bin" "hcc-config"
   "$LIBRARY_DIR" "lib" "libhc_am.so"
   "$LIBRARY_DIR" "lib" "libmcwamp.a"
+  "$LIBRARY_DIR" "lib" "libmcwamp.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_atomic.a"
   "$LIBRARY_DIR" "lib" "libmcwamp_cpu.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_hsa.so"
@@ -50,8 +51,10 @@ do_softlinks() {
     DEST_DIR=${SOFTLINKS[i+1]}
     FILE=${SOFTLINKS[i+2]}
 
-    if [ ! -e $ROCM_PATH/$DEST_DIR/$FILE ] ; then
-      ln -sf $ROCM_PATH/hcc/$SOURCE_DIR/$FILE $ROCM_PATH/$DEST_DIR/$FILE
+    if [ -e $ROCM_PATH/hcc/$SOURCE_DIR/$FILE ] ; then
+      if [ ! -e $ROCM_PATH/$DEST_DIR/$FILE ] ; then
+        ln -sf $ROCM_PATH/hcc/$SOURCE_DIR/$FILE $ROCM_PATH/$DEST_DIR/$FILE
+      fi
     fi
   done
 }

--- a/packaging/debian/prerm.in
+++ b/packaging/debian/prerm.in
@@ -18,6 +18,7 @@ SOFTLINKS=(
   "bin" "bin" "hcc-config"
   "$LIBRARY_DIR" "lib" "libhc_am.so"
   "$LIBRARY_DIR" "lib" "libmcwamp.a"
+  "$LIBRARY_DIR" "lib" "libmcwamp.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_atomic.a"
   "$LIBRARY_DIR" "lib" "libmcwamp_cpu.so"
   "$LIBRARY_DIR" "lib" "libmcwamp_hsa.so"

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -61,7 +61,7 @@ macro(add_mcwamp_shared_library name )
   add_library( ${name} SHARED ${ARGN} )
   amp_target(${name})
   # LLVM and Clang shall be compiled beforehand
-  target_link_libraries(${name} PUBLIC hsa-runtime64)
+  target_link_libraries(${name} PUBLIC hsa-runtime64 dl)
   add_dependencies(${name} llvm-link opt clang rocdl)
 endmacro(add_mcwamp_library name )
 

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -63,7 +63,7 @@ macro(add_mcwamp_shared_library name )
   # LLVM and Clang shall be compiled beforehand
   target_link_libraries(${name} PUBLIC hsa-runtime64 dl)
   add_dependencies(${name} llvm-link opt clang rocdl)
-endmacro(add_mcwamp_library name )
+endmacro(add_mcwamp_shared_library name )
 
 ####################
 # C++AMP runtime (CPU implementation)

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -57,6 +57,14 @@ macro(add_mcwamp_library name )
   add_dependencies(${name} llvm-link opt clang rocdl)
 endmacro(add_mcwamp_library name )
 
+macro(add_mcwamp_shared_library name )
+  add_library( ${name} SHARED ${ARGN} )
+  amp_target(${name})
+  # LLVM and Clang shall be compiled beforehand
+  target_link_libraries(${name} PUBLIC hsa-runtime64)
+  add_dependencies(${name} llvm-link opt clang rocdl)
+endmacro(add_mcwamp_library name )
+
 ####################
 # C++AMP runtime (CPU implementation)
 ####################

--- a/tests/Unit/SharedLibrary/shared_library2.cpp
+++ b/tests/Unit/SharedLibrary/shared_library2.cpp
@@ -1,7 +1,7 @@
 
 // RUN: %hc -fPIC -shared -DSHARED_LIBRARY_1 %s -o %T/libtest2_foo.so
 // RUN: %hc -fPIC -shared -DSHARED_LIBRARY_2 %s -o %T/libtest2_bar.so
-// RUN: %clang -std=c++11 -ldl -lpthread %s -o %t.out -ldl && LD_LIBRARY_PATH=%T %t.out
+// RUN: %hc -hc -std=c++11 -ldl -lpthread %s -o %t.out -ldl && LD_LIBRARY_PATH=%T %t.out
 
 // kernels built as multiple shared libraries
 // loaded dynamically via dlopen()

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -54,6 +54,9 @@ if os.environ.get('HCC_ENABLE_PRINTF'):
 else:
     config.environment['HCC_ENABLE_PRINTF'] = "1"
  
+if os.environ.get('AMDGPU_OBJ_CODEGEN'):
+    config.environment['AMDGPU_OBJ_CODEGEN'] = os.environ['AMDGPU_OBJ_CODEGEN']
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -57,6 +57,9 @@ else:
 if os.environ.get('AMDGPU_OBJ_CODEGEN'):
     config.environment['AMDGPU_OBJ_CODEGEN'] = os.environ['AMDGPU_OBJ_CODEGEN']
 
+if os.environ.get('HCC_EXTRA_GPU_ARCH'):
+    config.environment['HCC_EXTRA_GPU_ARCH'] = os.environ['HCC_EXTRA_GPU_ARCH']
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 


### PR DESCRIPTION
This is runtime portion to support early finalization in HCC.  The main changes include:

- teach to runtime to extract more than one code blobs from the .kernel section
- change the embedding of GPU IR into .kernel_ir section
- change scripts to allow GPU codegen during compilation rather than during linking
- changing libmcwamp from a static library into a shared library 
- a new env var to force early finalization