### PR TITLE
Fix Compilation for KMDUMPISA dump dir

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -224,9 +224,9 @@ fi
 
 if [ $KMDUMPISA == "1" ]; then
   if [ $KMTHINLTO == "1" ]; then
-    cp $2 ./dump-$AMDGPU_TARGET.isabin
+    cp $2 ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
   else
-    cp $2.isabin ./dump-$AMDGPU_TARGET.isabin
+    cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
   fi
   $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=asm -o $2.isa $2.opt.bc
   mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -7,6 +7,9 @@ then
   set -x
 fi
 
+# directory where files are dumped
+KMDUMPDIR="${KMDUMPDIR:=.}"
+
 # dump the isa
 KMDUMPISA="${KMDUMPISA:=0}"
 


### PR DESCRIPTION
HCC is dumping the hsaco object to root directory, but should be dumping
to the default dump directory. Fix this path for KMTHINLTO=1 and
KMDUMPISA=1. Fixes compilation error reported in #917