### PR TITLE
disable wg_register_limit1 test until issue is resolved

### DIFF
--- a/tests/Unit/HC/wg_register_limit1.cpp
+++ b/tests/Unit/HC/wg_register_limit1.cpp
@@ -1,4 +1,6 @@
 // RUN: %hc %s -o %t.out && %t.out
+// XFAIL: *
+// SWDEV-170201
 
 #include <hc.hpp>
 #include <string>


### PR DESCRIPTION
Just disabling this test until we resolve the failure.