### PR TITLE
Fix HCC Assembler Scripts

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -42,6 +42,7 @@ install(PROGRAMS ${PROJECT_BINARY_DIR}/compiler/bin/clamp-device
     ${PROJECT_BINARY_DIR}/compiler/bin/clamp-embed
     ${PROJECT_BINARY_DIR}/compiler/bin/clamp-assemble
     ${PROJECT_BINARY_DIR}/compiler/bin/clamp-link
+    ${PROJECT_BINARY_DIR}/compiler/bin/error-check
     ${PROJECT_BINARY_DIR}/compiler/bin/hc-kernel-assemble
     ${PROJECT_BINARY_DIR}/compiler/bin/hc-host-assemble
     DESTINATION bin)

--- a/lib/clamp-assemble.in
+++ b/lib/clamp-assemble.in
@@ -11,22 +11,28 @@ fi
 BINDIR=$(dirname $0)
 EMBED=$BINDIR/clamp-embed
 
+# Add error handling functions
+. $BINDIR/error-check
+
 if [ "$#" -ne 3 ]; then
   echo "Usage: $0 kernel-bitcode object elf_section_name" >&2
-  exit 1
+  exit -1
 fi
 
 if [ ! -f "$1" ]; then
   echo "kernel-bitcode $1 is not valid" >&2
-  exit 1
+  exit -1
 fi
 
 if [ -f "$2" ]; then
   mv "$2" "$2.host.o"
   $EMBED "$1" "$2.kernel.o" "$3"
+  check_exit_status $EMBED
   ld -r "$2.kernel.o" "$2.host.o" -o "$2"
+  check_exit_status ld
   rm "$2.kernel.o" "$2.host.o"
 else
   $EMBED "$1" "$2" "$3"
+  check_exit_status $EMBED
 fi
 

--- a/lib/error-check.in
+++ b/lib/error-check.in
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Clang Driver requires exit code -1 for failure and -2 for crash
+# Report exit code status if non-zero for Linux or kill signal
+
+check_exit_status ()
+{
+  local status="$?"
+  local signal=""
+  local orig_msg="${@}"
+  if [ ${status} -ne 0 ]; then
+    local src_lineno="${BASH_SOURCE[1]##*/}[${BASH_LINENO[0]}]"
+    if [ $((${status} < 128)) -ne 0 ]; then
+      echo "Error: $src_lineno: $orig_msg failed with status $status"
+      exit -1
+    else
+      signal="$(builtin kill -l $((${status} - 128)) 2>/dev/null)"
+      if [ "$signal" ]; then
+        echo "Error: $src_lineno: $orig_msg failed by kill signal $signal"
+      fi
+      exit -2
+    fi
+  fi
+  return 0;
+}

--- a/lib/hc-host-assemble.in
+++ b/lib/hc-host-assemble.in
@@ -20,14 +20,17 @@ LLVM_AS=$BINDIR/llvm-as
 LLVM_DIS=$BINDIR/llvm-dis
 LIBPATH=$BINDIR/../lib
 
+# Add error handling functions
+. $BINDIR/error-check
+
 if [ "$#" -lt 2 ]; then
   echo "Usage: $0 kernel-bitcode object (options)" >&2
-  exit 1
+  exit -1
 fi
 
 if [ ! -f "$1" ]; then
   echo "kernel-bitcode $1 is not valid" >&2
-  exit 1
+  exit -1
 fi
 
 CXXFLAGS=
@@ -46,3 +49,4 @@ CO="-c -o"
 
 ln -s "$1" "$1.bc"
 eval "$CLANG $CXXFLAGS \"$1.bc\" $CO \"$2\" "
+check_exit_status "eval $CLANG"

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -29,6 +29,9 @@ CLAMP_ASM=$BINDIR/clamp-assemble
 LIBPATH=$BINDIR/../lib
 CLANG_OFFLOAD_BUNDLER=$BINDIR/clang-offload-bundler
 
+# Add error handling functions
+. $BINDIR/error-check
+
 # At build directory, HCC compiler tools are placed under compiler/bin/, and
 # header files are placed under include/. At install directory, HCC compiler
 # tools are placed under bin/, and header files are placed under include/.
@@ -64,7 +67,7 @@ esac
 
 if [ "$#" -lt 2 ]; then
   echo "Usage: $0 kernel-bitcode object" >&2
-  exit 1
+  exit -1
 fi
 
 AMDGPU_TARGET_ARRAY=()
@@ -101,7 +104,7 @@ fi
 
 if [ ! -f "$KERNEL_INPUT" ]; then
   echo "kernel-bitcode $KERNEL_INPUT is not valid" >&2
-  exit 1
+  exit -1
 fi
 
 CO="-c -o"
@@ -117,9 +120,11 @@ KERNEL_SECTION=".kernel"
 # hip-kernel-assemble goes after hip-host-assemble, so attempt to link object from host
 if [ -f "$2" ]; then
   mv "$2" "$TEMP_DIR/$BASENAME.tmp.o"
+  check_exit_status mv
 fi
 
 cp $KERNEL_INPUT "$TEMP_NAME.bc"
+check_exit_status cp
 if [ $KMDUMPLLVM == "1" ]; then
   $LLVM_DIS "$TEMP_NAME.bc" -o "$TEMP_NAME.ll"
   cp "$TEMP_NAME.ll" ./dump.kernel_input.ll
@@ -156,25 +161,30 @@ if [ $AMDGPU_OBJ_CODEGEN == 1 ]; then
     wait $pid || ret=$((ret+$?))
   done
   if [ $ret != 0 ]; then
-    exit $ret
+    exit -1
   fi
 
   # invoke clang-offload-bundler
   $CLANG_OFFLOAD_BUNDLER -type=o $CLANG_OFFLOAD_BUNDLER_INPUTS_ARGS $CLANG_OFFLOAD_BUNDLER_TARGETS_ARGS -outputs=$TEMP_DIR/kernel.bundle
+  check_exit_status $CLANG_OFFLOAD_BUNDLER
 
   OLD_PWD=$PWD
   cd $TEMP_DIR
   $CLAMP_ASM "kernel.bundle" "$TEMP_NAME.camp.o" "$KERNEL_SECTION"
+  check_exit_status $CLAMP_ASM
   cd $OLD_PWD
 else
   ln -s "$KERNEL_INPUT" "$1.bc"
   $CLAMP_ASM "$1.bc" "$TEMP_NAME.camp.o" "$KERNEL_IR_SECTION"
+  check_exit_status $CLAMP_ASM
 fi
 
 if [ -f "$TEMP_DIR/$BASENAME.tmp.o" ]; then
   ld -r --allow-multiple-definition "$TEMP_DIR/$BASENAME.tmp.o" "$TEMP_NAME.camp.o" -o "$2"
+  check_exit_status ld
 else
   mv "$TEMP_NAME.camp.o" "$2"
+  check_exit_status mv
 fi
 
 rm -rf "$TEMP_DIR"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,10 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/../compiler/bin/clamp-assemble @ONLY)
 
 configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib/error-check.in
+  ${CMAKE_CURRENT_BINARY_DIR}/../compiler/bin/error-check @ONLY)
+
+configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/../lib/hc-kernel-assemble.in
   ${CMAKE_CURRENT_BINARY_DIR}/../compiler/bin/hc-kernel-assemble @ONLY)
 


### PR DESCRIPTION
There are multiple issues with hc-host-assemble, hc-kernel-assemble, and clamp-assemble scripts. Firstly, we use exit code 1 for errors, which is incorrect as clang driver does not halt to exit code 1 (only for assembler tool, not linker). Secondly, we are not checking the exit code values of the tools they call upon. Thirdly, exit code checking is not very informative.

So I've created these changes:
- Add new error-handling.in script for present and future error handling functions
- Changed exit codes to -1 for failures (since clang driver requires -1 for failure and -2 for crash)
- Added check_exit_status function for exit code checking, and it will print file and line number along with the failed status number, or kill signal used to kill a process.
- Added above checking to assembler scripts