### PR TITLE
add missing double quotes around the kernel file name

### DIFF
--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -123,7 +123,7 @@ if [ -f "$2" ]; then
   check_exit_status mv
 fi
 
-cp $KERNEL_INPUT "$TEMP_NAME.bc"
+cp "$KERNEL_INPUT" "$TEMP_NAME.bc"
 check_exit_status cp
 if [ $KMDUMPLLVM == "1" ]; then
   $LLVM_DIS "$TEMP_NAME.bc" -o "$TEMP_NAME.ll"


### PR DESCRIPTION
this should fix the "Unit/FilePath/file path_test2.cpp" test