### PR TITLE
add centOS docker builds for hcc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ properties([buildDiscarder(logRotator(
     numToKeepStr: '10')),
     disableConcurrentBuilds(),
     parameters([booleanParam( name: 'run_hip_integration_testing', defaultValue: false, description: 'Build hip with this compiler and run hip unit tests' ),
-                string( name: 'hip_integration_branch', defaultValue: 'ROCm-Developer-Tools/HIP/master', description: 'Path to hip branch to build & test' )]),
+                string( name: 'hip_integration_branch', defaultValue: 'ROCm-Developer-Tools/HIP/master', description: 'Path to hip branch to build & test' ),
+                choice ( name: 'build_os', choices: "ubuntu-16.04\ncentos-7", description: '')]),
     [$class: 'CopyArtifactPermissionProperty', projectNames: '*']
   ])
 
@@ -61,10 +62,10 @@ node( 'hcctest' )
   }
 
   def hcc_build_image = null
-  stage('ubuntu-16.04 image')
+  stage('Build docker image')
   {
     def build_org = "hcc-lc"
-    def build_type_name = "build-ubuntu-16.04"
+    def build_type_name = "build-${params.build_os}"
     def dockerfile_name = "dockerfile-${build_type_name}"
     def build_image_name = "${build_type_name}"
     dir('docker')
@@ -145,7 +146,7 @@ node( 'hcctest' )
   stage('artifactory')
   {
     def artifactory_org = "${env.JOB_NAME}".toLowerCase()
-    def image_name = "hcc-lc-ubuntu-16.04"
+    def image_name = "hcc-lc-${params.build_os}"
 
     dir("${build_dir_release_abs}/docker")
     {

--- a/docker/dockerfile-build-centos-7
+++ b/docker/dockerfile-build-centos-7
@@ -1,0 +1,94 @@
+#FROM centos/devtoolset-7-toolchain-centos7
+FROM centos:7
+
+# Update centos
+RUN yum -y update; yum clean all
+
+# Base
+RUN yum -y install git java-1.8.0-openjdk python; yum clean all
+
+# Enable epel-release repositories
+RUN yum --enablerepo=extras install -y epel-release
+
+# Install required base build and packaging commands for ROCm
+RUN yum -y install \
+    bc \
+    bridge-utils \
+    bison \
+    cmake3 \
+    devscripts \
+    dkms \
+    doxygen \
+    dpkg \
+    dpkg-dev \
+    dpkg-perl \
+    elfutils-libelf-devel \
+    expect \
+    file \
+    flex \
+    gcc-c++ \
+    libgcc \
+    glibc.i686 \
+    libcxx-devel \
+    ncurses \
+    ncurses-base \
+    ncurses-libs \
+    numactl-devel \
+    numactl-libs \
+    libnuma-dev \
+    libssh \
+    libunwind-devel \
+    libunwind \
+    llvm \
+    llvm-libs \
+    make \
+    openssl \
+    openssl-libs \
+    openssl-devel \
+    openssh \
+    openssh-clients \
+    pciutils \
+    pciutils-devel \
+    pciutils-libs \
+    pkgconfig \
+    pth \
+    qemu-kvm \
+    re2c \
+    rpm \
+    rpm-build \
+    subversion \
+    sudo \
+    time \
+    vim \
+    wget
+
+# Enable the epel repository for fakeroot
+RUN yum --enablerepo=extras install -y fakeroot
+RUN yum clean all
+
+# Build and install the currently blessed version of cmake
+RUN wget http://compute-artifactory.amd.com/artifactory/compat-source/cmake-3.5.2.tar.gz
+RUN tar -xvf cmake-3.5.2.tar.gz
+RUN cd cmake-3.5.2 && ./configure && make && make install && cd .. && rm -rf cmake-3.5.2 && rm -rf cmake-3.5.2.tar.gz
+
+# On CentOS, install package centos-release-scl available in CentOS repository:
+RUN yum install -y centos-release-scl
+
+# Install the devtoolset-7 collection:
+RUN yum install -y devtoolset-7
+RUN yum install -y devtoolset-7-libatomic-devel devtoolset-7-elfutils-libelf-devel
+
+# Add the artifactory repo containing the pre-compiled ROCm rpms
+RUN yum-config-manager --nogpgcheck --add-repo http://repo.radeon.com/rocm/yum/rpm
+RUN yum --enablerepo=\* clean metadata
+
+# Install the ROCm rpms
+RUN yum install --nogpgcheck -y hsakmt-roct hsakmt-roct-dev
+RUN yum install --nogpgcheck -y hsa-ext-rocr-dev hsa-rocr-dev rocminfo
+RUN yum install --nogpgcheck -y atmi hcc hip_base hip_doc hip_hcc hip_samples hsa-amd-aqlprofile 
+RUN yum install --nogpgcheck -y rocm-opencl rocm-opencl-devel rocm-smi
+
+# Start using software collections:
+RUN scl enable devtoolset-7 bash
+RUN source scl_source enable devtoolset-7
+


### PR DESCRIPTION
With growing interest in CentOS, adding CentOS builds to regular HCC build/tests.  This change adds a build parameter to the HCC build jenkins file.  For now the default is ubuntu 16.04.  But we may add randomization to this parameter in the near future.