### PR TITLE
Update formatting in hc_am.cpp

### DIFF
--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -95,16 +95,15 @@ void printRocrPointerInfo(std::ostream &os, const void *ptr)
     hsa_agent_t * peerAgents = nullptr;
     hsa_status = hsa_amd_pointer_info(const_cast<void*> (ptr), &info, malloc, &peerAgentCnt, &peerAgents);
 
-    if(hsa_status == HSA_STATUS_SUCCESS) {
-
-        for (uint32_t i=0; i<peerAgentCnt; i++) {
-            os << " 0x" << std::hex << peerAgents[i].handle ;
-               //<< "(" << hc::accelerator::get_seqnum_from_agent(peerAgents[i]) << ")" << std::dec;
-        }
-
-        if (peerAgents) {
-            free (peerAgents);
-        }
+    if (hsa_status != HSA_STATUS_SUCCESS) {
+        return;
+    }
+    for (uint32_t i = 0; i < peerAgentCnt; i++) {
+        os << " 0x" << std::hex << peerAgents[i].handle ;
+           //<< "(" << hc::accelerator::get_seqnum_from_agent(peerAgents[i]) << ")" << std::dec;
+    }
+    if (peerAgents) {
+        free(peerAgents);
     }
     os << std::dec;
 }
@@ -197,16 +196,15 @@ std::size_t AmPointerTracker::reset (const hc::accelerator &acc)
     std::size_t count = 0;
     // relies on C++11 (erase returns iterator)
     for (auto iter = _tracker.begin() ; iter != _tracker.end(); ) {
-        if (iter->second._acc == acc) {
-            if (iter->second._isAmManaged) {
-                hsa_amd_memory_pool_free(const_cast<void*> (iter->second._unalignedDevicePointer));
-            }
-            count++;
-
-            iter = _tracker.erase(iter);
-        } else {
-            iter++;
+        if (iter->second._acc != acc) {
+          iter++;
+          continue;
         }
+        if (iter->second._isAmManaged) {
+            hsa_amd_memory_pool_free(const_cast<void*> (iter->second._unalignedDevicePointer));
+        }
+        count++;
+        iter = _tracker.erase(iter);
     }
 
     return count;
@@ -224,7 +222,7 @@ void AmPointerTracker::update_peers (const hc::accelerator &acc, int peerCnt, hs
     for (auto iter = _tracker.begin() ; iter != _tracker.end(); ) {
         if (iter->second._acc == acc) {
             hsa_amd_agents_allow_access(peerCnt, peerAgents, NULL, const_cast<void*> (iter->first._basePointer));
-        } 
+        }
         iter++;
     }
 }
@@ -248,54 +246,52 @@ namespace hc {
 auto_voidp am_aligned_alloc(std::size_t sizeBytes, hc::accelerator &acc, unsigned flags, std::size_t alignment)
 {
     void *ptr = NULL;
+    if (sizeBytes == 0) {
+        return ptr;
+    }
+    if (!acc.is_hsa_accelerator()) {
+        return ptr;
+    }
 
-    if (sizeBytes != 0 ) {
-        if (acc.is_hsa_accelerator()) {
-            hsa_agent_t *hsa_agent = static_cast<hsa_agent_t*> (acc.get_default_view().get_hsa_agent());
-            hsa_amd_memory_pool_t *alloc_region;
-            if (flags & amHostPinned) {
-               alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_system_region());
-            } else if (flags & amHostCoherent) {
-               alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_finegrained_system_region());
-            }else {
-               alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_region());
-            }
+    hsa_agent_t *hsa_agent = static_cast<hsa_agent_t*> (acc.get_default_view().get_hsa_agent());
+    hsa_amd_memory_pool_t *alloc_region;
+    if (flags & amHostPinned) {
+        alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_system_region());
+    } else if (flags & amHostCoherent) {
+        alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_finegrained_system_region());
+    } else {
+        alloc_region = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_region());
+    }
 
-            if (alloc_region && alloc_region->handle != -1) {
-                sizeBytes = alignment != 0 ? sizeBytes + alignment : sizeBytes;
-                hsa_status_t s1 = hsa_amd_memory_pool_allocate(*alloc_region, sizeBytes, 0, &ptr);
+    if (!alloc_region || alloc_region->handle == -1) {
+        return ptr;
+    }
 
-                void *unalignedPtr = ptr;
-                if (alignment != 0) {
-                    ptr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(ptr) + alignment - 1) & ~(alignment - 1));
-                }
+    sizeBytes = alignment != 0 ? sizeBytes + alignment : sizeBytes;
+    hsa_status_t s1 = hsa_amd_memory_pool_allocate(*alloc_region, sizeBytes, 0, &ptr);
+    void *unalignedPtr = ptr;
+    if (alignment != 0) {
+        ptr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(ptr) + alignment - 1) & ~(alignment - 1));
+    }
+    if (s1 != HSA_STATUS_SUCCESS) {
+        return NULL;
+    }
 
-                if (s1 != HSA_STATUS_SUCCESS) {
-                    ptr = NULL;
-                } else {
-                    if (flags & (amHostPinned|amHostCoherent)) {
-                        if (s1 != HSA_STATUS_SUCCESS) {
-                            hsa_amd_memory_pool_free(ptr);
-                            ptr = NULL;
-                        } else {
-                            hc::AmPointerInfo ampi(ptr/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, false/*isDevice*/, true /*isAMManaged*/);
-                            g_amPointerTracker.insert(unalignedPtr,ampi);
+    if (!(flags & (amHostPinned | amHostCoherent))) {
+        // This is a device memory allocation only.
+        hc::AmPointerInfo ampi(NULL/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, true/*isDevice*/, true /*isAMManaged*/);
+        g_amPointerTracker.insert(unalignedPtr, ampi);
+        return ptr;
+    }
 
-                            // Host memory is always mapped to all possible peers:
-                            auto accs = hc::accelerator::get_all();
-                            auto s2 = am_map_to_peers(ptr, accs.size(), accs.data());
-                            if (s2 != AM_SUCCESS) {
-                                hsa_amd_memory_pool_free(ptr);
-                                ptr = NULL;
-                            }
-                        }
-                    } else {
-                        hc::AmPointerInfo ampi(NULL/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, true/*isDevice*/, true /*isAMManaged*/);
-                        g_amPointerTracker.insert(unalignedPtr,ampi);
-                    }
-                }
-            }
-        }
+    hc::AmPointerInfo ampi(ptr/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, false/*isDevice*/, true /*isAMManaged*/);
+    g_amPointerTracker.insert(unalignedPtr,ampi);
+    // Host memory is always mapped to all possible peers:
+    auto accs = hc::accelerator::get_all();
+    auto s2 = am_map_to_peers(ptr, accs.size(), accs.data());
+    if (s2 != AM_SUCCESS) {
+        hsa_amd_memory_pool_free(ptr);
+        ptr = NULL;
     }
 
     return ptr;
@@ -306,19 +302,20 @@ auto_voidp am_alloc(std::size_t sizeBytes, hc::accelerator &acc, unsigned flags)
     return am_aligned_alloc(sizeBytes, acc, flags, 0);
 };
 
-am_status_t am_free(void* ptr) 
+am_status_t am_free(void* ptr)
 {
     am_status_t status = AM_SUCCESS;
+    if (ptr == NULL) {
+      return status;
+    }
 
-    if (ptr != NULL) {
-        auto info = g_amPointerTracker.find(ptr);
-        if (info != g_amPointerTracker.end()) {
-            hsa_amd_memory_pool_free(info->second._unalignedDevicePointer);
-        }
-        int numRemoved = g_amPointerTracker.remove(ptr) ;
-        if (numRemoved == 0) {
-            status = AM_ERROR_MISC;
-        }
+    auto info = g_amPointerTracker.find(ptr);
+    if (info != g_amPointerTracker.end()) {
+        hsa_amd_memory_pool_free(info->second._unalignedDevicePointer);
+    }
+    int numRemoved = g_amPointerTracker.remove(ptr) ;
+    if (numRemoved == 0) {
+        status = AM_ERROR_MISC;
     }
     return status;
 }
@@ -342,14 +339,13 @@ am_status_t am_copy(void*  dst, const void*  src, std::size_t sizeBytes)
 am_status_t am_memtracker_getinfo(hc::AmPointerInfo *info, const void *ptr)
 {
     auto infoI = g_amPointerTracker.find(ptr);
-    if (infoI != g_amPointerTracker.end()) {
-        if (info) {
-            *info = infoI->second;
-        }
-        return AM_SUCCESS;
-    } else {
-        return AM_ERROR_MISC;
+    if (infoI == g_amPointerTracker.end()) {
+      return AM_ERROR_MISC;
     }
+    if (info) {
+       *info = infoI->second;
+    }
+    return AM_SUCCESS;
 }
 
 
@@ -357,25 +353,22 @@ am_status_t am_memtracker_add(void* ptr, hc::AmPointerInfo &info)
 {
     if ((ptr == NULL) || (info._sizeBytes == 0)) {
         return AM_ERROR_MISC;
-    } else {
-        g_amPointerTracker.insert(ptr, info);
-        return AM_SUCCESS;
-    };
-
+    }
+    g_amPointerTracker.insert(ptr, info);
+    return AM_SUCCESS;
 }
 
 
 am_status_t am_memtracker_update(const void* ptr, int appId, unsigned allocationFlags, void *appPtr)
 {
     auto iter = g_amPointerTracker.find(ptr);
-    if (iter != g_amPointerTracker.end()) {
-        iter->second._appId              = appId;
-        iter->second._appAllocationFlags = allocationFlags;
-        iter->second._appPtr             = appPtr;;
-        return AM_SUCCESS;
-    } else {
-        return AM_ERROR_MISC;
+    if (iter == g_amPointerTracker.end()) {
+      return AM_ERROR_MISC;
     }
+    iter->second._appId              = appId;
+    iter->second._appAllocationFlags = allocationFlags;
+    iter->second._appPtr             = appPtr;;
+    return AM_SUCCESS;
 }
 
 
@@ -427,7 +420,6 @@ void am_memtracker_print(void *targetAddress)
             };
 
         }
-
         if (!foundMatch) {
             os << "db: memtracker did not find pointer:" << targetAddress << ".  However, it is closest to the following allocations:\n";
             if (closestBefore != g_amPointerTracker.end()) {
@@ -469,17 +461,18 @@ void am_memtracker_sizeinfo(const hc::accelerator &acc, std::size_t *deviceMemSi
 {
     *deviceMemSize = *hostMemSize = *userMemSize = 0;
     for (auto iter = g_amPointerTracker.readerLockBegin() ; iter != g_amPointerTracker.end(); iter++) {
-        if (iter->second._acc == acc) {
-            std::size_t sizeBytes = iter->second._sizeBytes;
-            if (iter->second._isAmManaged) {
-                if (iter->second._isInDeviceMem) {
-                    *deviceMemSize += sizeBytes;
-                } else {
-                    *hostMemSize += sizeBytes;
-                }
+        if (iter->second._acc != acc) {
+          continue;
+        }
+        std::size_t sizeBytes = iter->second._sizeBytes;
+        if (iter->second._isAmManaged) {
+            if (iter->second._isInDeviceMem) {
+                *deviceMemSize += sizeBytes;
             } else {
-                *userMemSize += sizeBytes;
+                *hostMemSize += sizeBytes;
             }
+        } else {
+            *userMemSize += sizeBytes;
         }
     }
 
@@ -501,109 +494,98 @@ void am_memtracker_update_peers (const hc::accelerator &acc, int peerCnt, hsa_ag
 am_status_t am_map_to_peers(void* ptr, std::size_t num_peer, const hc::accelerator* peers) 
 {
     // check input
-    if(nullptr == ptr || 0 == num_peer || nullptr == peers)
+    if (nullptr == ptr || 0 == num_peer || nullptr == peers)
         return AM_ERROR_MISC;
 
     hc::accelerator ptrAcc;
     AmPointerInfo info(nullptr, nullptr, nullptr, 0, ptrAcc, false, false);
     auto status = am_memtracker_getinfo(&info, ptr);
-    if(AM_SUCCESS != status)
+    if (AM_SUCCESS != status)
         return status;
 
-        hsa_amd_memory_pool_t* pool = nullptr;
-    if(info._isInDeviceMem)
-    {
+    hsa_amd_memory_pool_t* pool = nullptr;
+    if (info._isInDeviceMem) {
         // get accelerator and pool of device memory
         ptrAcc = info._acc;
         pool = static_cast<hsa_amd_memory_pool_t*>(ptrAcc.get_hsa_am_region());
-    }
-    else
-    {
+    } else {
         //TODO: the ptr is host pointer, it might be allocated through am_alloc, 
         // or allocated by others, but add it to the tracker.
         // right now, only support host pointer which is allocated through am_alloc.
-        if(info._isAmManaged)
-        {
-            // here, accelerator is the device, but used to query system memory pool
-            ptrAcc = info._acc;
-            pool = static_cast<hsa_amd_memory_pool_t*>(ptrAcc.get_hsa_am_system_region()); 
-        }
-        else
+        if (!info._isAmManaged) {
             return AM_ERROR_MISC;
+        }
+        // here, accelerator is the device, but used to query system memory pool
+        ptrAcc = info._acc;
+        pool = static_cast<hsa_amd_memory_pool_t*>(ptrAcc.get_hsa_am_system_region()); 
     }
 
     std::vector<hsa_agent_t> agents{hc::accelerator::get_all().size()};
 
     int peer_count = 0;
 
-    for(auto i = 0; i < num_peer; i++)
-    {
+    for (auto i = 0; i < num_peer; i++) {
         // if pointer is device pointer, and the accelerator itself is included in the list, ignore it
         auto& a = peers[i];
-        if(info._isInDeviceMem)
-        {
-            if(a == ptrAcc)
+        if (info._isInDeviceMem) {
+            if (a == ptrAcc)
                 continue;
         }
 
         hsa_agent_t* agent = static_cast<hsa_agent_t*>(a.get_hsa_agent());
 
-        if (agent) {
+        if (!agent) {
+          continue;
+        }
 
-            hsa_amd_memory_pool_access_t access;
-            hsa_status_t  status = hsa_amd_agent_memory_pool_get_info(*agent, *pool, HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access);
-            if(HSA_STATUS_SUCCESS != status)
-                return AM_ERROR_MISC;
+        hsa_amd_memory_pool_access_t access;
+        hsa_status_t  status = hsa_amd_agent_memory_pool_get_info(*agent, *pool, HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access);
+        if (HSA_STATUS_SUCCESS != status)
+            return AM_ERROR_MISC;
 
-            // check access
-            if(HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED == access)
-                return AM_ERROR_MISC;
+        // check access
+        if(HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED == access)
+            return AM_ERROR_MISC;
 
-            bool add_agent = true;
+        bool add_agent = true;
 
-            for(int ii = 0; ii < peer_count; ii++)
-            {
-                if(agent->handle == agents[ii].handle)
-                    add_agent = false;
-            } 
+        for (int ii = 0; ii < peer_count; ii++) {
+            if (agent->handle == agents[ii].handle)
+                add_agent = false;
+        }
 
-            if(add_agent)
-            {
-                 agents[peer_count] = *agent;
-                 peer_count++;
-            }    
+        if (add_agent) {
+            agents[peer_count] = *agent;
+            peer_count++;
         }
     }
 
     // allow access to the agents
-    if(peer_count)
-    {
+    if (peer_count) {
         hsa_status_t status = hsa_amd_agents_allow_access(peer_count, agents.data(), NULL, ptr);
-        return status == HSA_STATUS_SUCCESS ? AM_SUCCESS : AM_ERROR_MISC;
+        if (status != HSA_STATUS_SUCCESS) {
+            return AM_ERROR_MISC;
+        }
     }
-   
     return AM_SUCCESS;
 }
 
 am_status_t am_memory_host_lock(hc::accelerator &ac, void *hostPtr, std::size_t size, hc::accelerator *visible_ac, std::size_t num_visible_ac)
 {
-    am_status_t am_status = AM_ERROR_MISC;
     void *devPtr;
     std::vector<hsa_agent_t> agents;
-    for(int i=0;i<num_visible_ac;i++)
-    {
+    for (int i = 0; i < num_visible_ac; i++) {
         agents.push_back(*static_cast<hsa_agent_t*>(visible_ac[i].get_hsa_agent()));
     }
     hsa_status_t hsa_status = hsa_amd_memory_lock(hostPtr, size, &agents[0], num_visible_ac, &devPtr);
-    if(hsa_status == HSA_STATUS_SUCCESS)
-    {
-       hc::AmPointerInfo ampi(hostPtr, devPtr, devPtr, size, ac, false, false);
-       hc::AmPointerInfo ampi2(hostPtr, devPtr, devPtr, size, ac, true, false);
-       g_amPointerTracker.insert(hostPtr, ampi);
-       g_amPointerTracker.insert(devPtr, ampi2);
-       am_status = AM_SUCCESS;
+    if (hsa_status != HSA_STATUS_SUCCESS) {
+        return AM_ERROR_MISC;
     }
-    return am_status;
+    hc::AmPointerInfo ampi(hostPtr, devPtr, devPtr, size, ac, false, false);
+    hc::AmPointerInfo ampi2(hostPtr, devPtr, devPtr, size, ac, true, false);
+    g_amPointerTracker.insert(hostPtr, ampi);
+    g_amPointerTracker.insert(devPtr, ampi2);
+    return AM_SUCCESS;
 }
 
 am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
@@ -611,17 +593,16 @@ am_status_t am_memory_host_unlock(hc::accelerator &ac, void *hostPtr)
     am_status_t am_status = AM_ERROR_MISC;
     hc::AmPointerInfo amPointerInfo(NULL, NULL, NULL, 0, ac, 0, 0);
     am_status = am_memtracker_getinfo(&amPointerInfo, hostPtr);
-    if(am_status == AM_SUCCESS)
-    {
-        hsa_status_t hsa_status = hsa_amd_memory_unlock(hostPtr);
-        if (hsa_status == HSA_STATUS_SUCCESS) {
-            am_status = am_memtracker_remove(hostPtr);
-            if ( amPointerInfo._devicePointer )
-                am_status = am_memtracker_remove(amPointerInfo._devicePointer);
-        } else {
-            am_status = AM_ERROR_MISC;
-        }
+    if (am_status != AM_SUCCESS) {
+        return am_status;
     }
+    hsa_status_t hsa_status = hsa_amd_memory_unlock(hostPtr);
+    if (hsa_status != HSA_STATUS_SUCCESS) {
+        return AM_ERROR_MISC;
+    }
+    am_status = am_memtracker_remove(hostPtr);
+    if (amPointerInfo._devicePointer)
+        am_status = am_memtracker_remove(amPointerInfo._devicePointer);
     return am_status;
 }
 


### PR DESCRIPTION
I have been learning about the ROCm infrastructure, and while trying to understand the memory-allocation code I ended up reformatting some of this file to make it easier to read myself.

The most difficult-to-read function was `am_aligned_alloc`, which now requires about 4 fewer levels of indentation.  Additionally, I noticed that the check on line 277 was redundant after the same check on line 273.

Apologies in advance if you aren't looking for PRs like this!  However, if this is helpful I would be happy to continue to sending similar changes as I keep going through the code.