### PR TITLE
Stop using noduplicate

### DIFF
--- a/include/hc_defines.h
+++ b/include/hc_defines.h
@@ -50,8 +50,8 @@ extern "C" __attribute__((const,amp)) uint32_t amp_get_group_id(unsigned int n);
 #define tile_static __attribute__((tile_static))
 #endif
 
-extern "C" __attribute__((noduplicate,hc)) void hc_barrier(unsigned int n);
-extern "C" __attribute__((noduplicate,amp)) void amp_barrier(unsigned int n) ;
+extern "C" __attribute__((convergent,hc)) void hc_barrier(unsigned int n);
+extern "C" __attribute__((convergent,amp)) void amp_barrier(unsigned int n) ;
 
 /// macro to set if we want default queue be thread-local or not
 #define TLS_QUEUE (1)


### PR DESCRIPTION
It's been replaced by convergent for these purposes.
Explicitly adding convergent isn't really necessary, since
external functions are assumed convergent by default.

Change-Id: I0b35564edb7e98091944a59470d6e8a91d52c837
(cherry picked from commit 8bf8b8c6da9f895574ca8d07841bb471541014b9)