### PR TITLE
add zlib package to upstream merge docker file

### DIFF
--- a/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
+++ b/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
@@ -18,6 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \
     vim \
+    zlib1g-dev:amd64 \
     zip unzip 
 
 ENV HCC_HOME=$ROCM_PATH/hcc


### PR DESCRIPTION
This package contains necessary header files, and is sometimes not picked up when docker containers are built on various machines.  Adding this package to ensure the necessary headers are available in containers.