### PR TITLE
wg_register_limit1.cpp passes with clang:08d0c133ccb1b530ed743a021dc5…

### DIFF
--- a/tests/Unit/HC/wg_register_limit1.cpp
+++ b/tests/Unit/HC/wg_register_limit1.cpp
@@ -1,6 +1,4 @@
 // RUN: %hc %s -o %t.out && %t.out
-// XFAIL: *
-// SWDEV-170201
 
 #include <hc.hpp>
 #include <string>


### PR DESCRIPTION
…995fbcdaf012

This test is now passing with Clang commit:  https://github.com/llvm-mirror/clang/commit/08d0c133ccb1b530ed743a021dc5995fbcdaf012#diff-b68135a2e4144048f1b3a3af7d0d2a1f 