### PR TITLE
Update extractkernel to support multiple embedded device code blobs

### DIFF
--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -13,6 +13,11 @@ sub usage {
 }
 
 my $debug = 0;
+
+# use clang offload bundler (instead of "dd")
+# to extract device object from the bundle
+my $use_clang_offload_bundler = 1;
+
 my %options=();
 getopts('hi:', \%options);
 
@@ -80,7 +85,7 @@ while(1) {
   my $num_bundles;
   $read_bytes = read(INPUT_FP, $num_bundles, 8);
   $read_bytes == 8 or die("Fail to parse number of bundles\n");
-  $num_bundles = unpack("s", $num_bundles);
+  $num_bundles = unpack("Q", $num_bundles);
   if ($debug) {
     print "Blob $num_blobs, number of bundles: $num_bundles\n";
   }
@@ -103,14 +108,14 @@ while(1) {
     my $offset;
     $read_bytes = read(INPUT_FP, $offset, 8);
     $read_bytes == 8 or die("Fail to parse bundle offset\n");
-    $offset = unpack("s", $offset);
+    $offset = unpack("Q", $offset);
     $last_bundle_offset = max($last_bundle_offset, $offset);
 
     # read bundle size
     my $size;
     $read_bytes = read(INPUT_FP, $size, 8);
     $read_bytes == 8 or die("Fail to parse bundle size\n");
-    $size = unpack("s", $size);
+    $size = unpack("Q", $size);
     if ($last_bundle_offset == $offset) {
       $last_bundle_size = $size;
     }
@@ -119,12 +124,16 @@ while(1) {
     my $triple_size;
     $read_bytes = read(INPUT_FP, $triple_size, 8);
     $read_bytes == 8 or die("Fail to parse triple size\n");
-    $triple_size = unpack("s", $triple_size);
+    $triple_size = unpack("Q", $triple_size);
 
     # triple
     my $triple;
     $read_bytes = read(INPUT_FP, $triple, $triple_size);
     $read_bytes == $triple_size or die("Fail to parse triple\n");
+
+    if ($debug) {
+      print("\t bundle $iter: offset=$offset, size=$size, triple_size=$triple_size, triple=$triple\n");
+    }
 
     # Only process GPU targets, skip host targets
     if ($triple =~ /^hcc-amdgcn-amd-amdhsa--/) {
@@ -137,6 +146,17 @@ while(1) {
 
       # add into asic_target_array
       $asic_target_array[$#asic_target_array + 1]=$asic_target;
+
+      if (!$use_clang_offload_bundler) {
+        my $offset_for_hsaco = $current_blob_offset + $offset;
+        my $dd_command ="dd if=${input_file} of=${hsaco_file_name} skip=$offset_for_hsaco count=$size bs=1 status=none";
+        if ($debug) {
+          print("extract code bundle with dd: $dd_command\n");
+        }
+        system($dd_command) == 0
+          or die("Fail to extract code bundle with dd\n");
+      }
+
     } else {
       #print("Host target: " . $Triple . "\n");
     }
@@ -148,12 +168,18 @@ while(1) {
   system("dd if=$input_file of=$blob_filename skip=$current_blob_offset count=$write_bytes bs=1 status=none") == 0
     or die("Extracting kernel bundle file failed: $?");
 
-  if (-f $clang_offload_bundler) {
-    # use clang-offload-bundler to unbundle HSACO
-    system("${clang_offload_bundler} -unbundle -type=o -inputs=${blob_filename} ${clang_offloadbundler_outputs} ${clang_offloadbundler_targets}") == 0 
-      or die("Fail to execute clang-offload-bundler");
-  } else {
-    die("Can't find clang-offload-bundler\n");
+  if ($use_clang_offload_bundler) {
+    if (-f $clang_offload_bundler) {
+      # use clang-offload-bundler to unbundle HSACO
+      my $command = "${clang_offload_bundler} -unbundle -type=o -inputs=${blob_filename} ${clang_offloadbundler_outputs} ${clang_offloadbundler_targets}";
+      if ($debug) {
+        print("clang offload bundler command: $command\n");
+      }
+      system($command) == 0 
+        or die("Fail to execute clang-offload-bundler");
+    } else {
+      die("Can't find clang-offload-bundler\n");
+    }
   }
 
   if (-f $llvm_objdump) {

--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -2,6 +2,7 @@
 use strict;
 use File::Copy;
 use Getopt::Std;
+use List::Util qw(max);
 
 sub usage {
   print("Usage: $0 [OPTION]... -i <input>\n");
@@ -11,6 +12,7 @@ sub usage {
   exit;
 }
 
+my $debug = 0;
 my %options=();
 getopts('hi:', \%options);
 
@@ -18,96 +20,120 @@ if (!%options || defined $options{h}) {
   usage();
 }
 
+my $rocm_path = "@ROCM_ROOT@";
+# set the default to rocm path
+my $llvm_objdump = "$rocm_path/hcc/bin/llvm-objdump";
+my $clang_offload_bundler = "$rocm_path/hcc/bin/clang-offload-bundler";
+if (defined $ENV{'HCC_HOME'}) {
+  $llvm_objdump = "$ENV{'HCC_HOME'}/bin/llvm-objdump";
+  $clang_offload_bundler = "$ENV{'HCC_HOME'}/bin/clang-offload-bundler";
+}
+
 my $input_file;
 defined $options{i} || die("input not specified");
 $input_file = $options{i};
 (-f $input_file) || die("can't find $input_file");
 
-my $bundle_start_tag = "_binary_kernel_bundle_start";
-my $bundle_size_tag  = "_binary_kernel_bundle_size";
-my $bundle_start = hex(`objdump -t $input_file | grep $bundle_start_tag | awk '{print \$1}'`);
-my $bundle_size  = hex(`objdump -t $input_file | grep $bundle_size_tag | awk '{print \$1}'`);
-
-if ($bundle_start == 0 || $bundle_size == 0) {
-  die("can't find any kernel bundle file in $input_file\n");
+my $kernel_section_size =  hex(`objdump -h $input_file | grep ".kernel" | awk '{print \$3}'`);
+my $kernel_section_offset =  hex(`objdump -h $input_file | grep ".kernel" | awk '{print \$6}'`);
+my $kernel_section_end = $kernel_section_offset + $kernel_section_size;
+$kernel_section_size or die("No .kernel section found\n");
+if ($debug) {
+  print "kernel section size: $kernel_section_size\n";
+  print "kernel section offset: $kernel_section_offset\n";
+  print "kernel section end: $kernel_section_end\n";
 }
-else {
 
-  # extract kernel bundle file from the binary
-  my $data_lma         = hex(`objdump -h $input_file | grep ".kernel" | awk '{print \$5}'`);
-  my $data_file_offset = hex(`objdump -h $input_file | grep ".kernel" | awk '{print \$6}'`);
-  my $bundle_file_offset = $data_file_offset + ($bundle_start - $data_lma);
-  my $bundle_file_name = "$input_file.bundle";
-  system("dd if=$input_file of=$bundle_file_name skip=$bundle_file_offset count=$bundle_size bs=1 status=none") == 0
-    or die("Extracting kernel bundle file failed: $?");
+# parse kernel bundle header
+open INPUT_FP, $input_file || die $!;
+binmode INPUT_FP;
 
-  # hold the array of GPU targets
-  # parsed below by looking into kernel bundle file header
-  # used by llvm-objdump later on
-  my @asic_target_array;
+my $current_blob_offset = $kernel_section_offset;
+my $num_blobs = 0;
+#while ($current_blob_offset < $kernel_section_end) {
+while(1) {
 
-  # parse kernel bundle header
-  open BUNDLE_FP, $bundle_file_name || die $!;
-  binmode BUNDLE_FP;
+  if ($debug) {
+    print "Current blob offset: $current_blob_offset\n";
+  }
+
+  if ($current_blob_offset >= $kernel_section_end) {
+    if ($debug) {
+      print "reached end of kernel section\n";
+    }
+    last;
+  }
+
+  seek(INPUT_FP, $current_blob_offset, 0);
 
   # skip OFFLOAD_BUNDLER_MAGIC_STR
   my $magic_str;
-  my $read_bytes;
-  $read_bytes = read(BUNDLE_FP, $magic_str, 24);
+  my $read_bytes = read(INPUT_FP, $magic_str, 24);
   if (($read_bytes != 24) || ($magic_str ne "__CLANG_OFFLOAD_BUNDLE__")) {
-    die("Incorrect magic string");
-  }
-
-  # read number of bundles
-  my $NumberOfBundles;
-  $read_bytes = read(BUNDLE_FP, $NumberOfBundles, 8);
-  if ($read_bytes != 8) {
-    die("Fail to parse number of bundles");
-  }
-  $NumberOfBundles = unpack("s", $NumberOfBundles);
-
-  my $ClangOffloadBundlerOutputsArgs="-outputs=/dev/null";
-  my $ClangOffloadBundlerTargetsArgs="-targets=host-@CMAKE_SYSTEM_PROCESSOR@-unknown-linux";
-
-  for (my $iter = 0; $iter < $NumberOfBundles; $iter++) {
-    # read offset
-    my $Offset;
-    $read_bytes = read(BUNDLE_FP, $Offset, 8);
-    if ($read_bytes != 8) {
-      die("Fail to parse bundle offset");
+    # didn't detect the bundle magic string
+    if ($debug) {
+      print "Offload bundle magic string not detected\n";
     }
+    last;
+  }
+  # read number of bundles
+  my $num_bundles;
+  $read_bytes = read(INPUT_FP, $num_bundles, 8);
+  $read_bytes == 8 or die("Fail to parse number of bundles\n");
+  $num_bundles = unpack("s", $num_bundles);
+  if ($debug) {
+    print "Blob $num_blobs, number of bundles: $num_bundles\n";
+  }
 
-    # read size
-    my $Size;
-    $read_bytes = read(BUNDLE_FP, $Size, 8);
-    if ($read_bytes != 8) {
-      die("Fail to parse bundle size");
+  # detected GPU targets
+  my @asic_target_array;
+
+  my $last_bundle_offset = 0;
+  my $last_bundle_size = 0;
+
+  # strings for creating new files
+  my $file_blob_number = sprintf("%03d", $num_blobs);
+  my $filename_prefix = "${input_file}-${file_blob_number}";
+
+  my $clang_offloadbundler_outputs="-outputs=/dev/null";
+  my $clang_offloadbundler_targets="-targets=host-@CMAKE_SYSTEM_PROCESSOR@-unknown-linux";
+
+  for (my $iter = 0; $iter < $num_bundles; $iter++) {
+    # read bundle offset
+    my $offset;
+    $read_bytes = read(INPUT_FP, $offset, 8);
+    $read_bytes == 8 or die("Fail to parse bundle offset\n");
+    $offset = unpack("s", $offset);
+    $last_bundle_offset = max($last_bundle_offset, $offset);
+
+    # read bundle size
+    my $size;
+    $read_bytes = read(INPUT_FP, $size, 8);
+    $read_bytes == 8 or die("Fail to parse bundle size\n");
+    $size = unpack("s", $size);
+    if ($last_bundle_offset == $offset) {
+      $last_bundle_size = $size;
     }
 
     # read triple size
-    my $TripleSize;
-    $read_bytes = read(BUNDLE_FP, $TripleSize, 8);
-    if ($read_bytes != 8) {
-      die("Fail to parse triple size");
-    }
-    $TripleSize = unpack("s", $TripleSize);
+    my $triple_size;
+    $read_bytes = read(INPUT_FP, $triple_size, 8);
+    $read_bytes == 8 or die("Fail to parse triple size\n");
+    $triple_size = unpack("s", $triple_size);
 
-    # read triple
-    my $Triple;
-    $read_bytes = read(BUNDLE_FP, $Triple, $TripleSize);
-    if ($read_bytes != $TripleSize) {
-      die("Fail to parse triple");
-    }
+    # triple
+    my $triple;
+    $read_bytes = read(INPUT_FP, $triple, $triple_size);
+    $read_bytes == $triple_size or die("Fail to parse triple\n");
 
     # Only process GPU targets, skip host targets
-    if ($Triple =~ /^hcc-amdgcn-amd-amdhsa--/) {
-      my $asic_target = substr($Triple, 23); # hcc-amdgcn-amd-amdhsa--
-      #print("GPU target: " . $asic_target . "\n");
+    if ($triple =~ /^hcc-amdgcn-amd-amdhsa--/) {
+      my $asic_target = substr($triple, 23); # hcc-amdgcn-amd-amdhsa--
 
       # augment arguments for clang-offload-bundler
-      my $hsaco_file_name = "$input_file-$asic_target.hsaco";
-      $ClangOffloadBundlerOutputsArgs = $ClangOffloadBundlerOutputsArgs . "," . $hsaco_file_name;
-      $ClangOffloadBundlerTargetsArgs = $ClangOffloadBundlerTargetsArgs . "," . $Triple;
+      my $hsaco_file_name = "${filename_prefix}-${asic_target}.hsaco";
+      $clang_offloadbundler_outputs = "${clang_offloadbundler_outputs},${hsaco_file_name}";
+      $clang_offloadbundler_targets = "${clang_offloadbundler_targets},${triple}";
 
       # add into asic_target_array
       $asic_target_array[$#asic_target_array + 1]=$asic_target;
@@ -116,25 +142,16 @@ else {
     }
   }
 
-  # close file
-  close BUNDLE_FP;
-
-  my $rocm_path = "@ROCM_ROOT@";
-  # set the default to rocm path
-  my $llvm_objdump = "$rocm_path/hcc/bin/llvm-objdump";
-  my $clang_offload_bundler = "$rocm_path/hcc/bin/clang-offload-bundler";
-
-  if (defined $ENV{'HCC_HOME'}) {
-    $llvm_objdump = "$ENV{'HCC_HOME'}/bin/llvm-objdump";
-    $clang_offload_bundler = "$ENV{'HCC_HOME'}/bin/clang-offload-bundler";
-  }
+  # extract the code blob
+  my $blob_filename = "${filename_prefix}.bundle";
+  my $write_bytes = $last_bundle_offset + $last_bundle_size;
+  system("dd if=$input_file of=$blob_filename skip=$current_blob_offset count=$write_bytes bs=1 status=none") == 0
+    or die("Extracting kernel bundle file failed: $?");
 
   if (-f $clang_offload_bundler) {
-    #print($ClangOffloadBundlerOutputsArgs);
-    #print($ClangOffloadBundlerTargetsArgs);
-
     # use clang-offload-bundler to unbundle HSACO
-    system("$clang_offload_bundler -unbundle -type=o -inputs=$bundle_file_name " . $ClangOffloadBundlerOutputsArgs . " " . $ClangOffloadBundlerTargetsArgs) == 0 or die("Fail to execute clang-offload-bundler");
+    system("${clang_offload_bundler} -unbundle -type=o -inputs=${blob_filename} ${clang_offloadbundler_outputs} ${clang_offloadbundler_targets}") == 0 
+      or die("Fail to execute clang-offload-bundler");
   } else {
     die("Can't find clang-offload-bundler\n");
   }
@@ -142,14 +159,24 @@ else {
   if (-f $llvm_objdump) {
     for (my $iter = 0; $iter <= $#asic_target_array; $iter++) {
       my $asic_target = $asic_target_array[$iter];
-      my $hsaco_file_name = "$input_file-$asic_target.hsaco";
-      my $isa_file_name = "$input_file-$asic_target.isa";
+      my $hsaco_file_name = "${filename_prefix}-${asic_target}.hsaco";
+      my $isa_file_name = "${filename_prefix}-${asic_target}.isa";
 
       # use llvm-objdump to dump out GCN ISA
       system("$llvm_objdump -disassemble -mcpu=$asic_target $hsaco_file_name > $isa_file_name") == 0 or die("Fail to disassemble AMDGPU ISA for target" . $asic_target);
-      print("Generated GCN ISA for " . $asic_target . " at: " . $isa_file_name . "\n");
+      
+      if ($debug) {
+        print("Generated GCN ISA for " . $asic_target . " at: " . $isa_file_name . "\n");
+      }
     }
   } else {
-    die("Can't find AMDGPU disassembler\n");
+    die("Can't find llvm-objdump\n");
   }
+
+  $current_blob_offset = $current_blob_offset + $last_bundle_offset + $last_bundle_size;
+  $num_blobs++;
 }
+
+$num_blobs or die("No device code found.\n");
+exit(0);
+


### PR DESCRIPTION
This adds to the extractkernel tool the support for extracting multiple embedded device code blobs from a host executable. 