### PR TITLE
getHSAQueue returns RocrQueue* instead of has_queue_t*

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1968,7 +1968,7 @@ public:
     }
 
     void* getHSAQueue() override {
-        return static_cast<void*>(rocrQueue);
+        return static_cast<void*>(rocrQueue->_hwQueue);
     }
 
     hsa_queue_t *acquireLockedRocrQueue();


### PR DESCRIPTION
https://github.com/RadeonOpenCompute/hcc/issues/1021
