### PR TITLE
Update AMDGCN triple field

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -200,7 +200,7 @@ fi
 
 # Optimization notes:
 #  -disable-simplify-libcalls:  prevents transforming loops into library calls such as memset, memcopy on GPU
-$OPT -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET \
+$OPT -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET \
   -amdgpu-internalize-symbols -disable-simplify-libcalls $KMOPTOPT -verify \
   < $2.selected.bc -o $2.opt.bc
 
@@ -230,9 +230,9 @@ fi
 CODE_OBJECT_FORMAT="-mattr=-code-object-v3"
 
 if [ $KMTHINLTO == "1" ]; then
-  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2 $2.opt.bc
+  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2 $2.opt.bc
 else
-  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2.isabin $2.opt.bc
+  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2.isabin $2.opt.bc
 fi
 
 # error handling for llc
@@ -248,7 +248,7 @@ if [ $KMDUMPISA == "1" ]; then
   else
     cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
   fi
-  $LLC $KMOPTLLC -mtriple amdgcn--amdhsa-amdgiz -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=asm -o $2.isa $2.opt.bc
+  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=asm -o $2.isa $2.opt.bc
   mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
 fi
 


### PR DESCRIPTION
I'm not sure when triples changed, but it looks like amdgcn--amdhsa-amdgiz is not used much in clang/llvm.