### PR TITLE
correct .gitmodules for compiler-rt and clang-tools-extra to use amd-…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,12 +13,12 @@
 [submodule "compiler-rt"]
 	path = compiler-rt
 	url = https://github.com/RadeonOpenCompute/compiler-rt
-    branch = amd-hcc
+        branch = amd-common
 [submodule "rocdl"]
 	path = rocdl
 	url = http://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
-    branch = master
+        branch = master
 [submodule "clang-tools-extra"]
 	path = clang-tools-extra
 	url = https://github.com/RadeonOpenCompute/clang-tools-extra.git
-	branch = amd-hcc
+	branch = amd-common


### PR DESCRIPTION
…common

the .gitmodules file was referencing amd-hcc branch for compiler-rt and clang-tools-extra.  We moved to amd-common a while ago.  Luckily, the git references are still correct.