### PR TITLE
Deferred cleanup of HSAOps.

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1563,7 +1563,7 @@ public:
         // Have to walk asyncOps since it can contain null pointers.
         // Also not all commands contain signals.
         // Start search at youngest op.
-        for (int i = decrement(asyncOpsIndex), count = 0; count < asyncOps.size(); i = decrement(i)) {
+        for (int i = decrement(asyncOpsIndex), count = 0; count < asyncOps.size(); i = decrement(i), ++count) {
             if (asyncOps[i] != nullptr) {
                 hsa_signal_t signal = *(static_cast <hsa_signal_t*> (asyncOps[i]->getNativeHandle()));
                 if (signal.handle) {
@@ -1610,7 +1610,7 @@ public:
         std::shared_future<void>* future = nullptr;
         {
             std::lock_guard<std::recursive_mutex> lg(qmutex);
-            for (int i = decrement(asyncOpsIndex); i != 0;  i--) {
+            for (int i = decrement(asyncOpsIndex), count = 0; count < asyncOps.size(); i = decrement(i), ++count) {
                 if (asyncOps[i] != nullptr) {
                     auto asyncOp = asyncOps[i];
                     // wait on valid futures only

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3992,6 +3992,9 @@ void HSAQueue::dispose() override {
         // wait on all existing kernel dispatches and barriers to complete
         wait();
 
+        // clear asyncOps to trigger any lingering resource cleanup while we still hold the locks
+        asyncOps.clear();
+
         this->valid = false;
 
         // clear bufferKernelMap

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4252,17 +4252,9 @@ HSAQueue::dispatch_hsa_kernel(const hsa_kernel_dispatch_packet_t *aql,
     pushAsyncOp(sp_dispatch);
     dispatch->setKernelName(kernelName);
 
-
-    // May be faster to create signals for each dispatch than to use markers.
-    // Perhaps could check HSA queue pointers.
-    bool needsSignal = true;
-    if (HCC_OPT_FLUSH && !HCC_PROFILE && (cf==nullptr) && !HCC_FORCE_COMPLETION_FUTURE && !HCC_SERIALIZE_KERNEL) {
-        // Only allocate a signal if the caller requested a completion_future to track status.
-        needsSignal = false;
-    };
-
-    dispatch->dispatchKernelAsync(args, argSize, needsSignal);
-
+    // We used to skip signal creation as part of HCC_OPT_FLUSH being true.
+    // However, the new asyncOps resource cleanup logic requires all async ops to have a signal.
+    dispatch->dispatchKernelAsync(args, argSize, true);
 
     if (cf) {
         *cf = hc::completion_future(sp_dispatch);

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -80,7 +80,7 @@
 #define MAX_INFLIGHT_COMMANDS_PER_QUEUE  (2*8192)
 
 // threshold to clean up finished kernel in HSAQueue.asyncOps
-#define ASYNCOPS_VECTOR_GC_SIZE (2*8192)
+int HCC_ASYNCOPS_SIZE = (2*8192);
 
 
 //---
@@ -3698,6 +3698,8 @@ void HSAContext::ReadHccEnv()
 
     GET_ENV_INT(HCC_SIGNAL_POOL_SIZE, "Number of pre-allocated HSA signals.  Signals are precious resource so manage carefully");
 
+    GET_ENV_INT(HCC_ASYNCOPS_SIZE, "Number of HSA operations to allow prior to resource cleanup.");
+
     GET_ENV_INT(HCC_UNPINNED_COPY_MODE, "Select algorithm for unpinned copies. 0=ChooseBest(see thresholds), 1=PinInPlace, 2=StagingBuffer, 3=Memcpy");
 
     GET_ENV_INT(HCC_CHECK_COPY, "Check dst == src after each copy operation.  Only works on large-bar systems.");
@@ -3949,7 +3951,7 @@ std::ostream& operator<<(std::ostream& os, const HSAQueue & hav)
 HSAQueue::HSAQueue(KalmarDevice* pDev, hsa_agent_t agent, execute_order order, queue_priority priority) :
     KalmarQueue(pDev, queuing_mode_automatic, order, priority),
     rocrQueue(nullptr),
-    asyncOps(ASYNCOPS_VECTOR_GC_SIZE), asyncOpsIndex(0),
+    asyncOps(HCC_ASYNCOPS_SIZE), asyncOpsIndex(0),
     valid(true), _nextSyncNeedsSysRelease(false), _nextKernelNeedsSysAcquire(false), bufferKernelMap(), kernelBufferMap()
 {
     {

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -827,8 +827,10 @@ public:
 
 
     ~HSACopy() {
-        future->wait();
-        STATUS_CHECK(_wait_complete_status, __LINE__);
+        if (future) {
+            future->wait();
+            STATUS_CHECK(_wait_complete_status, __LINE__);
+        }
         dispose();
     }
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1729,8 +1729,8 @@ public:
         auto&& dependentAsyncOpVector = bufferKernelMap[buffer];
         for (int i = 0; i < dependentAsyncOpVector.size(); ++i) {
           auto dependentAsyncOp = dependentAsyncOpVector[i];
-          if (!dependentAsyncOp.expired()) {
-            auto dependentAsyncOpPointer = dependentAsyncOp.lock();
+          auto dependentAsyncOpPointer = dependentAsyncOp.lock();
+          if (dependentAsyncOpPointer) {
             // wait on valid futures only
             std::shared_future<void>* future = dependentAsyncOpPointer->getFuture();
             if (future->valid()) {

--- a/tests/Unit/HC/get_use_count.cpp
+++ b/tests/Unit/HC/get_use_count.cpp
@@ -36,8 +36,10 @@ int main() {
 
   cf.wait();
 
-  // waiting removes the reference from the queue so we just have the one here in CF.
-  assert(cf.get_use_count() == 1);
+  // with the new lazy HCC queue op cleanup logic,
+  // waiting does not remove the reference from the queue,
+  // so we should still have the two references
+  assert(cf.get_use_count() == 2);
 
 
   return 0;


### PR DESCRIPTION
Treat asyncOps vector like a circular buffer.  New ops overwrite oldest ops, implicitly waiting for the old ops to complete and reclaiming resources.