### PR TITLE
Add Function Call Support for HCC by flag

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -40,6 +40,9 @@ KMTHINLTO="${KMTHINLTO:=0}"
 # flag for early finalization
 AMDGPU_OBJ_CODEGEN="0"
 
+# flag for function calls enabled
+AMDGPU_FUNC_CALLS="0"
+
 if [ $KMDBSCRIPT == "1" ]
 then
   set -x
@@ -105,6 +108,10 @@ do
     --early-finalize)
     AMDGPU_OBJ_CODEGEN="1"
     KMTHINLTO="0"
+    continue
+    ;;
+    --amdgpu-func-calls)
+    AMDGPU_FUNC_CALLS="1"
     continue
     ;;
     --hcc-extra-libs=*)
@@ -187,7 +194,8 @@ fi
 # Invoke HCC-specific opt passes
 $OPT -load $LIB/LLVMSelectAcceleratorCode@CMAKE_SHARED_LIBRARY_SUFFIX@ \
   -load $LIB/LLVMPromotePointerKernArgsToGlobal@CMAKE_SHARED_LIBRARY_SUFFIX@ \
-  -select-accelerator-code -promote-pointer-kernargs-to-global \
+  -select-accelerator-code -sac-enable-function-calls=$AMDGPU_FUNC_CALLS \
+  -promote-pointer-kernargs-to-global \
   -dce -globaldce -always-inline -infer-address-spaces \
   < $2.linked.bc -o $2.selected.bc
 
@@ -230,9 +238,11 @@ fi
 CODE_OBJECT_FORMAT="-mattr=-code-object-v3"
 
 if [ $KMTHINLTO == "1" ]; then
-  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2 $2.opt.bc
+  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+    $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2 $2.opt.bc
 else
-  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=obj -o $2.isabin $2.opt.bc
+  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+    $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2.isabin $2.opt.bc
 fi
 
 # error handling for llc
@@ -248,7 +258,8 @@ if [ $KMDUMPISA == "1" ]; then
   else
     cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
   fi
-  $LLC $KMOPTLLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT -filetype=asm -o $2.isa $2.opt.bc
+  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+     $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=asm -o $2.isa $2.opt.bc
   mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
 fi
 

--- a/lib/clamp-link.in
+++ b/lib/clamp-link.in
@@ -25,6 +25,9 @@ fi
 # enable bundle dumping
 KMDUMPBUNDLE="${KMDUMPBUNDLE:=0}"
 
+# flag for function calls enabled
+AMDGPU_FUNC_CALLS="0"
+
 BINDIR=$(dirname $0)
 LINK=$BINDIR/llvm-link
 LTO=$BINDIR/llvm-lto
@@ -163,7 +166,11 @@ _thinlto_path() {
     i=0
     for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}
     do
-      { $CLAMP_DEVICE $KERNEL.thinlto.imported.bc $KERNEL-$AMDGPU_TARGET.isabin --amdgpu-target=$AMDGPU_TARGET; } &
+      if [ $AMDGPU_FUNC_CALLS == "1" ]; then
+        { $CLAMP_DEVICE $KERNEL.thinlto.imported.bc $KERNEL-$AMDGPU_TARGET.isabin --amdgpu-target=$AMDGPU_TARGET --amdgpu-func-calls; } &
+      else
+        { $CLAMP_DEVICE $KERNEL.thinlto.imported.bc $KERNEL-$AMDGPU_TARGET.isabin --amdgpu-target=$AMDGPU_TARGET; } &
+      fi
       # error handling
       pids=("${pids[@]}" "$!")
 
@@ -231,8 +238,11 @@ _default_path() {
   declare -a pids
   # for each GPU target, lower to GCN ISA in HSACO format
   for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}; do
-    { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET; } &
-
+    if [ $AMDGPU_FUNC_CALLS == "1" ]; then
+      { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET --amdgpu-func-calls; } &
+    else
+      { $CLAMP_DEVICE $TEMP_DIR/kernel.bc $TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco --amdgpu-target=$AMDGPU_TARGET; } &
+    fi
     # error handling
     pids+=("${pids[@]}" "$!")
 
@@ -299,6 +309,10 @@ do
     ######################
     --amdgpu-target=*)
     AMDGPU_TARGET_ARRAY+=("${ARG#*=}")
+    continue
+    ;;
+    --amdgpu-func-calls)
+    AMDGPU_FUNC_CALLS="1"
     continue
     ;;
     ################################################

--- a/tests/Unit/FunctionCall/fcs_saxpy.cpp
+++ b/tests/Unit/FunctionCall/fcs_saxpy.cpp
@@ -1,0 +1,58 @@
+// RUN: %hc -hc -amdgpu-function-calls %s -o %t.out && %t.out
+
+#include <random>
+#include <algorithm>
+#include <iostream>
+#include <cmath>
+#include <hc.hpp>
+
+#define N (1024 * 500)
+
+__attribute__((noinline))
+float mul_by_100(float input) [[hc]] {
+  float a = 100.0f;
+  return a * input;
+}
+
+int main() {
+  using namespace hc;
+
+  const float a = 100.0f;
+  float x[N];
+  float y[N];
+
+  // initialize the input data
+  std::default_random_engine random_gen;
+  std::uniform_real_distribution<float> distribution(-N, N);
+  std::generate_n(x, N, [&]() { return distribution(random_gen); });
+  std::generate_n(y, N, [&]() { return distribution(random_gen); });
+
+  float y_gpu[N];
+  std::copy_n(y, N, y_gpu);
+
+  // CPU implementation of saxpy
+  for (int i = 0; i < N; i++) {
+    y[i] = a * x[i] + y[i];
+  }
+
+  hc::array_view<float, 1> av_x(N, x);
+  hc::array_view<float, 1> av_y(N, y_gpu);
+
+  // launch a GPU kernel to compute the saxpy in parallel
+  hc::parallel_for_each(hc::extent<1>(N), [=](hc::index<1> i) [[hc]] {
+    av_y[i] = mul_by_100(av_x[i]) + av_y[i];
+  });
+
+  // verify the results
+  int errors = 0;
+  for (int i = 0; i < N; i++) {
+    if (fabs(y[i] - av_y[i]) > fabs(y[i] * 0.0001f)) {
+      std::cout << "GPU: " << av_y[i] << " CPU: " << y[i] << std::endl;
+      errors++;
+    }
+  }
+  std::cout << errors << " errors" << std::endl;
+
+  return errors;
+}
+


### PR DESCRIPTION
Pass into hcc command arg -amdgpu-function-calls to enable function call support. This flag will be consumed by clang, and passed into linker. Linker will handle function call support, and pass correctly into LLC and SAC pass. This Flag will allow the user to toggle on/off FCS.


We need to first merge these PRs to clang and llvm.
https://github.com/RadeonOpenCompute/hcc-clang-upgrade/pull/168
https://github.com/RadeonOpenCompute/llvm/pull/159