### PR TITLE
fix potential deadlock triggered by a cleanup of the asyncops

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1604,8 +1604,7 @@ public:
         {
           // lock the queue and find the first valid op
           std::lock_guard<std::recursive_mutex> lg(qmutex);
-
-          for (int i = asyncOps.size()-1; i>=0; i--) {
+          for (int i = 0; i < asyncOps.size(); i++) {
             if (asyncOps[i] != nullptr) {
               // wait on valid futures only
               std::shared_future<void>* future = asyncOps[i]->getFuture();
@@ -1617,13 +1616,7 @@ public:
                 break;
               }
             }
-            else {
-              // found an nullptr in the asyncOps vector
-              // older ops should 
-              break;
-            }
           }
-
           // not more valid op in the asyncOps vector,
           // shrink the asyncOps vector and leave
           if (!found) {
@@ -1631,7 +1624,6 @@ public:
             return;
           }
         }
-
         // wait for the op to complete
         std::shared_future<void>* future = r->getFuture();
         if (future && future->valid()) {

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1605,24 +1605,27 @@ public:
           // lock the queue and find the first valid op
           std::lock_guard<std::recursive_mutex> lg(qmutex);
 
-          for (int i = asyncOps.size()-1; i>=0; i--) {
-            if (asyncOps[i] != nullptr) {
-              // wait on valid futures only
-              std::shared_future<void>* future = asyncOps[i]->getFuture();
-              if (future && future->valid()) {
-                // move the op from the vector into a temp
-                // so that we can wait outside lock
-                r = std::move(asyncOps[i]);
-                found = true;
-                break;
-              }
-            }
-            else {
-              // found an nullptr in the asyncOps vector
-              // older ops should 
+          auto s = asyncOps.size();
+          if (s == 0) return;  // nothing to do here
+
+          unsigned int i = s - 1;
+          do {
+            // if we find an op that has been completed
+            // then older ops must have been completed as
+            // well, so stop looking further
+            if (asyncOps[i] == nullptr)
+              break;  
+            
+            // wait on valid futures only
+            std::shared_future<void>* future = asyncOps[i]->getFuture();
+            if (future && future->valid()) {
+              // move the op from the vector into a temp
+              // so that we can wait outside lock
+              r = std::move(asyncOps[i]);
+              found = true;
               break;
             }
-          }
+          } while (i--!=0); // quit once i==0
 
           // not more valid op in the asyncOps vector,
           // shrink the asyncOps vector and leave
@@ -1630,7 +1633,7 @@ public:
             asyncOps.clear();
             return;
           }
-        }
+        }  // end of lock_guard scope
 
         // wait for the op to complete
         std::shared_future<void>* future = r->getFuture();

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1604,7 +1604,8 @@ public:
         {
           // lock the queue and find the first valid op
           std::lock_guard<std::recursive_mutex> lg(qmutex);
-          for (int i = 0; i < asyncOps.size(); i++) {
+
+          for (int i = asyncOps.size()-1; i>=0; i--) {
             if (asyncOps[i] != nullptr) {
               // wait on valid futures only
               std::shared_future<void>* future = asyncOps[i]->getFuture();
@@ -1616,7 +1617,13 @@ public:
                 break;
               }
             }
+            else {
+              // found an nullptr in the asyncOps vector
+              // older ops should 
+              break;
+            }
           }
+
           // not more valid op in the asyncOps vector,
           // shrink the asyncOps vector and leave
           if (!found) {
@@ -1624,6 +1631,7 @@ public:
             return;
           }
         }
+
         // wait for the op to complete
         std::shared_future<void>* future = r->getFuture();
         if (future && future->valid()) {


### PR DESCRIPTION
This fixes a deadlock introduced by https://github.com/RadeonOpenCompute/hcc/pull/1013 .  The important thing is avoid locking a queue while waiting on the completion of an event.
https://github.com/RadeonOpenCompute/hcc/pull/1046 will be the next step will providing improvements on how the asyncops vector is being used and managed.