### PR TITLE
update tests to fully qualify names in hc::    

### DIFF
--- a/tests/Unit/AMDGPU/activelanecount.cpp
+++ b/tests/Unit/AMDGPU/activelanecount.cpp
@@ -66,7 +66,7 @@ bool test() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __activelanecount_u32_b1(test_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/activelaneid.cpp
+++ b/tests/Unit/AMDGPU/activelaneid.cpp
@@ -64,7 +64,7 @@ bool test() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     if (test_GPU[idx] == 1)
       output_GPU(idx) = __activelaneid_u32();
     else

--- a/tests/Unit/AMDGPU/activelanemask.cpp
+++ b/tests/Unit/AMDGPU/activelanemask.cpp
@@ -67,7 +67,7 @@ bool test() {
   array<uint64_t, 1> output_GPU(GRID_SIZE);
   array<uint32_t, 1> output_GPU2(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __activelanemask_v4_b64_b1(test_GPU(idx));
     output_GPU2(idx) = __popcount_u32_b64(output_GPU(idx));
   }).wait();

--- a/tests/Unit/AMDGPU/bitextract.cpp
+++ b/tests/Unit/AMDGPU/bitextract.cpp
@@ -64,7 +64,7 @@ bool test_bitextract_u32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitextract_u32(test0_GPU(idx), test1_GPU(idx), test2_GPU(idx));
   }).wait();
 
@@ -108,7 +108,7 @@ bool test_bitextract_u64() {
 
   array<uint64_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitextract_u64(test0_GPU(idx), test1_GPU(idx), test2_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/bitinsert.cpp
+++ b/tests/Unit/AMDGPU/bitinsert.cpp
@@ -62,7 +62,7 @@ bool test_bitinsert_u32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitinsert_u32(test0_GPU(idx), test1_GPU(idx),
                                       test2_GPU(idx), test3_GPU(idx));
   }).wait();
@@ -112,7 +112,7 @@ bool test_bitinsert_u64() {
 
   array<uint64_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitinsert_u64(test0_GPU(idx), test1_GPU(idx),
                                       test2_GPU(idx), test3_GPU(idx));
   }).wait();

--- a/tests/Unit/AMDGPU/bitselect.cpp
+++ b/tests/Unit/AMDGPU/bitselect.cpp
@@ -51,7 +51,7 @@ bool test_bitselect_b32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitselect_b32(test0_GPU(idx), test1_GPU(idx), test2_GPU(idx));
   }).wait();
 
@@ -94,7 +94,7 @@ bool test_bitselect_b64() {
 
   array<uint64_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __bitselect_b64(test0_GPU(idx), test1_GPU(idx), test2_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/clock.cpp
+++ b/tests/Unit/AMDGPU/clock.cpp
@@ -16,7 +16,7 @@ int main() {
   extent<1> ex(GRID_SIZE);
 
   // launch a kernel, log current timestamp
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __clock_u64();
   }).wait();
 
@@ -25,7 +25,7 @@ int main() {
 
   // launch a kernel again, log current timestamp
   array<uint64_t, 1> table2(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table2(idx) = __clock_u64();
   }).wait();
 

--- a/tests/Unit/AMDGPU/clock2.cpp
+++ b/tests/Unit/AMDGPU/clock2.cpp
@@ -17,7 +17,7 @@ int main() {
   extent<1> ex(GRID_SIZE);
 
   // launch a kernel, log current timestamp
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __clock_u64();
     table2(idx) = __clock_u64();
   }).wait();

--- a/tests/Unit/AMDGPU/firstbit.cpp
+++ b/tests/Unit/AMDGPU/firstbit.cpp
@@ -158,7 +158,7 @@ bool test_gpu_u32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __firstbit_u32_u32(test_GPU(idx));
   }).wait();
 
@@ -190,7 +190,7 @@ bool test_gpu_u64() {
   copy(test.begin(), test_GPU);
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __firstbit_u32_u64(test_GPU(idx));
   }).wait();
 
@@ -223,7 +223,7 @@ bool test_gpu_s32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __firstbit_u32_s32(test_GPU(idx));
   }).wait();
 
@@ -255,7 +255,7 @@ bool test_gpu_s64() {
   copy(test.begin(), test_GPU);
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __firstbit_u32_s64(test_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/laneid.cpp
+++ b/tests/Unit/AMDGPU/laneid.cpp
@@ -23,7 +23,7 @@ bool test() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __lane_id();
   }).wait();
 

--- a/tests/Unit/AMDGPU/popcount.cpp
+++ b/tests/Unit/AMDGPU/popcount.cpp
@@ -43,7 +43,7 @@ bool test32() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __popcount_u32_b32(test_GPU(idx));
   }).wait();
 
@@ -75,7 +75,7 @@ bool test64() {
   copy(test.begin(), test_GPU);
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __popcount_u32_b64(test_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/register-control.cpp
+++ b/tests/Unit/AMDGPU/register-control.cpp
@@ -14,7 +14,7 @@ int main() {
   // CHECK-LABEL: define weak_odr amdgpu_kernel void @"_ZZ4mainEN3$_019__cxxamp_trampolineEPjii"
   // CHECK-SAME:({{[^)]*}}){{[^#]*}}#[[ATTR0:[0-9]+]]
   // CHECK: attributes #[[ATTR0]] = {{{.*}}"amdgpu-flat-work-group-size"="1,10" "amdgpu-max-work-group-dim"="10,1,1" "amdgpu-waves-per-eu"="5,6"
-  auto k = [&](index<1>& idx) [[hc]]
+  auto k = [&](hc::index<1>& idx) [[hc]]
                               [[hc_waves_per_eu(5,6)]]
                               [[hc_flat_workgroup_size(1,10)]]
                               [[hc_max_workgroup_dim(10,1,1)]]{

--- a/tests/Unit/AMDGPU/shfl.cpp
+++ b/tests/Unit/AMDGPU/shfl.cpp
@@ -24,7 +24,7 @@ bool test__shfl(int grid_size, T arg) {
   array<T, 1> table(grid_size);
 
   // broadcast of a single value across a wavefront
-  parallel_for_each(ex, [&, arg](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, arg](hc::index<1>& idx) [[hc]] {
     T value = T();
     if (__lane_id() == 0)
       value = arg;
@@ -56,7 +56,7 @@ bool test__shfl2(int grid_size, int sub_wavefront_width, T arg) {
   array<T, 1> table(grid_size);
 
   // broadcast of a single value across a sub-wavefront
-  parallel_for_each(ex, [&, arg, sub_wavefront_width](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, arg, sub_wavefront_width](hc::index<1>& idx) [[hc]] {
     T value = T();
     unsigned int laneId = __lane_id();
     // each subsection of a wavefront would have a different test value

--- a/tests/Unit/AMDGPU/shfl_down.cpp
+++ b/tests/Unit/AMDGPU/shfl_down.cpp
@@ -24,7 +24,7 @@ bool test__shfl_down(int grid_size, int offset, T init_value) {
   array<T, 1> table(grid_size);
 
   // shift values down in a wavefront
-  parallel_for_each(ex, [&, offset, init_value](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, offset, init_value](hc::index<1>& idx) [[hc]] {
     T value = init_value + __lane_id();
     value = __shfl_down(value, offset);
     table(idx) = value;
@@ -57,7 +57,7 @@ bool test__shfl_down2(int grid_size, int sub_wavefront_width, int offset, T init
   array<T, 1> table(grid_size);
 
   // shift values down in a wavefront, divided into subsections
-  parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](hc::index<1>& idx) [[hc]] {
     T value = init_value + (__lane_id() % sub_wavefront_width);
     value = __shfl_down(value, offset, sub_wavefront_width);
     table(idx) = value;

--- a/tests/Unit/AMDGPU/shfl_scan.cpp
+++ b/tests/Unit/AMDGPU/shfl_scan.cpp
@@ -21,7 +21,7 @@ bool test_scan(int grid_size, int sub_wavefront_width) {
   extent<1> ex(grid_size);
   array<int, 1> table(grid_size);
 
-  parallel_for_each(ex, [&, sub_wavefront_width](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, sub_wavefront_width](hc::index<1>& idx) [[hc]] {
     int laneId = __lane_id();
     int logicalLaneId = laneId % sub_wavefront_width;
     int value = (WAVEFRONT_SIZE - 1) - laneId;

--- a/tests/Unit/AMDGPU/shfl_up.cpp
+++ b/tests/Unit/AMDGPU/shfl_up.cpp
@@ -24,7 +24,7 @@ bool test__shfl_up(int grid_size, int offset, T init_value) {
   array<T, 1> table(grid_size);
 
   // shift values up in a wavefront
-  parallel_for_each(ex, [&, offset, init_value](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, offset, init_value](hc::index<1>& idx) [[hc]] {
     T value = init_value + __lane_id();
     value = __shfl_up(value, offset);
     table(idx) = value;
@@ -55,7 +55,7 @@ bool test__shfl_up2(int grid_size, int sub_wavefront_width, int offset, T init_v
   array<T, 1> table(grid_size);
 
   // shift values up in a wavefront, divided into subsections
-  parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&, offset, sub_wavefront_width, init_value](hc::index<1>& idx) [[hc]] {
     T value = init_value + (__lane_id() % sub_wavefront_width);
     value = __shfl_up(value, offset, sub_wavefront_width);
     table(idx) = value;

--- a/tests/Unit/AMDGPU/shfl_xor.cpp
+++ b/tests/Unit/AMDGPU/shfl_xor.cpp
@@ -21,7 +21,7 @@ bool test_reduce(int grid_size) {
   extent<1> ex(grid_size);
   array<int, 1> table(grid_size);
 
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     int laneId = __lane_id();
     int value = (WAVEFRONT_SIZE - 1) - laneId;
 

--- a/tests/Unit/AMDGPU/vote_any_all.cpp
+++ b/tests/Unit/AMDGPU/vote_any_all.cpp
@@ -67,7 +67,7 @@ bool test__any() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __any(test_GPU(idx));
   }).wait();
 
@@ -142,7 +142,7 @@ bool test__all() {
 
   array<uint32_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __all(test_GPU(idx));
   });
 

--- a/tests/Unit/AMDGPU/vote_ballot.cpp
+++ b/tests/Unit/AMDGPU/vote_ballot.cpp
@@ -66,7 +66,7 @@ bool test() {
 
   array<uint64_t, 1> output_GPU(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     output_GPU(idx) = __ballot(test_GPU(idx));
   }).wait();
 

--- a/tests/Unit/AMDGPU/wavesize.cpp
+++ b/tests/Unit/AMDGPU/wavesize.cpp
@@ -14,7 +14,7 @@ int main() {
   using namespace hc;
   array<unsigned int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __wavesize();
   }).wait();
 

--- a/tests/Unit/AmpMath/amp_math_acos.cpp
+++ b/tests/Unit/AmpMath/amp_math_acos.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::acos(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_acos_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_acos_precise_math.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::acos(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_acosf.cpp
+++ b/tests/Unit/AmpMath/amp_math_acosf.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::acosf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_acosh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_acosh_precise_math.cpp
@@ -28,13 +28,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::acosh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_asin.cpp
+++ b/tests/Unit/AmpMath/amp_math_asin.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::asin(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_asin_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_asin_precise_math.cpp
@@ -30,12 +30,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::asin(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_asinf.cpp
+++ b/tests/Unit/AmpMath/amp_math_asinf.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::asinf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_asinh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_asinh_precise_math.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::asinh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan.cpp
@@ -28,14 +28,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::atan(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan2.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan2.cpp
@@ -33,14 +33,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::atan2(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan2_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan2_precise_math.cpp
@@ -33,14 +33,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::atan2(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan2f.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan2f.cpp
@@ -33,14 +33,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::atan2f(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan2f_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan2f_precise_math.cpp
@@ -33,14 +33,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::atan2f(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atan_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_atan_precise_math.cpp
@@ -28,14 +28,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::atan(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atanf.cpp
+++ b/tests/Unit/AmpMath/amp_math_atanf.cpp
@@ -28,14 +28,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::atanf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_atanh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_atanh_precise_math.cpp
@@ -28,13 +28,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::atanh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cbrt_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cbrt_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cbrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cbrtf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cbrtf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cbrtf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ceil.cpp
+++ b/tests/Unit/AmpMath/amp_math_ceil.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::ceil(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ceil_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_ceil_precise_math.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::ceil(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ceilf.cpp
+++ b/tests/Unit/AmpMath/amp_math_ceilf.cpp
@@ -28,12 +28,12 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::ceilf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_copysign_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_copysign_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::copysign(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_copysignf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_copysignf_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::copysignf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cos.cpp
+++ b/tests/Unit/AmpMath/amp_math_cos.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::cos(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cos_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cos_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cos(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cosf.cpp
+++ b/tests/Unit/AmpMath/amp_math_cosf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::cosf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cosh.cpp
+++ b/tests/Unit/AmpMath/amp_math_cosh.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::cosh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cosh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cosh_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cosh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_coshf.cpp
+++ b/tests/Unit/AmpMath/amp_math_coshf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::coshf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_coshf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_coshf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::coshf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cospi_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cospi_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cospi(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_cospif_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_cospif_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::cospi(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_erf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::erf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_erfc_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erfc_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::erfc(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_erfcf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erfcf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::erfcf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_erff_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_erff_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::erff(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::exp(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp10.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp10.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::exp10(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp10_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp10_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::exp10(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp10f.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp10f.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::exp10f(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp2.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp2.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::exp2(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp2_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp2_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::exp2(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp2f.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp2f.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::exp2f(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_exp_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_exp_precise_math.cpp
@@ -35,13 +35,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::exp(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_expf.cpp
+++ b/tests/Unit/AmpMath/amp_math_expf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::expf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_expf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_expf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::expf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_expm1.cpp
+++ b/tests/Unit/AmpMath/amp_math_expm1.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::expm1(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_expm1_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_expm1_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::expm1(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_expm1f.cpp
+++ b/tests/Unit/AmpMath/amp_math_expm1f.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::expm1f(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fdim_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fdim_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::fdim(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_floor.cpp
+++ b/tests/Unit/AmpMath/amp_math_floor.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::floor(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_floor_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_floor_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::floor(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_floorf.cpp
+++ b/tests/Unit/AmpMath/amp_math_floorf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::floorf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fma_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fma_precise_math.cpp
@@ -33,7 +33,7 @@ bool test() {
   array_view<_Tp> gd(d);
   array_view<_Tp> ge(e);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
     gc[i] = dis(gen);
@@ -41,7 +41,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
           gd[idx] = precise_math::fma(ga[idx], gb[idx], gc[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmaf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmaf_precise_math.cpp
@@ -33,7 +33,7 @@ bool test() {
   array_view<_Tp> gd(d);
   array_view<_Tp> ge(e);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
     gc[i] = dis(gen);
@@ -41,7 +41,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
           gd[idx] = precise_math::fmaf(ga[idx], gb[idx], gc[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmax.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmax.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fmax(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmax_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmax_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::fmax(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmaxf.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmaxf.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fmaxf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmin.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmin.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fmin(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmin_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmin_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::fmin(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fminf.cpp
+++ b/tests/Unit/AmpMath/amp_math_fminf.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fminf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmod.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmod.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fmod(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmod_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmod_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::fmod(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_fmodf.cpp
+++ b/tests/Unit/AmpMath/amp_math_fmodf.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::fmodf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_hypot_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_hypot_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::hypot(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ilogb.cpp
+++ b/tests/Unit/AmpMath/amp_math_ilogb.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::ilogb(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ilogb_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_ilogb_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::ilogb(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ilogbf.cpp
+++ b/tests/Unit/AmpMath/amp_math_ilogbf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::ilogbf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isfinite.cpp
+++ b/tests/Unit/AmpMath/amp_math_isfinite.cpp
@@ -20,7 +20,7 @@ int main(void) {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = fast_math::isfinite(6.5f/in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isfinite_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_isfinite_precise_math.cpp
@@ -25,7 +25,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::isfinite(6.5/in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isinf.cpp
+++ b/tests/Unit/AmpMath/amp_math_isinf.cpp
@@ -21,7 +21,7 @@ int main(void) {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = fast_math::isinf(6.5f/in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isinf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_isinf_precise_math.cpp
@@ -23,7 +23,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::isinf(6.5/in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isnan.cpp
+++ b/tests/Unit/AmpMath/amp_math_isnan.cpp
@@ -24,7 +24,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = fast_math::isnan(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isnan_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_isnan_precise_math.cpp
@@ -24,7 +24,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::isnan(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isnormal.cpp
+++ b/tests/Unit/AmpMath/amp_math_isnormal.cpp
@@ -20,7 +20,7 @@ int main(void) {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::isnormal(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_isnormal_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_isnormal_precise_math.cpp
@@ -25,7 +25,7 @@ bool test() {
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::isnormal(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ldexp.cpp
+++ b/tests/Unit/AmpMath/amp_math_ldexp.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = fast_math::ldexp(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ldexp_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_ldexp_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = precise_math::ldexp(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ldexpf.cpp
+++ b/tests/Unit/AmpMath/amp_math_ldexpf.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = fast_math::ldexpf(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_ldexpf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_ldexpf_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = precise_math::ldexpf(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log.cpp
+++ b/tests/Unit/AmpMath/amp_math_log.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::log(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log10.cpp
+++ b/tests/Unit/AmpMath/amp_math_log10.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::log10(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log10_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_log10_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::log10(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log10f.cpp
+++ b/tests/Unit/AmpMath/amp_math_log10f.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::log10f(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log1p_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_log1p_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::log1p(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log1pf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_log1pf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::log1pf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log2.cpp
+++ b/tests/Unit/AmpMath/amp_math_log2.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::log2(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log2_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_log2_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::log2(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log2f.cpp
+++ b/tests/Unit/AmpMath/amp_math_log2f.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::log2f(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_log_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_log_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::log(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_logb_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_logb_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::logb(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_logbf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_logbf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::logbf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_max.cpp
+++ b/tests/Unit/AmpMath/amp_math_max.cpp
@@ -35,14 +35,14 @@
     array_view<_Tp> gc(c);
     array_view<_Tp> gd(d);
 
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       ga[i] = dis(gen);
       gb[i] = dis(gen);
     }
 
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = fast_math::max(ga[idx], gb[idx]);
     });
 

--- a/tests/Unit/AmpMath/amp_math_max_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_max_precise_math.cpp
@@ -35,14 +35,14 @@
     array_view<_Tp> gc(c);
     array_view<_Tp> gd(d);
 
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       ga[i] = dis(gen);
       gb[i] = dis(gen);
     }
 
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = precise_math::max(ga[idx], gb[idx]);
     });
 

--- a/tests/Unit/AmpMath/amp_math_min.cpp
+++ b/tests/Unit/AmpMath/amp_math_min.cpp
@@ -35,14 +35,14 @@
     array_view<_Tp> gc(c);
     array_view<_Tp> gd(d);
 
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       ga[i] = dis(gen);
       gb[i] = dis(gen);
     }
 
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = fast_math::min(ga[idx], gb[idx]);
     });
 

--- a/tests/Unit/AmpMath/amp_math_min_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_min_precise_math.cpp
@@ -35,14 +35,14 @@
     array_view<_Tp> gc(c);
     array_view<_Tp> gd(d);
 
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       ga[i] = dis(gen);
       gb[i] = dis(gen);
     }
 
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = precise_math::min(ga[idx], gb[idx]);
     });
 

--- a/tests/Unit/AmpMath/amp_math_nearbyint_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_nearbyint_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::nearbyint(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_nextafter_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_nextafter_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::nextafter(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_pow.cpp
+++ b/tests/Unit/AmpMath/amp_math_pow.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::pow(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_pow_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_pow_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::pow(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_powf.cpp
+++ b/tests/Unit/AmpMath/amp_math_powf.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::powf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_rcbrt_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_rcbrt_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::rcbrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_rcbrtf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_rcbrtf_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::rcbrtf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_remainder_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_remainder_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::remainder(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_remainderf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_remainderf_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gc(c);
   array_view<_Tp> gd(d);
 
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gb[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::remainderf(ga[idx], gb[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_round.cpp
+++ b/tests/Unit/AmpMath/amp_math_round.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::round(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_round_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_round_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::round(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_roundf.cpp
+++ b/tests/Unit/AmpMath/amp_math_roundf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::roundf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_rsqrt.cpp
+++ b/tests/Unit/AmpMath/amp_math_rsqrt.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::rsqrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_rsqrt_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_rsqrt_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::rsqrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_rsqrtf.cpp
+++ b/tests/Unit/AmpMath/amp_math_rsqrtf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::rsqrtf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_scalb_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_scalb_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<_Tp> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = static_cast<_Tp>(dis_int(gen));
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = precise_math::scalb(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_scalbn_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_scalbn_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = precise_math::scalbn(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_scalbnf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_scalbnf_precise_math.cpp
@@ -32,14 +32,14 @@ bool test() {
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
   array_view<int> gexp(exp);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
     gexp[i] = dis_int(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gb[idx] = precise_math::scalbnf(ga[idx], gexp[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_signbit.cpp
+++ b/tests/Unit/AmpMath/amp_math_signbit.cpp
@@ -21,7 +21,7 @@ int main(void) {
   
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = fast_math::signbit(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_signbit_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_signbit_precise_math.cpp
@@ -24,7 +24,7 @@ bool test() {
   
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = precise_math::signbit(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_signbitf.cpp
+++ b/tests/Unit/AmpMath/amp_math_signbitf.cpp
@@ -24,7 +24,7 @@ bool test() {
   
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     out[idx] = fast_math::signbit(in[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sin.cpp
+++ b/tests/Unit/AmpMath/amp_math_sin.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::sin(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sin_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_sin_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::sin(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sinf.cpp
+++ b/tests/Unit/AmpMath/amp_math_sinf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::sinf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sinh.cpp
+++ b/tests/Unit/AmpMath/amp_math_sinh.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::sinh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sinh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_sinh_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::sinh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sinpi_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_sinpi_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::sinpi(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sinpif_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_sinpif_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::sinpif(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sqrt.cpp
+++ b/tests/Unit/AmpMath/amp_math_sqrt.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::sqrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sqrt_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_sqrt_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::sqrt(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_sqrtf.cpp
+++ b/tests/Unit/AmpMath/amp_math_sqrtf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::sqrtf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tan.cpp
+++ b/tests/Unit/AmpMath/amp_math_tan.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
    parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::tan(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tan_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_tan_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
    parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::tan(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tanf.cpp
+++ b/tests/Unit/AmpMath/amp_math_tanf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
    parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::tanf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tanh.cpp
+++ b/tests/Unit/AmpMath/amp_math_tanh.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = fast_math::tanh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tanh_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_tanh_precise_math.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::tanh(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tanpi_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_tanpi_precise_math.cpp
@@ -28,13 +28,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::tanpi(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tgamma_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_tgamma_precise_math.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::tgamma(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_tgammaf_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_tgammaf_precise_math.cpp
@@ -29,14 +29,14 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::tgammaf(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_trunc.cpp
+++ b/tests/Unit/AmpMath/amp_math_trunc.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::trunc(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_trunc_precise_math.cpp
+++ b/tests/Unit/AmpMath/amp_math_trunc_precise_math.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::trunc(ga[idx]);
   });
 

--- a/tests/Unit/AmpMath/amp_math_truncf.cpp
+++ b/tests/Unit/AmpMath/amp_math_truncf.cpp
@@ -29,13 +29,13 @@ bool test() {
   array_view<_Tp> ga(a);
   array_view<_Tp> gb(b);
   array_view<_Tp> gc(c);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = precise_math::truncf(ga[idx]);
   });
 

--- a/tests/Unit/AmpShortVectors/amp_short_vectors_norm.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_norm.cpp
@@ -250,7 +250,7 @@ int main(void) {
     array_view<norm> gb(b);
     array_view<norm> gc(c);
     array_view<norm> gd(d);
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       norm tmp1(rand() / 1000.0f);
       ga[i] = tmp1;
       norm tmp2(rand() / 1000.0f);
@@ -258,7 +258,7 @@ int main(void) {
     }
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = -ga[idx];
       gc[idx] += (ga[idx] + gb[idx]);
       gc[idx] -= (ga[idx] - gb[idx]);

--- a/tests/Unit/AmpShortVectors/amp_short_vectors_unorm.cpp
+++ b/tests/Unit/AmpShortVectors/amp_short_vectors_unorm.cpp
@@ -242,7 +242,7 @@ int main(void) {
     array_view<unorm> gb(b);
     array_view<unorm> gc(c);
     array_view<unorm> gd(d);
-    for (index<1> i(0); i[0] < vecSize; i++) {
+    for (hc::index<1> i(0); i[0] < vecSize; i++) {
       unorm tmp1(rand() / 1000.0f);
       ga[i] = tmp1;
       unorm tmp2(rand() / 1000.0f);
@@ -251,7 +251,7 @@ int main(void) {
 
     parallel_for_each(
       e,
-      [=](index<1> idx) [[hc]] {
+      [=](hc::index<1> idx) [[hc]] {
       gc[idx] = ga[idx];
       gc[idx] += (ga[idx] + gb[idx]);
       gc[idx] -= (ga[idx] - gb[idx]);

--- a/tests/Unit/AmpShortVectors/hc_short_vector_device.cpp
+++ b/tests/Unit/AmpShortVectors/hc_short_vector_device.cpp
@@ -11,7 +11,7 @@ template<typename T>
 bool test_norm() {
     extent<1> ex(GRID_SIZE);
     array_view<int, 1> av(GRID_SIZE);
-    parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+    parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
         T val;
         av[idx] = (int)val;
     }).wait();
@@ -24,7 +24,7 @@ template<typename T>
 bool test() {
     extent<1> ex(GRID_SIZE);
     array_view<int, 1> av(GRID_SIZE);
-    parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+    parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
         T val;
         av[idx] = (int)(val.get_x());
     }).wait();

--- a/tests/Unit/AmpShortVectors/hc_short_vector_device3.cpp
+++ b/tests/Unit/AmpShortVectors/hc_short_vector_device3.cpp
@@ -11,7 +11,7 @@ template<typename T>
 bool test_norm() {
     extent<1> ex(GRID_SIZE);
     array_view<int, 1> av(GRID_SIZE);
-    parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+    parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
         T val;
         av[idx] = (int)val;
     }).wait();
@@ -24,7 +24,7 @@ template<typename T>
 bool test() {
     extent<1> ex(GRID_SIZE);
     array_view<int, 1> av(GRID_SIZE);
-    parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+    parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
         T val;
         av[idx] = (int)(val.get_x());
     }).wait();
@@ -36,10 +36,10 @@ bool test() {
 int main(void) {
     bool ret = true;
 
-    ret &= test<short_vector<double,1>::type>();
-    ret &= test<short_vector<int,2>::type>();
-    ret &= test<short_vector<unsigned int,3>::type>();
-    ret &= test<short_vector<float,4>::type>();
+    ret &= test<hc::short_vector::short_vector<double,1>::type>();
+    ret &= test<hc::short_vector::short_vector<int,2>::type>();
+    ret &= test<hc::short_vector::short_vector<unsigned int,3>::type>();
+    ret &= test<hc::short_vector::short_vector<float,4>::type>();
 
     return !(ret == true);
 }

--- a/tests/Unit/AmpShortVectors/hc_short_vector_template.cpp
+++ b/tests/Unit/AmpShortVectors/hc_short_vector_template.cpp
@@ -8,76 +8,76 @@ using namespace hc::short_vector;
 
 int main(void) {
 
-  static_assert(std::is_same<typename short_vector<unsigned char, 1>::type, uchar_1>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned char, 1>::type, uchar_1>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned char, 2>::type, uchar_2>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned char, 2>::type, uchar_2>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned char, 3>::type, uchar_3>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned char, 3>::type, uchar_3>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned char, 4>::type, uchar_4>::value, 
-                "Mismatched vector types!");
-
-  static_assert(std::is_same<typename short_vector<char, 1>::type, char_1>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<char, 2>::type, char_2>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<char, 3>::type, char_3>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<char, 4>::type, char_4>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned char, 4>::type, uchar_4>::value,
                 "Mismatched vector types!");
 
-  static_assert(std::is_same<typename short_vector<unsigned short, 1>::type, ushort_1>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<char, 1>::type, char_1>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned short, 2>::type, ushort_2>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<char, 2>::type, char_2>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned short, 3>::type, ushort_3>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<char, 3>::type, char_3>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned short, 4>::type, ushort_4>::value, 
-                "Mismatched vector types!");
-
-  static_assert(std::is_same<typename short_vector<short, 1>::type, short_1>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<short, 2>::type, short_2>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<short, 3>::type, short_3>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<short, 4>::type, short_4>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<char, 4>::type, char_4>::value,
                 "Mismatched vector types!");
 
-  static_assert(std::is_same<typename short_vector<unsigned int, 1>::type, uint_1>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned short, 1>::type, ushort_1>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned int, 2>::type, uint_2>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned short, 2>::type, ushort_2>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned int, 3>::type, uint_3>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned short, 3>::type, ushort_3>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<unsigned int, 4>::type, uint_4>::value, 
-                "Mismatched vector types!");
-
-  static_assert(std::is_same<typename short_vector<int, 1>::type, int_1>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<int, 2>::type, int_2>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<int, 3>::type, int_3>::value, 
-                "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<int, 4>::type, int_4>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned short, 4>::type, ushort_4>::value,
                 "Mismatched vector types!");
 
-  static_assert(std::is_same<typename short_vector<float, 1>::type, float_1>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<short, 1>::type, short_1>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<float, 2>::type, float_2>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<short, 2>::type, short_2>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<float, 3>::type, float_3>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<short, 3>::type, short_3>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<float, 4>::type, float_4>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<short, 4>::type, short_4>::value,
                 "Mismatched vector types!");
 
-  static_assert(std::is_same<typename short_vector<double, 1>::type, double_1>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned int, 1>::type, uint_1>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<double, 2>::type, double_2>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned int, 2>::type, uint_2>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<double, 3>::type, double_3>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned int, 3>::type, uint_3>::value,
                 "Mismatched vector types!");
-  static_assert(std::is_same<typename short_vector<double, 4>::type, double_4>::value, 
+  static_assert(std::is_same<typename hc::short_vector::short_vector<unsigned int, 4>::type, uint_4>::value,
+                "Mismatched vector types!");
+
+  static_assert(std::is_same<typename hc::short_vector::short_vector<int, 1>::type, int_1>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<int, 2>::type, int_2>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<int, 3>::type, int_3>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<int, 4>::type, int_4>::value,
+                "Mismatched vector types!");
+
+  static_assert(std::is_same<typename hc::short_vector::short_vector<float, 1>::type, float_1>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<float, 2>::type, float_2>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<float, 3>::type, float_3>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<float, 4>::type, float_4>::value,
+                "Mismatched vector types!");
+
+  static_assert(std::is_same<typename hc::short_vector::short_vector<double, 1>::type, double_1>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<double, 2>::type, double_2>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<double, 3>::type, double_3>::value,
+                "Mismatched vector types!");
+  static_assert(std::is_same<typename hc::short_vector::short_vector<double, 4>::type, double_4>::value,
                 "Mismatched vector types!");
 
   return 0;

--- a/tests/Unit/Atomic/atomic_add_float_global.cpp
+++ b/tests/Unit/Atomic/atomic_add_float_global.cpp
@@ -19,7 +19,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_add(&count[i], INIT);
     }

--- a/tests/Unit/Atomic/atomic_add_float_local.cpp
+++ b/tests/Unit/Atomic/atomic_add_float_local.cpp
@@ -21,8 +21,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_add_global.cpp
+++ b/tests/Unit/Atomic/atomic_add_global.cpp
@@ -12,7 +12,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_add(&count[i], 1);
     }

--- a/tests/Unit/Atomic/atomic_add_local.cpp
+++ b/tests/Unit/Atomic/atomic_add_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static unsigned localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_and_global.cpp
+++ b/tests/Unit/Atomic/atomic_and_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; i++) {
       atomic_fetch_and(&count[i], 1);
     }

--- a/tests/Unit/Atomic/atomic_and_local.cpp
+++ b/tests/Unit/Atomic/atomic_and_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_compare_exchange_global.cpp
+++ b/tests/Unit/Atomic/atomic_compare_exchange_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     // 0 -> 2
     // 1 -> 1
     int v = 0;

--- a/tests/Unit/Atomic/atomic_compare_exchange_local.cpp
+++ b/tests/Unit/Atomic/atomic_compare_exchange_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
     int v = 0;
 
     tile_static int localA[tile_size][tile_size];

--- a/tests/Unit/Atomic/atomic_dec_global.cpp
+++ b/tests/Unit/Atomic/atomic_dec_global.cpp
@@ -12,7 +12,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_dec(&count[i]);
     }

--- a/tests/Unit/Atomic/atomic_dec_local.cpp
+++ b/tests/Unit/Atomic/atomic_dec_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_exchange_float_global.cpp
+++ b/tests/Unit/Atomic/atomic_exchange_float_global.cpp
@@ -19,7 +19,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_exchange(&count(idx), NEW_VALUE);
   });
 

--- a/tests/Unit/Atomic/atomic_exchange_float_local.cpp
+++ b/tests/Unit/Atomic/atomic_exchange_float_local.cpp
@@ -21,8 +21,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_exchange_global.cpp
+++ b/tests/Unit/Atomic/atomic_exchange_global.cpp
@@ -12,7 +12,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_exchange(&count(idx), 1);
   });
 

--- a/tests/Unit/Atomic/atomic_exchange_local.cpp
+++ b/tests/Unit/Atomic/atomic_exchange_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_inc_global.cpp
+++ b/tests/Unit/Atomic/atomic_inc_global.cpp
@@ -12,7 +12,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_inc(&count[i]);
     }

--- a/tests/Unit/Atomic/atomic_inc_local.cpp
+++ b/tests/Unit/Atomic/atomic_inc_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static unsigned localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_max_global.cpp
+++ b/tests/Unit/Atomic/atomic_max_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; i++) {
       atomic_fetch_max(&count[i], vecSize / 2);
     }

--- a/tests/Unit/Atomic/atomic_max_local.cpp
+++ b/tests/Unit/Atomic/atomic_max_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_min_global.cpp
+++ b/tests/Unit/Atomic/atomic_min_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; i++) {
       atomic_fetch_min(&count[i], vecSize / 2);
     }

--- a/tests/Unit/Atomic/atomic_min_local.cpp
+++ b/tests/Unit/Atomic/atomic_min_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_or_global.cpp
+++ b/tests/Unit/Atomic/atomic_or_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; i++) {
       atomic_fetch_or(&count[i], 1);
     }

--- a/tests/Unit/Atomic/atomic_or_local.cpp
+++ b/tests/Unit/Atomic/atomic_or_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_sub_float_global.cpp
+++ b/tests/Unit/Atomic/atomic_sub_float_global.cpp
@@ -19,7 +19,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_sub(&count[i], INIT);
     }

--- a/tests/Unit/Atomic/atomic_sub_float_local.cpp
+++ b/tests/Unit/Atomic/atomic_sub_float_local.cpp
@@ -21,8 +21,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_sub_global.cpp
+++ b/tests/Unit/Atomic/atomic_sub_global.cpp
@@ -12,7 +12,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_sub(&count[i], 1);
     }

--- a/tests/Unit/Atomic/atomic_sub_local.cpp
+++ b/tests/Unit/Atomic/atomic_sub_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/Atomic/atomic_xor_global.cpp
+++ b/tests/Unit/Atomic/atomic_xor_global.cpp
@@ -15,7 +15,7 @@ int main(void) {
   }
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_fetch_xor(&count(idx), 1);
   });
 

--- a/tests/Unit/Atomic/atomic_xor_local.cpp
+++ b/tests/Unit/Atomic/atomic_xor_local.cpp
@@ -19,8 +19,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[cpu, hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/CaptureByCopy/test1.cpp
+++ b/tests/Unit/CaptureByCopy/test1.cpp
@@ -37,7 +37,7 @@ bool test1(const user_functor& functor) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     long t = functor.value(idx[0]);
     terms[idx[0]] = t;
     accumulator->fetch_add(t);
@@ -76,7 +76,7 @@ bool test2(const user_functor& functor) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     terms[idx[0]] = functor.value(idx[0]);
     accumulator->fetch_add(terms[idx[0]]);
   });
@@ -114,7 +114,7 @@ bool test3(const user_functor& functor) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     long t = idx[0] + 1;
     terms[idx[0]] = t;
     accumulator->fetch_add(t);

--- a/tests/Unit/CaptureByCopy/test2.cpp
+++ b/tests/Unit/CaptureByCopy/test2.cpp
@@ -40,7 +40,7 @@ bool test1(const user_functor<_Tp>& functor) {
   *accumulator = _Tp{};
 
   extent<1> ex(N);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     _Tp t = functor.value(idx[0]);
     terms[idx[0]] = t;
     accumulator->fetch_add(t);
@@ -80,7 +80,7 @@ bool test2(const user_functor<_Tp>& functor) {
   *accumulator = _Tp{};
 
   extent<1> ex(N);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     terms[idx[0]] = functor.value(idx[0]);
     accumulator->fetch_add(terms[idx[0]]);
   });
@@ -119,7 +119,7 @@ bool test3(const user_functor<_Tp>& functor) {
   *accumulator = _Tp{};
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     _Tp t = idx[0] + 1;
     terms[idx[0]] = t;
     accumulator->fetch_add(t);

--- a/tests/Unit/CaptureByCopy/test3.cpp
+++ b/tests/Unit/CaptureByCopy/test3.cpp
@@ -41,7 +41,7 @@ bool test1(const user_functor& functor, long val) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     long t = functor.value(idx[0]);
     terms[idx[0]] = t;
     accumulator->fetch_add(t);
@@ -80,7 +80,7 @@ bool test2(const user_functor& functor, long val) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     terms[idx[0]] = functor.value(idx[0]);
     accumulator->fetch_add(terms[idx[0]]);
   });
@@ -118,7 +118,7 @@ bool test3(const user_functor& functor, long val) {
   *accumulator = 0;
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     long t = idx[0] + val;
     terms[idx[0]] = t;
     accumulator->fetch_add(t);

--- a/tests/Unit/CaptureByCopy/test4.cpp
+++ b/tests/Unit/CaptureByCopy/test4.cpp
@@ -44,7 +44,7 @@ bool test1(const user_functor<_Tp>& functor, _Tp val) {
   *accumulator = _Tp{};
 
   extent<1> ex(N);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     _Tp t = functor.value(idx[0]);
     terms[idx[0]] = t;
     accumulator->fetch_add(t);
@@ -84,7 +84,7 @@ bool test2(const user_functor<_Tp>& functor, _Tp val) {
   *accumulator = _Tp{};
 
   extent<1> ex(N);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     terms[idx[0]] = functor.value(idx[0]);
     accumulator->fetch_add(terms[idx[0]]);
   });
@@ -123,7 +123,7 @@ bool test3(const user_functor<_Tp>& functor, _Tp val) {
   *accumulator = _Tp{};
 
   extent<1> ex(SIZE);
-  parallel_for_each(ex, [=] (index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=] (hc::index<1>& idx) [[hc]] {
     _Tp t = idx[0] + val;
     terms[idx[0]] = t;
     accumulator->fetch_add(t);

--- a/tests/Unit/CaptureByRef/test1.cpp
+++ b/tests/Unit/CaptureByRef/test1.cpp
@@ -24,7 +24,7 @@ bool test() {
 
   extent<1> ex(VECTOR_SIZE);
   array_view<int, 1> av(ex, table);
-  parallel_for_each(av.get_extent(), [&, av](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [&, av](hc::index<1> idx) [[hc]] {
     // capture scalar type by reference
     av[idx] *= (val * val);
   });

--- a/tests/Unit/CaptureByRef/test10.cpp
+++ b/tests/Unit/CaptureByRef/test10.cpp
@@ -32,7 +32,7 @@ bool test() {
 
   extent<1> ex(VECTOR_SIZE);
   array_view<int, 1> av(ex, table);
-  parallel_for_each(av.get_extent(), [&, av](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [&, av](hc::index<1> idx) [[hc]] {
     // capture POD type by reference
     av[idx] *= (p.foo + p.bar);
   });

--- a/tests/Unit/CaptureByRef/test11.cpp
+++ b/tests/Unit/CaptureByRef/test11.cpp
@@ -57,7 +57,7 @@ bool test() {
 
   extent<1> ex(VECTOR_SIZE);
   array_view<int, 1> av(ex, table);
-  parallel_for_each(av.get_extent(), [&, av](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [&, av](hc::index<1> idx) [[hc]] {
     // capture multitple POD types by reference
     av[idx] *= ((p.foo + p.bar) + (p2.foo + p2.bar + p2.baz) + (p3.foo + p3.bar + p3.baz + p3.qux));
   });

--- a/tests/Unit/CaptureByRef/test12.cpp
+++ b/tests/Unit/CaptureByRef/test12.cpp
@@ -31,7 +31,7 @@ bool test() {
   p.bar = rand() % 15 + 1;
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture array type, and POD type by reference
     table[idx[0]] *= (p.foo * p.bar);
   });

--- a/tests/Unit/CaptureByRef/test13.cpp
+++ b/tests/Unit/CaptureByRef/test13.cpp
@@ -38,7 +38,7 @@ bool test() {
   p.setBar(rand() % 15 + 1);
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture array type, and POD type by reference
     // use member function to access POD type
     table[idx[0]] *= (p.getFoo() * p.getBar());

--- a/tests/Unit/CaptureByRef/test14.cpp
+++ b/tests/Unit/CaptureByRef/test14.cpp
@@ -35,7 +35,7 @@ bool test() {
   }
 
   extent<2> ex(VECTOR_SIZE, VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<2> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<2> idx) [[hc]] {
     // capture array type, and POD type by reference
     // use member function to access POD type
     int result = 0;

--- a/tests/Unit/CaptureByRef/test15.cpp
+++ b/tests/Unit/CaptureByRef/test15.cpp
@@ -44,7 +44,7 @@ bool test() {
   p.qux = rand() % 15 + 1;
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture array type, and an inherited type by reference
     table[idx[0]] = (p.foo * p.bar * p.baz * p.qux);
   });

--- a/tests/Unit/CaptureByRef/test2.cpp
+++ b/tests/Unit/CaptureByRef/test2.cpp
@@ -26,7 +26,7 @@ bool test() {
 
   extent<1> ex(VECTOR_SIZE);
   array_view<int, 1> av(ex, table);
-  parallel_for_each(av.get_extent(), [&, av](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [&, av](hc::index<1> idx) [[hc]] {
     // capture multiple scalar types by reference
     av[idx] *= (val + val2);
   });

--- a/tests/Unit/CaptureByRef/test3.cpp
+++ b/tests/Unit/CaptureByRef/test3.cpp
@@ -24,7 +24,7 @@ bool test() {
   int val = rand() % 15 + 1;
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture array type, and scalar type by reference
     table[idx[0]] *= (val * val);
   });

--- a/tests/Unit/CaptureByRef/test4.cpp
+++ b/tests/Unit/CaptureByRef/test4.cpp
@@ -25,7 +25,7 @@ bool test() {
   int val2 = rand() % 15 + 1;
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture multiple scalar types by reference
     table[idx[0]] *= (val + val2);
   });

--- a/tests/Unit/CaptureByRef/test5.cpp
+++ b/tests/Unit/CaptureByRef/test5.cpp
@@ -27,7 +27,7 @@ bool test() {
   int val2 = rand() % 15 + 1;
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture multiple scalar types by reference
     table[idx[0]] += table2[idx[0]];
   });

--- a/tests/Unit/CaptureByRef/test6.cpp
+++ b/tests/Unit/CaptureByRef/test6.cpp
@@ -28,7 +28,7 @@ bool test() {
   }
 
   extent<1> ex(VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<1> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1> idx) [[hc]] {
     // capture multiple array types and scalar types by reference
     table3[idx[0]] = (p1 * table1[idx[0]]) + (p2 * table2[idx[0]]);
   });

--- a/tests/Unit/CaptureByRef/test7.cpp
+++ b/tests/Unit/CaptureByRef/test7.cpp
@@ -27,7 +27,7 @@ bool test() {
   }
 
   extent<2> ex(VECTOR_SIZE, VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<2> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<2> idx) [[hc]] {
     // capture multiple 2D array types and scalar type by reference
     table2[idx[0]][idx[1]] = table[idx[0]][idx[1]] * p;
   });

--- a/tests/Unit/CaptureByRef/test8.cpp
+++ b/tests/Unit/CaptureByRef/test8.cpp
@@ -29,7 +29,7 @@ bool test() {
   }
 
   extent<3> ex(VECTOR_SIZE, VECTOR_SIZE, VECTOR_SIZE);
-  parallel_for_each(ex, [&](index<3> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<3> idx) [[hc]] {
     // capture multiple 3D array types and scalar type by reference
     table2[idx[0]][idx[1]][idx[2]] = table[idx[0]][idx[1]][idx[2]] * p;
   });

--- a/tests/Unit/CaptureByRef/test9.cpp
+++ b/tests/Unit/CaptureByRef/test9.cpp
@@ -32,7 +32,7 @@ bool test() {
 
   int dim[4] { VECTOR_SIZE, VECTOR_SIZE, VECTOR_SIZE, VECTOR_SIZE };
   extent<4> ex(dim);
-  parallel_for_each(ex, [&](index<4> idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<4> idx) [[hc]] {
     // capture multiple 4D array types and scalar type by reference
     table2[idx[0]][idx[1]][idx[2]][idx[3]] = table[idx[0]][idx[1]][idx[2]][idx[3]] * p;
   });

--- a/tests/Unit/Codegen/indirect-func-arg.cpp
+++ b/tests/Unit/Codegen/indirect-func-arg.cpp
@@ -37,7 +37,7 @@ int main() {
   array<unsigned int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
   int i = 0;
-  auto k = [&table, i](index<1>& idx) [[hc]]{
+  auto k = [&table, i](hc::index<1>& idx) [[hc]]{
     A a;
     table(idx) = f(a, i);
   };

--- a/tests/Unit/Codegen/opt_level0.cpp
+++ b/tests/Unit/Codegen/opt_level0.cpp
@@ -24,7 +24,7 @@ void vectorAdd_by_array(const std::vector<float>& vecA, const std::vector<float>
    extent<1> e(N);
 
    parallel_for_each(e,
-         [=](index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
+         [=](hc::index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
 }
 
 int main(void)

--- a/tests/Unit/Codegen/opt_level1.cpp
+++ b/tests/Unit/Codegen/opt_level1.cpp
@@ -24,7 +24,7 @@ void vectorAdd_by_array(const std::vector<float>& vecA, const std::vector<float>
    extent<1> e(N);
 
    parallel_for_each(e,
-         [=](index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
+         [=](hc::index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
 }
 
 int main(void)

--- a/tests/Unit/Codegen/tworef.cpp
+++ b/tests/Unit/Codegen/tworef.cpp
@@ -9,6 +9,6 @@ int main()
   array<int, 1> temp(length);
   array<int, 1> data(length);
   extent<1> cdomain_transpose(16);
-  parallel_for_each (cdomain_transpose, [=, &data, &temp] (index<1> tidx)  [[hc]] {});
+  parallel_for_each (cdomain_transpose, [=, &data, &temp] (hc::index<1> tidx)  [[hc]] {});
   return 0;
 }

--- a/tests/Unit/Codegen/vector_addition_using_array.cpp
+++ b/tests/Unit/Codegen/vector_addition_using_array.cpp
@@ -24,7 +24,7 @@ void vectorAdd_by_array(const std::vector<float>& vecA, const std::vector<float>
    extent<1> e(N);
 
    parallel_for_each(e,
-         [=](index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
+         [=](hc::index<1> idx) [[hc]] { cv[idx] = av[idx] + bv[idx]; }); 
 }
 
 int main(void)

--- a/tests/Unit/DataContainers/array_view_2d.1.cpp
+++ b/tests/Unit/DataContainers/array_view_2d.1.cpp
@@ -9,7 +9,7 @@ int main()
   extent<2> e(5, 2);
   {
     array_view<int, 2> av(e, v); 
-    parallel_for_each(av.get_extent(), [=](index<2> idx) [[hc]] { 
+    parallel_for_each(av.get_extent(), [=](hc::index<2> idx) [[hc]] { 
 	av[idx] -= 1; 
 	});
     assert(av.get_extent() == e);

--- a/tests/Unit/DataContainers/array_view_2d.2.cpp
+++ b/tests/Unit/DataContainers/array_view_2d.2.cpp
@@ -9,7 +9,7 @@ int main()
   extent<2> e(5, 2);
   {
     array_view<int, 2> av(e, v); 
-    parallel_for_each(av.get_extent(), [=](index<2> idx) [[hc]] { 
+    parallel_for_each(av.get_extent(), [=](hc::index<2> idx) [[hc]] { 
 	av(idx) -= 1; 
 	});
     assert(av.get_extent() == e);

--- a/tests/Unit/DataContainers/array_view_2d.3.cpp
+++ b/tests/Unit/DataContainers/array_view_2d.3.cpp
@@ -13,7 +13,7 @@ int main()
   extent<2> e(5, 2);
   {
     array_view<int, 2> av(5, 2, vv); 
-    parallel_for_each(av.get_extent(), [=](index<2> idx) [[hc]] { 
+    parallel_for_each(av.get_extent(), [=](hc::index<2> idx) [[hc]] { 
 	av(idx) -= 1; 
 	});
     assert(av.get_extent() == e);

--- a/tests/Unit/Design/5d.support.cpp
+++ b/tests/Unit/Design/5d.support.cpp
@@ -12,7 +12,7 @@ bool test_array_rank(int extval = _rank)
     extent<_rank> e(data);
     array<_type, _rank> a1(e);
 
-    parallel_for_each(e, [&](index<_rank> idx) [[hc]] {
+    parallel_for_each(e, [&](hc::index<_rank> idx) [[hc]] {
         a1[idx] = 1;
     });
 

--- a/tests/Unit/Design/addr_space.cpp
+++ b/tests/Unit/Design/addr_space.cpp
@@ -23,13 +23,13 @@ int main(void) {
   array_view<float> ga(vecSize);
   array_view<float> gb(vecSize);
   array_view<float> gc(vecSize);
-  for (index<1> i(0); i[0] < vecSize; i++) {
+  for (hc::index<1> i(0); i[0] < vecSize; i++) {
     ga[i] = dis(gen);
   }
 
   parallel_for_each(
     e,
-    [=](index<1> idx) [[hc]] {
+    [=](hc::index<1> idx) [[hc]] {
     gc[idx] = x(&ga[idx]);
   });
 

--- a/tests/Unit/Design/array_view_extent.cpp
+++ b/tests/Unit/Design/array_view_extent.cpp
@@ -7,7 +7,7 @@ int main()
   int v[11] = {'G', 'd', 'k', 'k', 'n', 31, 'v', 'n', 'q', 'k', 'c'};
 
   array_view<int> av(11, v); 
-  parallel_for_each(av.get_extent(), [=](index<1> idx) [[hc]] { 
+  parallel_for_each(av.get_extent(), [=](hc::index<1> idx) [[hc]] { 
     av[idx] += 1; 
   });
 

--- a/tests/Unit/Design/array_view_extent_2d.cpp
+++ b/tests/Unit/Design/array_view_extent_2d.cpp
@@ -8,7 +8,7 @@ int main()
   extent<2> e(5, 2);
 
   array_view<int, 2> av(e, v); 
-  parallel_for_each(av.get_extent(), [=](index<2> idx) [[hc]] { 
+  parallel_for_each(av.get_extent(), [=](hc::index<2> idx) [[hc]] { 
     av[idx] -= 1; 
   });
   assert(av.get_extent() == e);

--- a/tests/Unit/Design/double_lamda_in_one_fuction.cpp
+++ b/tests/Unit/Design/double_lamda_in_one_fuction.cpp
@@ -6,11 +6,11 @@ int main() {
   int v[11] = {0,1,2,3,4,5,6,7,8,9,10};
   int expexted_v[11] = {11,12,13,14,15,16,17,18,19,20,21};
   array_view<int> av(11, v);
-  parallel_for_each(av.get_extent(), [=](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [=](hc::index<1> idx) [[hc]] {
     av[idx] +=1 ;
   });
 
-  parallel_for_each(av.get_extent(), [=](index<1> idx) [[hc]] {
+  parallel_for_each(av.get_extent(), [=](hc::index<1> idx) [[hc]] {
     av[idx] += 10;
   });
 

--- a/tests/Unit/Design/overload.cpp
+++ b/tests/Unit/Design/overload.cpp
@@ -16,7 +16,7 @@ bool TestOnDevice()
     array<int, 1> a((extent<1>(1)));
     array_view<int> A(a);
     extent<1> ex(1);
-    parallel_for_each(ex, [&](index<1> idx) [[cpu, hc]] {
+    parallel_for_each(ex, [&](hc::index<1> idx) [[cpu, hc]] {
         A(idx) = g();
     });
     return A[0] == 55;

--- a/tests/Unit/Design/transpose.cpp
+++ b/tests/Unit/Design/transpose.cpp
@@ -33,7 +33,7 @@ void transpose_simple(const array_view<const _value_type, 2>& data,
   assert(data.get_extent() == transpose(data_transpose.get_extent()));
 
   data_transpose.discard_data();
-  parallel_for_each(data.get_extent(), [=] (index<2> idx) [[hc]] {
+  parallel_for_each(data.get_extent(), [=] (hc::index<2> idx) [[hc]] {
     data_transpose[transpose(idx)] = data[idx];
   });
 }
@@ -219,8 +219,8 @@ void transpose_tiled_truncate_option_b(
   tiled_extent<2> e_truncated(e_tiled.truncate());
 
   // Transform matrix to be multiple of 16*16 and transpose.
-  auto b  = data.section(index<2>(0,0), e_truncated);
-  auto b_t = data_transpose.section(index<2>(0,0),
+  auto b  = data.section(hc::index<2>(0,0), e_truncated);
+  auto b_t = data_transpose.section(hc::index<2>(0,0),
                  transpose(static_cast<extent<2>>(e_truncated)));
   transpose_tiled_even<_value_type, _tile_size>(b, b_t);
 

--- a/tests/Unit/Design/veccadd3.cpp
+++ b/tests/Unit/Design/veccadd3.cpp
@@ -14,7 +14,7 @@ void vecAdd(float* A, float* B, float* C, int n)
     copy(A,AA);
     copy(B,BA);	
     parallel_for_each(view, CA.get_extent(), 
-            [&AA,&BA,&CA](index<1> i) [[hc]] {
+            [&AA,&BA,&CA](hc::index<1> i) [[hc]] {
             CA[i] = AA[i] + BA[i];
     });
     copy(CA,C);

--- a/tests/Unit/DynamicTileStatic/test12.cpp
+++ b/tests/Unit/DynamicTileStatic/test12.cpp
@@ -22,8 +22,8 @@ bool test() {
     tile_static int lds1[TILE_SIZE];
 
     // obtain workitem absolute index and workgroup index
-    index<1> global = tidx.global;
-    index<1> local = tidx.local;
+    hc::index<1> global = tidx.global;
+    hc::index<1> local = tidx.local;
 
     // fetch the address of a variable in group segment
     unsigned char* ptr = (unsigned char*)&lds1[local[0]];

--- a/tests/Unit/DynamicTileStatic/test13.cpp
+++ b/tests/Unit/DynamicTileStatic/test13.cpp
@@ -21,8 +21,8 @@ bool test() {
     tile_static int lds1[TILE_SIZE];
 
     // obtain workitem absolute index and workgroup index
-    index<1> global = tidx.global;
-    index<1> local = tidx.local;
+    hc::index<1> global = tidx.global;
+    hc::index<1> local = tidx.local;
 
     // fetch the address of a variable in group segment
     unsigned char* ptr = (unsigned char*)&lds1[local[0]];

--- a/tests/Unit/DynamicTileStatic/test14.cpp
+++ b/tests/Unit/DynamicTileStatic/test14.cpp
@@ -25,8 +25,8 @@ bool test() {
     tile_static int lds1[TILE_SIZE];
 
     // obtain workitem absolute index and workgroup index
-    index<1> global = tidx.global;
-    index<1> local = tidx.local;
+    hc::index<1> global = tidx.global;
+    hc::index<1> local = tidx.local;
 
     lds1[local[0]] = local[0];
     tidx.barrier.wait();

--- a/tests/Unit/DynamicTileStatic/test6.cpp
+++ b/tests/Unit/DynamicTileStatic/test6.cpp
@@ -22,8 +22,8 @@ bool test() {
     tile_static int lds1[TILE_SIZE];
 
     // obtain workitem absolute index and workgroup index
-    index<1> global = tidx.global;
-    index<1> local = tidx.local;
+    hc::index<1> global = tidx.global;
+    hc::index<1> local = tidx.local;
 
     // fetch the address of a variable in group segment
     unsigned char* ptr = (unsigned char*)&lds1[local[0]];

--- a/tests/Unit/FilePath/file_path_test4.cpp
+++ b/tests/Unit/FilePath/file_path_test4.cpp
@@ -17,7 +17,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -35,7 +35,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 

--- a/tests/Unit/HC/auto_annotate_attribute.cpp
+++ b/tests/Unit/HC/auto_annotate_attribute.cpp
@@ -18,7 +18,7 @@ bool test1() {
   bool ret = true;
   array<int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table[idx] = foo();
   }).wait();
 
@@ -46,7 +46,7 @@ bool test2() {
   bool ret = true;
   array<int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table[idx] = bar();
   }).wait();
 
@@ -82,7 +82,7 @@ bool test3() {
   array<int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
   baz obj;
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table[idx] = obj.test();
   }).wait();
 
@@ -103,7 +103,7 @@ bool test4() {
   bool ret = true;
   array<int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table[idx] = baz::test2();
   }).wait();
 

--- a/tests/Unit/HC/capture_struct_with_carray_by_copy.cpp
+++ b/tests/Unit/HC/capture_struct_with_carray_by_copy.cpp
@@ -43,7 +43,7 @@ int main() {
 
   av.copy(data, data_d, 3 * sizeof(int));
 
-  parallel_for_each(extent<1>(3), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(3), [=](hc::index<1> idx) [[hc]] {
                       data_d[idx[0]] = f.table[idx[0]] + 999;
                     });
 

--- a/tests/Unit/HC/capture_struct_with_carray_by_copy2.cpp
+++ b/tests/Unit/HC/capture_struct_with_carray_by_copy2.cpp
@@ -41,7 +41,7 @@ bool test() {
 
   av.copy(data, data_d, 3 * sizeof(T));
 
-  parallel_for_each(extent<1>(3), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(3), [=](hc::index<1> idx) [[hc]] {
                       data_d[idx[0]] = f.table[idx[0]] + T(999);
                     });
 

--- a/tests/Unit/HC/capture_struct_with_carray_by_copy3.cpp
+++ b/tests/Unit/HC/capture_struct_with_carray_by_copy3.cpp
@@ -139,7 +139,7 @@ bool test() {
 
   av.copy(data, data_d, N * sizeof(T));
 
-  parallel_for_each(extent<1>(N), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(N), [=](hc::index<1> idx) [[hc]] {
                       data_d[idx[0]] = f.table[idx[0]] + T(999);
                     });
 

--- a/tests/Unit/HC/capture_struct_with_carray_by_copy4.cpp
+++ b/tests/Unit/HC/capture_struct_with_carray_by_copy4.cpp
@@ -186,7 +186,7 @@ bool test() {
 
   av.copy(data, data_d, N * sizeof(T));
 
-  parallel_for_each(extent<1>(N), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(N), [=](hc::index<1> idx) [[hc]] {
                       data_d[idx[0]] = f.table[idx[0]] + T(999);
                     });
 

--- a/tests/Unit/HC/cycle.cpp
+++ b/tests/Unit/HC/cycle.cpp
@@ -11,7 +11,7 @@ int main() {
   extent<1> ex(GRID_SIZE);
 
   // launch a kernel, log current hardware cycle count
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __cycle_u64();
   }).wait();
 

--- a/tests/Unit/HC/cycle2.cpp
+++ b/tests/Unit/HC/cycle2.cpp
@@ -14,7 +14,7 @@ int main() {
   extent<1> ex(GRID_SIZE);
 
   // launch a kernel, log current hardware cycle count
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __cycle_u64();
     table2(idx) = __cycle_u64();
   }).wait();

--- a/tests/Unit/HC/get_use_count.cpp
+++ b/tests/Unit/HC/get_use_count.cpp
@@ -22,7 +22,7 @@ int main() {
   extent<1> ex(GRID_SIZE);
 
   // launch a kernel, log current hardware cycle count
-  completion_future cf = parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  completion_future cf = parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     table(idx) = __cycle_u64();
   });
 

--- a/tests/Unit/HC/hc_atomic_add_float_global.cpp
+++ b/tests/Unit/HC/hc_atomic_add_float_global.cpp
@@ -20,7 +20,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_add(&count[i], INIT);
     }

--- a/tests/Unit/HC/hc_atomic_add_float_local.cpp
+++ b/tests/Unit/HC/hc_atomic_add_float_local.cpp
@@ -22,8 +22,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/HC/hc_atomic_add_global.cpp
+++ b/tests/Unit/HC/hc_atomic_add_global.cpp
@@ -14,7 +14,7 @@ bool test() {
   T init[vecSize] { 0 };
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; i++) {
       atomic_fetch_add(&count[i], T(1));
     }

--- a/tests/Unit/HC/hc_atomic_add_local.cpp
+++ b/tests/Unit/HC/hc_atomic_add_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_and_global.cpp
+++ b/tests/Unit/HC/hc_atomic_and_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; ++i) {
       atomic_fetch_and(&count[i], T(1));
     }

--- a/tests/Unit/HC/hc_atomic_and_local.cpp
+++ b/tests/Unit/HC/hc_atomic_and_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_compare_exchange_global.cpp
+++ b/tests/Unit/HC/hc_atomic_compare_exchange_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     // 0 -> 2
     // 1 -> 1
     T v = T(0);

--- a/tests/Unit/HC/hc_atomic_compare_exchange_local.cpp
+++ b/tests/Unit/HC/hc_atomic_compare_exchange_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
     T v = T(0);
 
     tile_static T localA[tile_size][tile_size];

--- a/tests/Unit/HC/hc_atomic_dec_global.cpp
+++ b/tests/Unit/HC/hc_atomic_dec_global.cpp
@@ -13,7 +13,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_dec(&count[i]);
     }

--- a/tests/Unit/HC/hc_atomic_dec_local.cpp
+++ b/tests/Unit/HC/hc_atomic_dec_local.cpp
@@ -20,8 +20,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static int localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/HC/hc_atomic_exchange_float_global.cpp
+++ b/tests/Unit/HC/hc_atomic_exchange_float_global.cpp
@@ -20,7 +20,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_exchange(&count(idx), NEW_VALUE);
   });
 

--- a/tests/Unit/HC/hc_atomic_exchange_float_local.cpp
+++ b/tests/Unit/HC/hc_atomic_exchange_float_local.cpp
@@ -22,8 +22,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/HC/hc_atomic_exchange_global.cpp
+++ b/tests/Unit/HC/hc_atomic_exchange_global.cpp
@@ -14,7 +14,7 @@ bool test() {
   T init[vecSize] { 0 };
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_exchange(&count(idx), T(1));
   });
 

--- a/tests/Unit/HC/hc_atomic_exchange_local.cpp
+++ b/tests/Unit/HC/hc_atomic_exchange_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_inc_global.cpp
+++ b/tests/Unit/HC/hc_atomic_inc_global.cpp
@@ -13,7 +13,7 @@ int main(void) {
   int init[vecSize] { 0 };
   array<int, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_inc(&count[i]);
     }

--- a/tests/Unit/HC/hc_atomic_inc_local.cpp
+++ b/tests/Unit/HC/hc_atomic_inc_local.cpp
@@ -20,8 +20,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static unsigned localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/HC/hc_atomic_max_global.cpp
+++ b/tests/Unit/HC/hc_atomic_max_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; ++i) {
       atomic_fetch_max(&count[i], T(vecSize / 2));
     }

--- a/tests/Unit/HC/hc_atomic_max_local.cpp
+++ b/tests/Unit/HC/hc_atomic_max_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_min_global.cpp
+++ b/tests/Unit/HC/hc_atomic_min_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; ++i) {
       atomic_fetch_min(&count[i], T(vecSize / 2));
     }

--- a/tests/Unit/HC/hc_atomic_min_local.cpp
+++ b/tests/Unit/HC/hc_atomic_min_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_or_global.cpp
+++ b/tests/Unit/HC/hc_atomic_or_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; ++i) {
       atomic_fetch_or(&count[i], T(1));
     }

--- a/tests/Unit/HC/hc_atomic_or_local.cpp
+++ b/tests/Unit/HC/hc_atomic_or_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_atomic_sub_float_global.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_float_global.cpp
@@ -20,7 +20,7 @@ int main(void) {
   std::vector<T> init(vecSize, INIT);
   array<T, 1> count(vecSize, init.begin());
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(unsigned i = 0; i < vecSize; i++) {
       atomic_fetch_sub(&count[i], INIT);
     }

--- a/tests/Unit/HC/hc_atomic_sub_float_local.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_float_local.cpp
@@ -22,8 +22,8 @@ int main(void) {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = 0;

--- a/tests/Unit/HC/hc_atomic_sub_global.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_global.cpp
@@ -15,7 +15,7 @@ bool test() {
   for (int i = 0; i < vecSize; ++i) { init[i] = T(vecSize); }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     for(int i = 0; i < vecSize; ++i) {
       atomic_fetch_sub(&count[i], T(1));
     }

--- a/tests/Unit/HC/hc_atomic_sub_local.cpp
+++ b/tests/Unit/HC/hc_atomic_sub_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(tile_size * tile_size);

--- a/tests/Unit/HC/hc_atomic_wrapinc_wrapdec.cpp
+++ b/tests/Unit/HC/hc_atomic_wrapinc_wrapdec.cpp
@@ -21,7 +21,7 @@ bool test_atomic_wrapinc_global() {
   array<unsigned int, 1> data2(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
 
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     // initialize value
     data1(idx) = idx[0]; // data1 initialized as workitem index
     data2(idx) = 0;      // data2 initialized as 0
@@ -96,7 +96,7 @@ bool test_atomic_wrapdec_global() {
   array<unsigned int, 1> data2(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
 
-  parallel_for_each(ex, [&](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [&](hc::index<1>& idx) [[hc]] {
     // initialize value
     data1(idx) = idx[0]; // data1 initialized as workitem index
     data2(idx) = 0;      // data2 initialized as 0

--- a/tests/Unit/HC/hc_atomic_xor_global.cpp
+++ b/tests/Unit/HC/hc_atomic_xor_global.cpp
@@ -17,7 +17,7 @@ bool test() {
   }
   array<T, 1> count(vecSize, std::begin(init));
 
-  parallel_for_each(count.get_extent(), [=, &count](index<1> idx) [[hc]] {
+  parallel_for_each(count.get_extent(), [=, &count](hc::index<1> idx) [[hc]] {
     atomic_fetch_xor(&count(idx), T(1));
   });
 

--- a/tests/Unit/HC/hc_atomic_xor_local.cpp
+++ b/tests/Unit/HC/hc_atomic_xor_local.cpp
@@ -21,8 +21,8 @@ bool test() {
 
   extent<2> compute_domain(e_a);
   parallel_for_each(compute_domain.tile(tile_size, tile_size), [=] (tiled_index<2> tidx) [[hc]] {
-    index<2> localIdx = tidx.local;
-    index<2> globalIdx = tidx.global;
+    hc::index<2> localIdx = tidx.local;
+    hc::index<2> globalIdx = tidx.global;
 
     tile_static T localA[tile_size][tile_size];
     localA[localIdx[0]][localIdx[1]] = T(0);

--- a/tests/Unit/HC/hc_math.cpp
+++ b/tests/Unit/HC/hc_math.cpp
@@ -38,7 +38,7 @@ bool test_math_fn(const char* name, F f, G ref_f)
 
     array_view<T> table(grid_sz);
 
-    parallel_for_each(table.get_extent(), [=](const index<1>& idx) __HC__ {
+    parallel_for_each(table.get_extent(), [=](const hc::index<1>& idx) __HC__ {
        table[idx] = f(static_cast<T>(idx[0] + 1));
     });
 

--- a/tests/Unit/HC/hc_math2.cpp
+++ b/tests/Unit/HC/hc_math2.cpp
@@ -34,7 +34,7 @@
 
   #define TEST(func) \
     { \
-      parallel_for_each(ex, [=](index<1>& idx) __HC__ { \
+      parallel_for_each(ex, [=](hc::index<1>& idx) __HC__ { \
         table3(idx) = func(table1(idx), table2(idx)); \
       }); \
       accelerator().get_default_view().wait(); \

--- a/tests/Unit/HC/hc_math3.cpp
+++ b/tests/Unit/HC/hc_math3.cpp
@@ -36,7 +36,7 @@ bool test() {
 
 #define TEST(func) \
   { \
-    parallel_for_each(ex, [=](index<1>& idx) __HC__ { \
+    parallel_for_each(ex, [=](hc::index<1>& idx) __HC__ { \
       table3(idx) = func(table1(idx), table2(idx)); \
     }).wait(); \
     int error = 0; \

--- a/tests/Unit/HC/kernel-call-undefined-func.cpp
+++ b/tests/Unit/HC/kernel-call-undefined-func.cpp
@@ -9,7 +9,7 @@ int main() {
   using namespace hc;
   array<unsigned int, 1> table(GRID_SIZE);
   extent<1> ex(GRID_SIZE);
-  auto k = [&](index<1>& idx) [[hc]] {
+  auto k = [&](hc::index<1>& idx) [[hc]] {
     table(idx) = idx[0];
     func();
   };

--- a/tests/Unit/HC/memcpy_symbol1.cpp
+++ b/tests/Unit/HC/memcpy_symbol1.cpp
@@ -32,7 +32,7 @@ bool test1() {
 
   // dispatch a kernel which reads from globalVar and stores result to table1
   extent<1> ex(GRID_SIZE);
-  completion_future fut = parallel_for_each(ex, [=](index<1>& idx) __attribute__((hc)) {
+  completion_future fut = parallel_for_each(ex, [=](hc::index<1>& idx) __attribute__((hc)) {
     tableOutput1(idx) = tableGlobal[idx[0]];
   });
 

--- a/tests/Unit/HC/memcpy_symbol2.cpp
+++ b/tests/Unit/HC/memcpy_symbol2.cpp
@@ -33,7 +33,7 @@ bool test2() {
 
   // dispatch a kernel which reads from globalVar and stores result to table1
   extent<1> ex(GRID_SIZE);
-  completion_future fut = parallel_for_each(ex, [=](index<1>& idx) __attribute__((hc)) {
+  completion_future fut = parallel_for_each(ex, [=](hc::index<1>& idx) __attribute__((hc)) {
     tableOutput1(idx) = tableGlobal[idx[0]];
   });
 

--- a/tests/Unit/HC/memcpy_symbol3.cpp
+++ b/tests/Unit/HC/memcpy_symbol3.cpp
@@ -33,7 +33,7 @@ bool test1() {
 
   // dispatch a kernel which reads from globalVar and stores result to table1
   extent<1> ex(GRID_SIZE);
-  completion_future fut = parallel_for_each(ex, [=](index<1>& idx) __attribute__((hc)) {
+  completion_future fut = parallel_for_each(ex, [=](hc::index<1>& idx) __attribute__((hc)) {
     tableOutput1(idx) = tableGlobal[idx[0]];
   });
 

--- a/tests/Unit/HC/memcpy_symbol4.cpp
+++ b/tests/Unit/HC/memcpy_symbol4.cpp
@@ -34,7 +34,7 @@ bool test2() {
 
   // dispatch a kernel which reads from globalVar and stores result to table1
   extent<1> ex(GRID_SIZE);
-  completion_future fut = parallel_for_each(ex, [=](index<1>& idx) __attribute__((hc)) {
+  completion_future fut = parallel_for_each(ex, [=](hc::index<1>& idx) __attribute__((hc)) {
     tableOutput1(idx) = tableGlobal[idx[0]];
   });
 

--- a/tests/Unit/HC/reduction_hc.cpp
+++ b/tests/Unit/HC/reduction_hc.cpp
@@ -72,7 +72,7 @@ float reduction_simple_1(const std::vector<float>& source)
     // back only the first element.
     array<float, 1> a(element_count, source.begin());
 
-    // Takes care of odd input elements – we could completely avoid tail sum
+    // Takes care of odd input elements ï¿½ we could completely avoid tail sum
     // if we would require source to have even number of elements.
     float tail_sum = (element_count % 2) ? source[element_count - 1] : 0;
     array_view<float, 1> av_tail_sum(1, &tail_sum);
@@ -80,7 +80,7 @@ float reduction_simple_1(const std::vector<float>& source)
     // Each thread reduces two elements.
     for (unsigned s = element_count / 2; s > 0; s /= 2)
     {
-        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) [[hc]]
+        parallel_for_each(extent<1>(s), [=, &a] (hc::index<1> idx) [[hc]]
         {
             a[idx] = a[idx] + a[idx + s];
 
@@ -127,7 +127,7 @@ float reduction_simple_2(const std::vector<float>& source)
     unsigned prev_s = element_count;
     for (unsigned s = element_count / window_width; s > 0; s /= window_width)
     {
-        parallel_for_each(extent<1>(s), [=, &a] (index<1> idx) [[hc]]
+        parallel_for_each(extent<1>(s), [=, &a] (hc::index<1> idx) [[hc]]
         {
             float sum = 0.f;
             for(unsigned i = 0; i < window_width; i++)

--- a/tests/Unit/HC/subword_types.cpp
+++ b/tests/Unit/HC/subword_types.cpp
@@ -12,7 +12,7 @@ template<typename T>
 bool test_aggregate_use()
 {
     array_view<T> out{42};
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
        T tmp[42] = {};
        for (auto i = 0u; i != out.get_extent().size(); ++i) out[i] = tmp[i];
     });
@@ -28,7 +28,7 @@ template<typename T>
 bool test_direct_use()
 {
     array_view<T> out{1};
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         T tmp = {};
         out[0] = tmp;
     });
@@ -42,7 +42,7 @@ bool test_nested_use()
     struct Tmp { T x; };
 
     array_view<Tmp> out{1};
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         Tmp tmp = {};
         out[0] = tmp;
     });

--- a/tests/Unit/HC/zero_extent.cpp
+++ b/tests/Unit/HC/zero_extent.cpp
@@ -22,7 +22,7 @@ bool test1D() {
 
   // 1D non-tiled
   extent<1> ex1d(0);
-  completion_future fut1 = parallel_for_each(ex1d, [&](index<1>& idx) __HC__ {
+  completion_future fut1 = parallel_for_each(ex1d, [&](hc::index<1>& idx) __HC__ {
     table[idx[0]] = 1;
   });
 
@@ -47,7 +47,7 @@ bool test1D() {
   ret &= (std::count(std::begin(table), std::end(table), 0) == TABLE_X);
 
   // 1D non-tiled
-  completion_future fut3 = parallel_for_each(ex1d, [&](index<1>& idx) __HC__ {
+  completion_future fut3 = parallel_for_each(ex1d, [&](hc::index<1>& idx) __HC__ {
     table[idx[0]] = 1;
   });
 
@@ -83,7 +83,7 @@ bool test2D() {
 
   // 2D non-tiled
   extent<2> ex2d(0, 0);
-  completion_future fut1 = parallel_for_each(ex2d, [&](index<2>& idx) __HC__ {
+  completion_future fut1 = parallel_for_each(ex2d, [&](hc::index<2>& idx) __HC__ {
     table[idx[0] * TABLE_Y + idx[1]] = 1;
   });
 
@@ -108,7 +108,7 @@ bool test2D() {
   ret &= (std::count(std::begin(table), std::end(table), 0) == TABLE_X * TABLE_Y);
 
   // 2D non-tiled
-  completion_future fut3 = parallel_for_each(ex2d, [&](index<2>& idx) __HC__ {
+  completion_future fut3 = parallel_for_each(ex2d, [&](hc::index<2>& idx) __HC__ {
     table[idx[0] * TABLE_Y + idx[1]] = 1;
   });
 
@@ -144,7 +144,7 @@ bool test3D() {
 
   // 3D non-tiled
   extent<3> ex3d(0, 0, 0);
-  completion_future fut1 = parallel_for_each(ex3d, [&](index<3>& idx) __HC__ {
+  completion_future fut1 = parallel_for_each(ex3d, [&](hc::index<3>& idx) __HC__ {
     table[idx[0] * TABLE_X * TABLE_Y + idx[1] * TABLE_Y + idx[2]] = 1;
   });
 
@@ -169,7 +169,7 @@ bool test3D() {
   ret &= (std::count(std::begin(table), std::end(table), 0) == TABLE_X * TABLE_Y * TABLE_Z);
 
   // 2D non-tiled
-  completion_future fut3 = parallel_for_each(ex3d, [&](index<3>& idx) __HC__ {
+  completion_future fut3 = parallel_for_each(ex3d, [&](hc::index<3>& idx) __HC__ {
     table[idx[0] * TABLE_X * TABLE_Y + idx[1] * TABLE_Y + idx[2]] = 1;
   });
 

--- a/tests/Unit/HSA/functor1.cpp
+++ b/tests/Unit/HSA/functor1.cpp
@@ -22,7 +22,7 @@ class prog {
 public:
   prog(int (&t)[SIZE]) [[cpu, hc]] : input(t) {}
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     input[idx[0]] = idx[0];
   }
 

--- a/tests/Unit/HSA/functor2.cpp
+++ b/tests/Unit/HSA/functor2.cpp
@@ -19,7 +19,7 @@ using namespace hc;
 // the class will call a separate functor
 class user_functor {
 public:
-  void operator() (index<1>& idx, int (&input)[SIZE]) [[hc]] {
+  void operator() (hc::index<1>& idx, int (&input)[SIZE]) [[hc]] {
     input[idx[0]] = idx[0];
   }
 };
@@ -32,7 +32,7 @@ public:
   prog(int (&t)[SIZE], user_functor& f) [[cpu, hc]] : input(t), kernel(f) {
   }
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     kernel(idx, input);
   }
 

--- a/tests/Unit/HSA/functor3.cpp
+++ b/tests/Unit/HSA/functor3.cpp
@@ -23,7 +23,7 @@ public:
 
   user_functor(int (&t)[SIZE]) [[cpu, hc]] : input(t) {}
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     input[idx[0]] = idx[0];
   }
 };
@@ -35,7 +35,7 @@ public:
   prog(user_functor& f) [[cpu, hc]] : kernel(f) {
   }
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     kernel(idx);
   }
 

--- a/tests/Unit/HSA/functor4.cpp
+++ b/tests/Unit/HSA/functor4.cpp
@@ -24,7 +24,7 @@ public:
   prog(_Tp (&t)[N]) [[cpu, hc]] : input(t) {
   }
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     input[idx[0]] = idx[0];
   }
 

--- a/tests/Unit/HSA/functor5.cpp
+++ b/tests/Unit/HSA/functor5.cpp
@@ -21,7 +21,7 @@ using namespace hc;
 template<typename _Tp, size_t N>
 class user_functor {
 public:
-  void operator() (index<1>& idx, _Tp (&input)[N]) [[hc]] {
+  void operator() (hc::index<1>& idx, _Tp (&input)[N]) [[hc]] {
     input[idx[0]] = idx[0];
   }
 };
@@ -35,7 +35,7 @@ public:
   prog(_Tp (&t)[N], user_functor<_Tp, N>& f) [[cpu, hc]] : input(t), kernel(f) {
   }
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     kernel(idx, input);
   }
 

--- a/tests/Unit/HSA/functor6.cpp
+++ b/tests/Unit/HSA/functor6.cpp
@@ -25,7 +25,7 @@ public:
 
   user_functor(_Tp (&t)[N]) [[cpu, hc]] : input(t) {}
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     input[idx[0]] = idx[0];
   }
 };
@@ -38,7 +38,7 @@ public:
   prog(_Tp& f) [[cpu, hc]] : kernel(f) {
   }
 
-  void operator() (index<1>& idx) [[hc]] {
+  void operator() (hc::index<1>& idx) [[hc]] {
     kernel(idx);
   }
 

--- a/tests/Unit/HSA/list.cpp
+++ b/tests/Unit/HSA/list.cpp
@@ -34,7 +34,7 @@ bool test() {
   int n = nodes.size();
 
   // test on GPU
-  parallel_for_each(extent<1>(1),[=, &sum_gpu](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(1),[=, &sum_gpu](hc::index<1> idx) [[hc]] {
     List* l = head;
     for (int i = 0; i < n; ++i) {
       sum_gpu += l->data;

--- a/tests/Unit/HSA/sizeof.cpp
+++ b/tests/Unit/HSA/sizeof.cpp
@@ -17,7 +17,7 @@ bool test() {
 
   int width = 0;
 
-  auto k = [&width] (const index<1>& idx) [[hc]] {
+  auto k = [&width] (const hc::index<1>& idx) [[hc]] {
     width = sizeof(T);
   };
 

--- a/tests/Unit/HSA/string.cpp
+++ b/tests/Unit/HSA/string.cpp
@@ -30,7 +30,7 @@ bool test() {
   int sum_cpu = 0;
 
   // test on GPU
-  parallel_for_each(extent<1>(1),[=,&l,&sum_gpu](index<1> i) [[hc]] {
+  parallel_for_each(extent<1>(1),[=,&l,&sum_gpu](hc::index<1> i) [[hc]] {
     for (int j = 0; j < 4; j++) {
       sum_gpu+=l.strings[j][0];
     }

--- a/tests/Unit/HSA/volatile_union.cpp
+++ b/tests/Unit/HSA/volatile_union.cpp
@@ -54,7 +54,7 @@ bool test() {
   float table[SIZE] { 0.0f };
 
   // test foo1
-  parallel_for_each(extent<1>(SIZE), [&table](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(SIZE), [&table](hc::index<1> idx) [[hc]] {
     table[idx[0]] = foo1(0.0f);
   });
 
@@ -70,7 +70,7 @@ bool test() {
   }
 
   // test foo2
-  parallel_for_each(extent<1>(SIZE), [&table](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(SIZE), [&table](hc::index<1> idx) [[hc]] {
     table[idx[0]] = foo2(0.0f);
   });
 

--- a/tests/Unit/Indexing/extent.cpp
+++ b/tests/Unit/Indexing/extent.cpp
@@ -12,7 +12,7 @@ int main()
   extent<2> e(5, 2);
   {
     array_view<int, 2> av(5, 2, vv.data()); 
-    parallel_for_each(av.get_extent(), [=](index<2> idx) [[hc]] { 
+    parallel_for_each(av.get_extent(), [=](hc::index<2> idx) [[hc]] { 
 	av(idx) -= av.get_extent()[1]; 
     });
     assert(av.get_extent() == e);

--- a/tests/Unit/Macro/check_hcc_accelerator.cpp
+++ b/tests/Unit/Macro/check_hcc_accelerator.cpp
@@ -9,7 +9,7 @@ int main() {
   using namespace hc;
   array_view<int, 1> av(1, test);
 
-  parallel_for_each(extent<1>(1), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(1), [=](hc::index<1> idx) [[hc]] {
 #ifdef __HCC_ACCELERATOR__
     av[idx] = 1;
 #else

--- a/tests/Unit/Macro/check_hcc_cpu.cpp
+++ b/tests/Unit/Macro/check_hcc_cpu.cpp
@@ -9,7 +9,7 @@ int main() {
   using namespace hc;
   array_view<int, 1> av(1, test);
 
-  parallel_for_each(extent<1>(1), [=](index<1> idx) [[hc]] {
+  parallel_for_each(extent<1>(1), [=](hc::index<1> idx) [[hc]] {
 #ifdef __HCC_CPU__
     av[idx] = 0;
 #else

--- a/tests/Unit/NamespaceScopeVariables/global.cpp
+++ b/tests/Unit/NamespaceScopeVariables/global.cpp
@@ -21,7 +21,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = global_scalar;
         for (auto i = 0u; i != array_size; ++i) read_array[i] = global_array[i];
     });
@@ -32,7 +32,7 @@ int main()
     }
 
     #if false // 10/09/2017 - writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++global_scalar;
             for (auto&& x : global_array) ++x;
         }).wait();

--- a/tests/Unit/NamespaceScopeVariables/global_different_translation_units.cpp
+++ b/tests/Unit/NamespaceScopeVariables/global_different_translation_units.cpp
@@ -21,7 +21,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = global_scalar;
         for (auto i = 0u; i != array_size; ++i) read_array[i] = global_array[i];
     });
@@ -32,7 +32,7 @@ int main()
     }
 
     #if false // 10/09/2017 - GPU writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++global_scalar;
             for (auto&& x : global_array) ++x;
         }).wait();

--- a/tests/Unit/NamespaceScopeVariables/global_from_shared_object.cpp
+++ b/tests/Unit/NamespaceScopeVariables/global_from_shared_object.cpp
@@ -19,7 +19,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = global_scalar;
         for (auto i = 0u; i != array_size; ++i) read_array[i] = global_array[i];
     });
@@ -30,7 +30,7 @@ int main()
     }
 
     #if false // 10/09/2017 - GPU writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++global_scalar;
             for (auto&& x : global_array) ++x;
         }).wait();

--- a/tests/Unit/NamespaceScopeVariables/namespace.cpp
+++ b/tests/Unit/NamespaceScopeVariables/namespace.cpp
@@ -25,7 +25,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = namespace_scalar;
         for (auto i = 0u; i != array_size; ++i) {
             read_array[i] = namespace_array[i];
@@ -41,7 +41,7 @@ int main()
     }
 
     #if false // 10/09/2017 - GPU writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++namespace_scalar;
             for (auto&& x : namespace_array) ++x;
         }).wait();

--- a/tests/Unit/NamespaceScopeVariables/namespace_different_translation_units.cpp
+++ b/tests/Unit/NamespaceScopeVariables/namespace_different_translation_units.cpp
@@ -25,7 +25,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = namespace_scalar;
         for (auto i = 0u; i != array_size; ++i) {
             read_array[i] = namespace_array[i];
@@ -41,7 +41,7 @@ int main()
     }
 
     #if false // 10/09/2017 - GPU writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++namespace_scalar;
             for (auto&& x : namespace_array) ++x;
         }).wait();

--- a/tests/Unit/NamespaceScopeVariables/namespace_from_shared_object.cpp
+++ b/tests/Unit/NamespaceScopeVariables/namespace_from_shared_object.cpp
@@ -20,7 +20,7 @@ int main()
     array_view<int> read_scalar{1};
     array_view<int> read_array(array_size);
 
-    parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+    parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
         read_scalar[0] = namespace_scalar;
         for (auto i = 0u; i != array_size; ++i) {
             read_array[i] = namespace_array[i];
@@ -34,7 +34,7 @@ int main()
     }
 
     #if false // 10/09/2017 - GPU writes to globals are not correctly observed.
-        parallel_for_each(hc::extent<1>{1}, [=](index<1>) [[hc]] {
+        parallel_for_each(hc::extent<1>{1}, [=](hc::index<1>) [[hc]] {
             ++namespace_scalar;
             for (auto&& x : namespace_array) ++x;
         }).wait();

--- a/tests/Unit/Overload/Caller-amp-only-Callee-global-cpu-only.cpp
+++ b/tests/Unit/Overload/Caller-amp-only-Callee-global-cpu-only.cpp
@@ -9,7 +9,7 @@ void foo()
 
 int main()
 {
-    parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+    parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
     {
         foo();  // Call from AMP to CPU. Caller: Lambda
     });

--- a/tests/Unit/Overload/Negative/call_amp_function_in_cpu_function_or_lambda_or_pfe.cpp
+++ b/tests/Unit/Overload/Negative/call_amp_function_in_cpu_function_or_lambda_or_pfe.cpp
@@ -21,7 +21,7 @@ int main()
 // CHECK-NEXT:    foo();
 // CHECK-NEXT:       ^
 
-  parallel_for_each(extent<1>(1), [](index<1>) [[cpu]] {
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[cpu]] {
     foo();
   });
 // CHECK: call_amp_function_in_cpu_function_or_lambda_or_pfe.cpp:[[@LINE-2]]:8: error:  'foo':  no overloaded function has restriction specifiers that are compatible with the ambient context 'main()::(anonymous class)::operator()'

--- a/tests/Unit/Overload/Negative/call_cpu_funtion_in_amp_function_or_lambda_or_pfe.cpp
+++ b/tests/Unit/Overload/Negative/call_cpu_funtion_in_amp_function_or_lambda_or_pfe.cpp
@@ -33,7 +33,7 @@ int main()
 // CHECK-NEXT:    foo();
 // CHECK-NEXT:       ^
 
-  parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
   {
     foo();
   });

--- a/tests/Unit/Overload/Negative/call_distinct_from_dual_context.cpp
+++ b/tests/Unit/Overload/Negative/call_distinct_from_dual_context.cpp
@@ -30,7 +30,7 @@ int main()
 // CHECK-NEXT:       ^
 
 
-  parallel_for_each(extent<1>(1), [](index<1>) [[cpu, hc]] {
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[cpu, hc]] {
     foo();
   });
 // CHECK: call_distinct_from_dual_context.cpp:[[@LINE-2]]:8: error:  'foo':  no overloaded function has restriction specifiers that are compatible with the ambient context 'main()::(anonymous class)::operator()'

--- a/tests/Unit/Overload/amp-lambda_or_pfe_in_main.cpp
+++ b/tests/Unit/Overload/amp-lambda_or_pfe_in_main.cpp
@@ -8,7 +8,7 @@ int main()
     // This test outlines a subtle issue with how we obtain mangled kernel names
     // which is tracked in SWDEV-137849. a_lambda_func is moved after the pfe to
     // work around this and ensure matched mangling.
-    parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+    parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
     {
        // OK. Since parallel_for_each is implemented as [[cpu, hc]] inside
     });

--- a/tests/Unit/Overload/amp_lambda_or_pfe_in_a_cpu_or_cpu_elided_function_or_lambda.cpp
+++ b/tests/Unit/Overload/amp_lambda_or_pfe_in_a_cpu_or_cpu_elided_function_or_lambda.cpp
@@ -23,7 +23,7 @@ int CPU_Func_1() [[cpu]]
 inline
 int CPU_Func_X()
 {
-  parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
   {
     // OK
   });
@@ -33,7 +33,7 @@ int CPU_Func_X()
 inline
 int CPU_Func_Y() [[cpu]]
 {
-  parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
   {
     // OK
   });
@@ -52,7 +52,7 @@ int main(void)
   CPU_Func_Y();
 
   auto a_lambda = [] () [[cpu]] {
-    parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+    parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
     {
       // OK
     });

--- a/tests/Unit/Overload/cpu_lambda_in_amp_function.cpp
+++ b/tests/Unit/Overload/cpu_lambda_in_amp_function.cpp
@@ -16,7 +16,7 @@ int main(void)
   // This test outlines a subtle issue with how we obtain mangled kernel names
   // which is tracked in SWDEV-137849. fooAMP is made inline to work around this
   // and ensure matched mangling.
-   parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+   parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
   {
     auto a_lambda = []() [[cpu]] {};// OK
   });

--- a/tests/Unit/Parse/lambda_attribute.cpp
+++ b/tests/Unit/Parse/lambda_attribute.cpp
@@ -15,7 +15,7 @@ int main() {
 
   {
     // case 1: placed between parameter list and left bracket
-    auto k1 = [=] (const index<1>& idx) __attribute__((amp)) {
+    auto k1 = [=] (const hc::index<1>& idx) __attribute__((amp)) {
       av[idx] = idx[0];
     };
   
@@ -31,7 +31,7 @@ int main() {
 
   {
     // case 2: placed between lambda introducer and parameter list
-    auto k2 = [=] __attribute__((amp)) (const index<1>& idx) {
+    auto k2 = [=] __attribute__((amp)) (const hc::index<1>& idx) {
       av[idx] = idx[0];
     };
   
@@ -47,7 +47,7 @@ int main() {
 
   {
     // case 3: placed in front of lambda introducer
-    auto k3 = __attribute__((amp)) [=] (const index<1>& idx) {
+    auto k3 = __attribute__((amp)) [=] (const hc::index<1>& idx) {
       av[idx] = idx[0];
     };
   

--- a/tests/Unit/Parse/lambda_attribute_hc.cpp
+++ b/tests/Unit/Parse/lambda_attribute_hc.cpp
@@ -15,7 +15,7 @@ int main() {
 
   {
     // case 1: placed between parameter list and left bracket
-    auto k1 = [=] (const index<1>& idx) __attribute__((hc)) {
+    auto k1 = [=] (const hc::index<1>& idx) __attribute__((hc)) {
       av[idx] = idx[0];
     };
   
@@ -31,7 +31,7 @@ int main() {
 
   {
     // case 2: placed between lambda introducer and parameter list
-    auto k2 = [=] __attribute__((hc)) (const index<1>& idx) {
+    auto k2 = [=] __attribute__((hc)) (const hc::index<1>& idx) {
       av[idx] = idx[0];
     };
   
@@ -47,7 +47,7 @@ int main() {
 
   {
     // case 3: placed in front of lambda introducer
-    auto k3 = __attribute__((hc)) [=] (const index<1>& idx) {
+    auto k3 = __attribute__((hc)) [=] (const hc::index<1>& idx) {
       av[idx] = idx[0];
     };
   

--- a/tests/Unit/RestrictionSpecifier/OKCase.cpp
+++ b/tests/Unit/RestrictionSpecifier/OKCase.cpp
@@ -32,7 +32,7 @@ int fooCPU() [[cpu]]  // OK
 
 int main(void)
 {
-  parallel_for_each(extent<1>(1), [](index<1>) [[hc]]
+  parallel_for_each(extent<1>(1), [](hc::index<1>) [[hc]]
     {
         fooAMP();
     });

--- a/tests/Unit/SharedLibrary/shared_library1.cpp
+++ b/tests/Unit/SharedLibrary/shared_library1.cpp
@@ -16,7 +16,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -34,7 +34,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 

--- a/tests/Unit/SharedLibrary/shared_library2.cpp
+++ b/tests/Unit/SharedLibrary/shared_library2.cpp
@@ -16,7 +16,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -40,7 +40,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 

--- a/tests/Unit/SharedLibrary/shared_library3.cpp
+++ b/tests/Unit/SharedLibrary/shared_library3.cpp
@@ -16,7 +16,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -40,7 +40,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 

--- a/tests/Unit/SharedLibrary/shared_library4.cpp
+++ b/tests/Unit/SharedLibrary/shared_library4.cpp
@@ -16,7 +16,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -34,7 +34,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 
@@ -58,7 +58,7 @@ int baz(int grid_size) {
 
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 3;
   }).wait();
 

--- a/tests/Unit/SharedLibrary/shared_library5.cpp
+++ b/tests/Unit/SharedLibrary/shared_library5.cpp
@@ -16,7 +16,7 @@ extern "C" int foo(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 1;
   }).wait();
 
@@ -34,7 +34,7 @@ extern "C" int bar(int grid_size) {
   extent<1> ex(grid_size);
   array_view<int, 1> av(grid_size);
 
-  parallel_for_each(ex, [=](index<1>& idx) [[hc]] {
+  parallel_for_each(ex, [=](hc::index<1>& idx) [[hc]] {
     av(idx) = 2;
   }).wait();
 


### PR DESCRIPTION
caused by  https://github.com/llvm-mirror/clang/commit/264d6736fec09b767e55b8671afb84b7fe0d051e

ambiguous names need to be fully qualified with their namespace.  Turns out there are a lot of instances where we do not do this in our tests.  The incoming upstream clang change exposes this, causing our tests to fail.  So we need to update them before we can merge this upstream change.