### PR TITLE
improve HSAQueue::wait() performance

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1624,9 +1624,22 @@ public:
                     }
                     future = nullptr;
                 }
+                else {
+                    // asyncOps queue is initialized to all nullptr.
+                    // until the queue history fills up, this condition will occur
+                    break;
+                }
             }
         }
         if (future) future->wait();
+        else {
+            DBOUTL(DB_CMD2, "HSAQueue::wait() no future, enqueued marker");
+            auto marker = EnqueueMarker(hc::no_scope);
+            std::shared_future<void>* future = marker->getFuture();
+            if (future && future->valid()) {
+                future->wait();
+            }
+        }
     }
 
     void LaunchKernel(void *ker, size_t nr_dim, size_t *global, size_t *local) override {
@@ -3993,10 +4006,14 @@ void HSAQueue::dispose() override {
         std::lock_guard<std::mutex> rl(device->rocrQueuesMutex);
         std::lock_guard<std::recursive_mutex> l(this->qmutex);
 
-        // wait on all existing kernel dispatches and barriers to complete
-        wait();
+        if (HCC_OPT_FLUSH && nextSyncNeedsSysRelease()) {
+            auto marker = EnqueueMarker(hc::system_scope);
+            DBOUTL(DB_CMD2, "HSAQueue::dispose() Sys-release needed, enqueued marker into " << *this << " to release written data " << marker);
+        }
 
         // clear asyncOps to trigger any lingering resource cleanup while we still hold the locks
+        // this implicitly waits on all remaining async ops as they destruct, including the
+        // possible marker from above
         asyncOps.clear();
 
         this->valid = false;

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1595,6 +1595,7 @@ public:
         // Ensures younger ops have chance to complete before older ops reclaim their resources
         //
 
+        std::lock_guard<std::recursive_mutex> lg(qmutex);
 
         if (HCC_OPT_FLUSH && nextSyncNeedsSysRelease()) {
 
@@ -1610,36 +1611,20 @@ public:
             printAsyncOps(std::cerr);
         }
 
-
-        std::shared_future<void>* future = nullptr;
-        {
-            std::lock_guard<std::recursive_mutex> lg(qmutex);
-            for (int i = decrement(asyncOpsIndex), count = 0; count < asyncOps.size(); i = decrement(i), ++count) {
-                if (asyncOps[i] != nullptr) {
-                    auto asyncOp = asyncOps[i];
-                    // wait on valid futures only
-                    future = asyncOp->getFuture();
-                    if (future && future->valid()) {
-                        break;
-                    }
-                    future = nullptr;
-                }
-                else {
-                    // asyncOps queue is initialized to all nullptr.
-                    // until the queue history fills up, this condition will occur
-                    break;
-                }
-            }
-        }
-        if (future) future->wait();
-        else {
-            DBOUTL(DB_CMD2, "HSAQueue::wait() no future, enqueued marker");
-            auto marker = EnqueueMarker(hc::no_scope);
-            std::shared_future<void>* future = marker->getFuture();
+        // if youngest op doesn't have a future, enqueue a marker to add the future
+        bool need_marker = true;
+        auto youngest_op = back();
+        if (youngest_op != nullptr) {
+            auto future = youngest_op->getFuture();
             if (future && future->valid()) {
-                future->wait();
+                need_marker = false;
             }
         }
+        if (need_marker) {
+            auto marker = EnqueueMarker(hc::no_scope);
+            DBOUT(DB_CMD2, "No future found in wait, enqueued marker into " << *this << "\n");
+        }
+        back()->getFuture()->wait();
     }
 
     void LaunchKernel(void *ker, size_t nr_dim, size_t *global, size_t *local) override {


### PR DESCRIPTION
Add a marker to HSAQueue::wait() in case a valid future is never found, so that the next wait() will stop its search after fewer iterations.  This new marker caused a deadlock during HSAQueue::dispose() that was resolved by removing the wait() inside dispose().