### PR TITLE
Various asyncops fixes

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -4633,13 +4633,15 @@ HSADispatch::dispose() {
         //LOG_PROFILE(this, start, end, "kernel", kname.c_str(), std::hex << "kernel="<< kernel << " " << (kernel? kernel->kernelCodeHandle:0x0) << " aql.kernel_object=" << aql.kernel_object << std::dec);
         LOG_PROFILE(this, start, end, "kernel", getKernelName(), "");
     }
+
     _activity_prof.report_gpu_timestamps<HSADispatch>(this);
-    Kalmar::ctx.releaseSignal(_signal, _signalIndex);
 
     if (future != nullptr) {
       delete future;
       future = nullptr;
     }
+
+    Kalmar::ctx.releaseSignal(_signal, _signalIndex);
 }
 
 inline uint64_t
@@ -4993,18 +4995,20 @@ HSABarrier::dispose() {
         };
         LOG_PROFILE(this, start, end, "barrier", "depcnt=" + std::to_string(depCount) + ",acq=" + fenceToString(acqBits) + ",rel=" + fenceToString(relBits), depss.str())
     }
-    _activity_prof.report_gpu_timestamps<HSABarrier>(this);
-    Kalmar::ctx.releaseSignal(_signal, _signalIndex);
 
-    // Release referecne to our dependent ops:
+    // Release references to our dependent ops:
     for (int i=0; i<depCount; i++) {
         depAsyncOps[i] = nullptr;
     }
+
+    _activity_prof.report_gpu_timestamps<HSABarrier>(this);
 
     if (future != nullptr) {
       delete future;
       future = nullptr;
     }
+
+    Kalmar::ctx.releaseSignal(_signal, _signalIndex);
 }
 
 inline uint64_t
@@ -5496,6 +5500,10 @@ HSACopy::dispose() {
     // clear reference counts for dependent ops.
     depAsyncOp = nullptr;
 
+    if (future != nullptr) {
+        delete future;
+        future = nullptr;
+    }
 
     // HSA signal may not necessarily be allocated by HSACopy instance
     // only release the signal if it was really allocated (signalIndex >= 0)
@@ -5518,11 +5526,6 @@ HSACopy::dispose() {
             LOG_PROFILE(this, start, end, "copyslo", getCopyCommandString(),  "\t" << sizeBytes << " bytes;\t" << sizeBytes/1024.0/1024 << " MB;\t" << bw << " GB/s;");
         }
         _activity_prof.report_system_ticks<HSACopy>(this, sizeBytes);
-    }
-
-    if (future != nullptr) {
-        delete future;
-        future = nullptr;
     }
 }
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -723,6 +723,10 @@ public:
 
     Kalmar::HSAQueue *hsaQueue() const;
     bool isReady() override;
+
+    static constexpr uint32_t _max_dependency_chain_length = 32;
+    uint32_t           _dependency_chain_length;
+
 protected:
     uint64_t     apiStartTick;
     HSAOpCoord   _opCoord;
@@ -5040,7 +5044,7 @@ HSAOp::HSAOp(hc::HSAOpId id, Kalmar::KalmarQueue *queue, hc::hcCommandKind comma
 
     _signalIndex(-1),
     _agent(static_cast<Kalmar::HSADevice*>(hsaQueue()->getDev())->getAgent()),
-
+    _dependency_chain_length(0),
     _activity_prof(id, _opCoord._queueId, _opCoord._deviceId)
 {
     _signal.handle=0;
@@ -5231,13 +5235,18 @@ hsa_status_t HSACopy::hcc_memory_async_copy(Kalmar::hcCommandKind copyKind, cons
             //      in streams that we depend on.
             // For both of these cases, we create an additional barrier packet in the source, and attach the desired fence.
             // Then we make the copy depend on the signal written by this command.
-            if ((depAsyncOp && depSignal.handle == 0x0) || (fenceScope != hc::no_scope)) {
+            if ((depAsyncOp && depSignal.handle == 0x0) || 
+                  (fenceScope != hc::no_scope) ||
+                  (depAsyncOp && depAsyncOp->_dependency_chain_length > _max_dependency_chain_length)) {
                 DBOUT( DB_CMD2, "  asyncCopy adding marker for needed dependency or release\n");
 
                 // Set depAsyncOp for use by the async copy below:
                 depAsyncOp = std::static_pointer_cast<HSAOp> (hsaQueue()->EnqueueMarkerWithDependency(0, nullptr, fenceScope));
                 depSignal = * (static_cast <hsa_signal_t*> (depAsyncOp->getNativeHandle()));
-            };
+            }
+            else if (depAsyncOp) {
+              this->_dependency_chain_length = depAsyncOp->_dependency_chain_length + 1;
+            }
 
             depSignalCnt = 1;
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -5497,9 +5497,6 @@ HSACopy::enqueueAsyncCopy2dCommand(size_t width, size_t height, size_t srcPitch,
 inline void
 HSACopy::dispose() {
 
-    // clear reference counts for dependent ops.
-    depAsyncOp = nullptr;
-
     if (future != nullptr) {
         delete future;
         future = nullptr;
@@ -5527,6 +5524,9 @@ HSACopy::dispose() {
         }
         _activity_prof.report_system_ticks<HSACopy>(this, sizeBytes);
     }
+
+    // clear reference counts for dependent ops.
+    depAsyncOp = nullptr;
 }
 
 inline uint64_t


### PR DESCRIPTION
This fixes detectStreamDeps essentially by determining the copy device for the current first before analyzing the dependency.  It handles the case which the copy device is unknown to the hcc runtime.

This also adds a length of the dependency chain to HSAOp so that we could detect when the chain has become too long (e.g. 32 ops for now) and break it up by inserting a new marker.  This avoids the case where each enqueue op is dependent on its previous op and preventing resources from freeing up. 

There are a couple of fixes to make sure we delete the future before releasing a signal when disposing an HSAOp.