### PR TITLE
Fix std::regex in printf causing bad_cast

### DIFF
--- a/include/hc_printf.hpp
+++ b/include/hc_printf.hpp
@@ -311,6 +311,7 @@ static inline PrintfError printf(const char* format_string, All... all) [[hc,cpu
 
 #endif
 
+#ifdef HCC_ENABLE_ACCELERATOR_PRINTF
 // regex for finding format string specifiers
 static const std::regex specifierPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([hl]*)([diuoxXfFeEgGaAcsp]){1}");
 static const std::regex signedIntegerPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([hl]*)([cdi]){1}");
@@ -386,6 +387,11 @@ static inline void processPrintfPackets(PrintfPacket* packets, const unsigned in
   }
   std::flush(std::cout);
 }
+#else
+static inline void processPrintfPackets(PrintfPacket* packets, const unsigned int numPackets) {
+  return;
+}
+#endif
 
 static inline void processPrintfBuffer(PrintfPacket* gpuBuffer) {
 


### PR DESCRIPTION
In hc_printf.hpp, static const std::regex specifierPattern(... is causing std::bad_cast. Let's guard this with a macro so that preprocessor can optimize it out by default.

Issue: Certain user env cannot process hc_printf.hpp's std::regex syntax
Fix: Use macro HCC_ENABLE_ACCELERATOR_PRINTF to exclude regex and processPrintfPackets