### PR TITLE
Add amHostUnmapped flag

### DIFF
--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -14,6 +14,7 @@ typedef int am_status_t;
 #define amHostPinned      0x1 ///< Allocate pinned host memory accessible from all GPUs.
 #define amHostNonCoherent 0x1 ///< Allocate non-coherent pinned host memory accessible from all GPUs.
 #define amHostCoherent    0x2 ///< Allocate coherent pinned host memory accessible from all GPUs.
+#define amHostUnmapped    0x4 ///< Don't map allocated pinned host memory to all GPUs. 
 
 namespace hc {
 

--- a/lib/hsa/hc_am.cpp
+++ b/lib/hsa/hc_am.cpp
@@ -280,13 +280,14 @@ auto_voidp am_aligned_alloc(std::size_t sizeBytes, hc::accelerator &acc, unsigne
                         } else {
                             hc::AmPointerInfo ampi(ptr/*hostPointer*/, ptr /*devicePointer*/, unalignedPtr, sizeBytes, acc, false/*isDevice*/, true /*isAMManaged*/);
                             g_amPointerTracker.insert(unalignedPtr,ampi);
-
-                            // Host memory is always mapped to all possible peers:
-                            auto accs = hc::accelerator::get_all();
-                            auto s2 = am_map_to_peers(ptr, accs.size(), accs.data());
-                            if (s2 != AM_SUCCESS) {
-                                hsa_amd_memory_pool_free(ptr);
-                                ptr = NULL;
+                            if(!(flags & amHostUnmapped)) {
+                                // Host memory is always mapped to all possible peers if !amHostUnmapped
+                                auto accs = hc::accelerator::get_all();
+                                auto s2 = am_map_to_peers(ptr, accs.size(), accs.data());
+                                if (s2 != AM_SUCCESS) {
+                                    hsa_amd_memory_pool_free(ptr);
+                                    ptr = NULL;
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
This resolves the double mapping of host pinned memory when used by HIP.