### PR TITLE
Remove support for libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,34 +191,6 @@ if(USE_PROF_API EQUAL 1)
 endif()
 
 #################
-# Configure which C++ runtime to use
-# hcc will use libc++ if USE_LIBCXX is set to ON; otherwise, it will use libstdc++
-#################
-
-# if USE_LIBCXX is not explicitly set
-if( NOT DEFINED USE_LIBCXX )
-  # default to libstdc++
-  set( USE_LIBCXX "OFF" )
-
-  if( CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0) )
-    # If host compiler is g++, use libc++ if version is less than 5.0
-    set( USE_LIBCXX "ON" )
-  elseif( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-    # If host compiler is clang, detect version of system g++ and use libc++ if less than 5.0
-    execute_process( COMMAND g++ -dumpversion OUTPUT_VARIABLE gplusplus_version )
-    if( gplusplus_version VERSION_LESS 5.0 )
-      set( USE_LIBCXX "ON" )
-    endif( )
-  endif( )
-endif( )
-
-# Detect libc++
-if (USE_LIBCXX)
-  find_path(LIBCXX_HEADER random PATHS /usr/local/include/c++/v1 /usr/include/c++/v1 NO_DEFAULT_PATH)
-  message( "libc++ headers found at ${LIBCXX_HEADER}" )
-endif( )
-
-#################
 # Set up version information
 #################
 
@@ -565,12 +537,6 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 
 set(HCC_GENERAL_DEBIAN_DEP "coreutils, g++-multilib, gcc-multilib, findutils, libelf1, libpci3, file")
 
-if ( USE_LIBCXX )
-  set(HCC_LIBCXX_DEBIAN_DEP ", libc++1, libc++-dev, libc++abi1, libc++abi-dev")
-else ( USE_LIBCXX )
-  set(HCC_LIBCXX_DEBIAN_DEP "")
-endif( USE_LIBCXX )
-
 # control the list of package dependency depending on whether this is an official release build.
 # for non-official release build, we want to relax the dependency on rocr runtime
 if (OFFICIAL_RELEASE_BUILD)
@@ -594,11 +560,6 @@ set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/packaging/debian/
 set(CPACK_RPM_PACKAGE_AUTOREQ 0)
 
 set(HCC_GENERAL_RPM_DEP "coreutils, findutils, elfutils-libelf, pciutils-libs, file, pth")
-if ( USE_LIBCXX )
-  set(HCC_LIBCXX_RPM_DEP ", libcxx, libcxxabi")
-else ( USE_LIBCXX )
-  set(HCC_LIBCXX_RPM_DEP "")
-endif( USE_LIBCXX )
 
 set(CPACK_RPM_PACKAGE_REQUIRES "${HCC_GENERAL_RPM_DEP} ${HCC_ROCR_DEP} ${HCC_LIBCXX_RPM_DEP}" )
 

--- a/hcc_config/CMakeLists.txt
+++ b/hcc_config/CMakeLists.txt
@@ -5,14 +5,6 @@ endif (HCC_RUNTIME_DEBUG)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../hcc_config)
 
-if (USE_LIBCXX)
-  add_definitions(-DUSE_LIBCXX  -DLIBCXX_HEADER=${LIBCXX_HEADER})
-  if (HCC_TOOLCHAIN_RHEL)
-    add_definitions(-DHCC_TOOLCHAIN_RHEL)
-  endif()
-endif (USE_LIBCXX)
-
-
 ####################
 # CodeXL Activity Logger
 ####################

--- a/hcc_config/hcc_config.cpp
+++ b/hcc_config/hcc_config.cpp
@@ -95,14 +95,6 @@ void cxxflags(void) {
         std::cout << " -hc";
     }
 
-    // extra compiler options and include paths if
-    // using the libc++ for C++ runtime
-#ifdef USE_LIBCXX
-    // Add include path to the libcxx headers
-    std::cout << " -I" XSTR(LIBCXX_HEADER) ;
-    std::cout << " -stdlib=libc++";
-#endif
-
     // Common options
     std::cout << " -std=c++amp";
 
@@ -150,12 +142,6 @@ void ldflags(void) {
         }
     }
 
-    // extra libraries if using libc++ for C++ runtime
-    // If using RHEL or CentOS, must also use c++abi
-#ifdef USE_LIBCXX
-    std::cout << " -stdlib=libc++";
-    std::cout << " -lc++ -lc++abi ";
-#endif
     std::cout << " -ldl -lm -lpthread";
 
     if (const char *p = getenv("TEST_CPU"))

--- a/include/hc_rt_debug.h
+++ b/include/hc_rt_debug.h
@@ -2,9 +2,6 @@
 
 #include <cstdlib>
 #include <cstdio>
-#ifndef USE_LIBCXX
-#include <cxxabi.h>
-#endif
 #include <iostream>
 #include <cstring>
 #include <sstream>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,13 +24,6 @@ target_compile_options(hccrt INTERFACE -hc)
 target_link_libraries(hccrt INTERFACE "-hc -L $<TARGET_FILE_DIR:$<TARGET_NAME:mcwamp>> -Wl,-rpath $<TARGET_FILE_DIR:$<TARGET_NAME:mcwamp>>" "-Wl,--whole-archive" mcwamp "-Wl,--no-whole-archive")
 target_link_libraries(hccrt INTERFACE dl m)
 
-if (USE_LIBCXX)
-  target_link_libraries(hccrt INTERFACE -stdlib=libc++)
-  if (NOT HCC_TOOLCHAIN_RHEL)
-    target_link_libraries(hccrt INTERFACE c++abi)
-  endif()
-endif (USE_LIBCXX)
-
 # Library interface for building shared libraries
 add_library(hccshared INTERFACE)
 target_link_libraries(hccshared INTERFACE -fPIC)

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -42,12 +42,6 @@ CLANG_OFFLOAD_BUNDLER=$BINDIR/clang-offload-bundler
 # always be found either in build directory or installed directory.
 CXXFLAGS="-std=c++amp -I$BINDIR/../include -I$BINDIR/../../include -fPIC"
 
-# Add additional flags if using libc++ for C++ runtime
-USE_LIBCXX=@USE_LIBCXX@
-if [ "$USE_LIBCXX" == "ON" ]; then
- CXXFLAGS+=" -stdlib=libc++ -I@LIBCXX_HEADER@"
-fi
-
 # Set additional CXXFLAGS based on CMAKE_BUILD_TYPE
 shopt -s nocasematch
 CMAKE_BUILD_TYPE="@CMAKE_BUILD_TYPE@"

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -29,9 +29,7 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
-#ifndef USE_LIBCXX
 #include <cxxabi.h>
-#endif
 
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_finalize.h>
@@ -2759,9 +2757,7 @@ public:
             if (kernelNameFormat == 1) {
                 shortName = fun; // mangled name
             } else {
-#ifndef USE_LIBCXX
                 demangled = abi::__cxa_demangle(fun, nullptr, nullptr, &demangleStatus);
-#endif
                 shortName = demangleStatus ? fun : std::string(demangled);
                 try {
                     if (demangleStatus == 0) {

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -19,17 +19,6 @@ include(ImportedTargets)
 # For example: cmake -DHCC_RUNTIME_CFLAGS=-g would configure HCC runtime be built
 # with debug information while other parts are not.
 
-macro(add_libcxx_option_if_needed name)
-  if (USE_LIBCXX)
-    target_include_directories(${name} SYSTEM PUBLIC ${LIBCXX_HEADER})
-    target_compile_options(${name} PUBLIC -stdlib=libc++)
-    if (NOT HCC_TOOLCHAIN_RHEL)
-      target_link_libraries(${name} INTERFACE c++abi)
-    endif()
-    add_definitions(-DUSE_LIBCXX)
-  endif (USE_LIBCXX)
-endmacro(add_libcxx_option_if_needed name)
-
 macro(amp_target name )
   set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
@@ -37,7 +26,6 @@ macro(amp_target name )
   target_include_directories(${name} SYSTEM PRIVATE ${GTEST_INC_DIR} ${LIBCXX_INC_DIR})
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})
   target_include_directories(${name} SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
-  add_libcxx_option_if_needed(${name})
   target_compile_options(${name} PUBLIC -hc -fPIC)
 
   # Enable debug line info only if it's a release build and HCC_RUNTIME_DEBUG is OFF
@@ -73,7 +61,6 @@ macro(add_mcwamp_library_cpu name )
   amp_target(${name})
   # LLVM and Clang shall be compiled beforehand
   add_dependencies(${name} llvm-link opt clang rocdl)
-  add_libcxx_option_if_needed(${name})
 endmacro(add_mcwamp_library_cpu name )
 
 ####################
@@ -87,7 +74,6 @@ macro(add_mcwamp_library_hsa name )
   # add HSA libraries
   target_link_libraries(${name} PUBLIC hsa-runtime64)
   target_link_libraries(${name} PRIVATE pthread)
-  add_libcxx_option_if_needed(${name})
   target_link_libraries(${name} PUBLIC hc_am)
 endmacro(add_mcwamp_library_hsa name )
 
@@ -99,7 +85,6 @@ macro(add_mcwamp_library_hc_am name )
   # add HSA libraries
   target_link_libraries(${name} PUBLIC hsa-runtime64)
   target_link_libraries(${name} PRIVATE pthread)
-  add_libcxx_option_if_needed(${name})
 endmacro(add_mcwamp_library_hc_am name )
 
 if(POLICY CMP0046)

--- a/utils/gtest/CMakeLists.txt
+++ b/utils/gtest/CMakeLists.txt
@@ -1,6 +1,1 @@
 add_mcwamp_library(mcwamp_gtest gtest_main.cc gtest-all.cc)
-
-if (USE_LIBCXX)
-  include_directories( ${LIBCXX_HEADER} )
-  target_link_libraries(mcwamp_gtest PRIVATE c++)
-endif (USE_LIBCXX)


### PR DESCRIPTION
hcc no longer maintains the support for using libc++ as the C++ runtime, remove it from the code to avoid unwanted side effects such as https://github.com/RadeonOpenCompute/hcc/issues/1092