### PR TITLE
expose an opaque pointer to accelerator::pDev

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -870,7 +870,16 @@ public:
         pQueue->set_mode(mode);
         return pQueue;
     }
-  
+
+    /**
+     * Clients can use the underlying device as an identifier for the
+     * accelerator. This complies with the equality opertor below,
+     * which says that two accelerators are the same if their pDev is
+     * the same. For example, the pointer returned here is used by HIP
+     * hostcall to track all buffers allocated on the same device.
+     */
+    const void* get_raw_device() const { return pDev; };
+
     /**
      * Compares "this" accelerator with the passed accelerator object to
      * determine if they represent the same underlying device.


### PR DESCRIPTION
Multiple accelerators can wrap the same pDev, and the equality
operator uses this to determine if two accelerators are "the
same". Exposing this as an opaque pointer allows clients to use the
pDev as a key in std::map etc when tracker per-accelerator
information.

This is used in HIP hostcall to track hostcall buffers that are
allocated per HIP device.