### PR TITLE
don't add dependency if the last op has been completed

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1533,7 +1533,9 @@ public:
             }
 
             if (needDep) {
-                if (hsa_signal_load_scacquire(*static_cast<hsa_signal_t*>(lastOp->getNativeHandle()))==0) {
+                hsa_signal_t* s = static_cast<hsa_signal_t*>(lastOp->getNativeHandle());
+                if (s->handle == 0 ||
+                    hsa_signal_load_scacquire(*s)==0) {
                     // if the last op has already been completed then don't need a dependency
                     return nullptr;
                 }

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1529,10 +1529,15 @@ public:
                 if (FORCE_SIGNAL_DEP_BETWEEN_COPIES) {
                     DBOUT(DB_CMD2, "Set NeedDep for " << newOp << "(FORCE_SIGNAL_DEP_BETWEEN_COPIES) " );
                     needDep = true;
+                    return lastOp;
                 }
             }
 
             if (needDep) {
+                if (hsa_signal_load_scacquire(*static_cast<hsa_signal_t*>(lastOp->getNativeHandle()))==0) {
+                    // if the last op has already been completed then don't need a dependency
+                    return nullptr;
+                }
                 DBOUT(DB_CMD2, "command type changed " << getHcCommandKindString(youngestCommandKind) << "  ->  " << getHcCommandKindString(newCommandKind) << "\n") ;
                 return lastOp;
             }

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1529,7 +1529,6 @@ public:
                 if (FORCE_SIGNAL_DEP_BETWEEN_COPIES) {
                     DBOUT(DB_CMD2, "Set NeedDep for " << newOp << "(FORCE_SIGNAL_DEP_BETWEEN_COPIES) " );
                     needDep = true;
-                    return lastOp;
                 }
             }
 


### PR DESCRIPTION
 When trying to detect stream dependency, check whether the last op and if it has been completed, then there's no need to report it as a dependency.  This check would avoid creating an extremely long dependency chain due to false dependencies. 