### PR TITLE
full lazy init of HSAContext

### DIFF
--- a/lib/cpu/mcwamp_cpu.cpp
+++ b/lib/cpu/mcwamp_cpu.cpp
@@ -90,3 +90,6 @@ static CPUContext ctx;
 extern "C" void *GetContextImpl() {
   return &Kalmar::ctx;
 }
+
+extern "C" void ShutdownImpl() {
+}

--- a/lib/mcwamp_impl.hpp
+++ b/lib/mcwamp_impl.hpp
@@ -5,6 +5,7 @@
 typedef void* (*PushArgImpl_t)(void *, int, size_t, const void *);
 typedef void* (*PushArgPtrImpl_t)(void *, int, size_t, const void *);
 typedef void* (*GetContextImpl_t)();
+typedef void  (*ShutdownImpl_t)();
 
 // Activity profiling routines
 typedef void (*InitActivityCallbackImpl_t)(void*, void*, void*);


### PR DESCRIPTION
HSAContext is no longer a module static object to be initialized during C++ static initialization.
HCC_LAZYINIT=ON is now the default behavior.

These changes allow dependent libraries and frameworks to be able to call fork() et al prior to
initializing the underlying HSA and kernel runtimes since HCC intialization is deferred until first use.