### PR TITLE
locked access to underlying hsa_queue_t

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -493,6 +493,22 @@ public:
     }
 
     /**
+     * @return An opaque handle of the underlying HSA queue, if the accelerator
+     *         view is based on HSA.  NULL if otherwise.
+     *
+     *         This locks the underlying RocrQueue so that the HSA
+     *         queue cannot be stolen. The caller must eventually
+     *         perform an matching release operation.
+     */
+    void* acquire_locked_hsa_queue() {
+        return pQueue->acquireLockedHsaQueue();
+    }
+
+    void release_locked_hsa_queue() {
+        pQueue->releaseLockedHsaQueue();
+    }
+
+    /**
      * Returns an opaque handle which points to the underlying HSA agent.
      *
      * @return An opaque handle of the underlying HSA agent, if the accelerator

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -256,6 +256,10 @@ public:
   /// Is the queue empty?  Same as getPendingAsyncOps but may be faster.
   virtual bool isEmpty() { return 0; }
 
+  /// get underlying native queue handle
+  virtual void* acquireLockedHsaQueue() { return nullptr; }
+  virtual void releaseLockedHsaQueue() { }
+
   /// get underlying native agent handle
   virtual void* getHSAAgent() { return nullptr; }
 


### PR DESCRIPTION
This allows a client like the HIP runtime to lock the HSA queue assigned to an accelerator_view, so that it is not stolen while the client depends on a stable mapping. The hostcall infrastructure needs this stability so that the HIP runtime can associate a hostcall buffer with an HSA queue when a kernel is being launched.