### PR TITLE
Make sure the context gets cleanup

### DIFF
--- a/lib/mcwamp.cpp
+++ b/lib/mcwamp.cpp
@@ -209,8 +209,8 @@ static RuntimeImpl* GetOrInitRuntime_impl() {
   return runtimeImpl;
 }
 
+static std::unique_ptr<RuntimeImpl> runtime;
 RuntimeImpl* GetOrInitRuntime() {
-  static std::unique_ptr<RuntimeImpl> runtime;
   static std::once_flag f;
   std::call_once(f, []() {
     runtime = std::move(std::unique_ptr<RuntimeImpl>(GetOrInitRuntime_impl()));


### PR DESCRIPTION
This fixes the breakage of HCC_PROFILE not generating the profiling information of kernels.  This is a side-effect of the context not being properly cleaned-up when the runtime gets unloaded on the lazy init path.