### PR TITLE
Disable the experimental hc::printf on all platforms

### DIFF
--- a/include/hc_printf.hpp
+++ b/include/hc_printf.hpp
@@ -15,11 +15,16 @@
 
 // The printf on the accelerator is only enabled when
 // The HCC_ENABLE_ACCELERATOR_PRINTF is defined
-//
-//#define HCC_ENABLE_ACCELERATOR_PRINTF (1)
+
+// Disabling hc::printf it's broken on certain platform
+// and this experimental feature is not longer being maintained.  
+#ifdef HCC_ENABLE_ACCELERATOR_PRINTF
+  #undef HCC_ENABLE_ACCELERATOR_PRINTF
+  #warning "The experimental hc::printf is no longer supported and is disabled"
+#endif
 
 // Indicate whether hc::printf is supported
-#define HC_FEATURE_PRINTF (1)
+//#define HC_FEATURE_PRINTF (1)
 
 // Enable extra debug messages
 #define HC_PRINTF_DEBUG  (0)

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3587,6 +3587,7 @@ public:
         }
         def = Devices[first_gpu_index + HCC_DEFAULT_GPU];
 
+#ifdef HC_PRINTF_SUPPORT_ENABLE
         // pinned hc::printf_buffer so that the GPUs could access it
         if (hc::printf_buffer_locked_va == nullptr) {
           hsa_status_t status = HSA_STATUS_SUCCESS;
@@ -3595,6 +3596,7 @@ public:
                                        hsa_agents, agents.size(), (void**)&hc::printf_buffer_locked_va);
           STATUS_CHECK(status, __LINE__);
         }
+#endif
 
         init_success = true;
     }
@@ -3621,6 +3623,7 @@ public:
         if (!init_success)
           return;
 
+#if HC_PRINTF_SUPPORT_ENABLE
         // deallocate the printf buffer
         if (HCC_ENABLE_PRINTF &&
             hc::printf_buffer != nullptr) {
@@ -3632,6 +3635,7 @@ public:
         status = hsa_amd_memory_unlock(&hc::printf_buffer);
         STATUS_CHECK(status, __LINE__);
         hc::printf_buffer_locked_va = nullptr;
+#endif
 
         // destroy all KalmarDevices associated with this context
         for (auto dev : Devices)
@@ -5792,6 +5796,8 @@ HSACopy::syncCopy() {
 // ----------------------------------------------------------------------
 
 extern "C" void *GetContextImpl() {
+
+#ifdef HC_PRINTF_SUPPORT_ENABLE
   // If hc::printf is enabled, it must be initialized *after* the Kalmar::ctx is created.
   // We only want to do this once, but the call to initPrintfBuffer will recurse back
   // into this getter. We use TLS to make sure the same thread is the one recursing.
@@ -5805,6 +5811,8 @@ extern "C" void *GetContextImpl() {
       });
     }
   }
+#endif
+
   return Kalmar::ctx;
 }
 

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -22,10 +22,11 @@ include(ImportedTargets)
 macro(amp_target name )
   set(CMAKE_CXX_COMPILER "${PROJECT_BINARY_DIR}/compiler/bin/clang++")
   add_compile_options(-std=c++11)
+
   # printf has to be disable on RHEL/CentOS 7.x due to unstable support of std::regex
-  if (NOT HCC_TOOLCHAIN_RHEL)
-    target_compile_definitions(${name} PRIVATE HC_PRINTF_SUPPORT_ENABLE)
-  endif()
+  # Disabling experimental hc::printf on all platforms due to breakage and lack of maintance
+  # target_compile_definitions(${name} PRIVATE HC_PRINTF_SUPPORT_ENABLE)
+
   target_compile_definitions(${name} PRIVATE "GTEST_HAS_TR1_TUPLE=0")
   target_include_directories(${name} SYSTEM PRIVATE ${GTEST_INC_DIR} ${LIBCXX_INC_DIR})
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})

--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_error_check.cpp
+++ b/tests/Unit/HSA/printf_error_check.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -DCHECK_PRINTF_ERROR -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_excess_args.cpp
+++ b/tests/Unit/HSA/printf_excess_args.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_minimal.cpp
+++ b/tests/Unit/HSA/printf_minimal.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <hc.hpp>

--- a/tests/Unit/HSA/printf_ptr_addr.cpp
+++ b/tests/Unit/HSA/printf_ptr_addr.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <hc.hpp>


### PR DESCRIPTION
Disabling since it has been broken on several platforms and due to lack of maintenance 