### PR TITLE
Fix queue stealing issue with queue priorities 

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1194,23 +1194,8 @@ struct RocrQueue {
     }
 
     RocrQueue(hsa_agent_t agent, size_t queue_size, HSAQueue *hccQueue, queue_priority priority)
-        : _priority(priority)
+        : _priority(priority_normal)
     {
-        // Map queue_priority to hsa_amd_queue_priority_t
-        hsa_amd_queue_priority_t queue_priority;
-        switch (priority) {
-            case priority_low:
-                queue_priority = HSA_AMD_QUEUE_PRIORITY_LOW;
-                break;
-            case priority_high:
-                queue_priority = HSA_AMD_QUEUE_PRIORITY_HIGH;
-                break;
-            case priority_normal:
-            default:
-                queue_priority = HSA_AMD_QUEUE_PRIORITY_NORMAL;
-                break;
-        }
-
         assert(queue_size != 0);
 
         /// Create a queue using the maximum size.
@@ -1220,8 +1205,7 @@ struct RocrQueue {
         STATUS_CHECK(status, __LINE__);
 
         // Set queue priority
-        status = hsa_amd_queue_set_priority(_hwQueue, queue_priority);
-        DBOUT(DB_QUEUE, "  " <<  __func__ << ": set priority for HSA command queue: " << _hwQueue << " to " << queue_priority << "\n");
+        status = setPriority(priority);
         STATUS_CHECK(status, __LINE__);
 
         // TODO - should we provide a mechanism to conditionally enable profiling as a performance optimization?
@@ -1241,6 +1225,8 @@ struct RocrQueue {
     };
 
     void assignHccQueue(HSAQueue *hccQueue);
+
+    hsa_status_t setPriority(queue_priority p);
 
     hsa_status_t setCuMask(HSAQueue *hccQueue);
 
@@ -1465,13 +1451,7 @@ public:
         asyncOps[asyncOpsIndex] = std::move(op);
         asyncOpsIndex = increment(asyncOpsIndex);
         has_been_used = true;
-
-        if (DBFLAG(DB_QUEUE)) {
-            printAsyncOps(std::cerr);
-        }
     }
-
-
 
     // Check upcoming command that will be sent to this queue against the youngest async op
     // in the queue to detect if any command dependency is required.
@@ -2154,6 +2134,37 @@ void RocrQueue::assignHccQueue(HSAQueue *hccQueue) {
     setCuMask(hccQueue);
 }
 
+hsa_status_t RocrQueue::setPriority(queue_priority p) {
+    auto status = HSA_STATUS_SUCCESS;
+    if (p != _priority) {
+          // Map queue_priority to hsa_amd_queue_priority_t
+        hsa_amd_queue_priority_t h_priority;
+        switch (p) {
+            case priority_low:
+                h_priority = HSA_AMD_QUEUE_PRIORITY_LOW;
+                break;
+            case priority_high:
+                h_priority = HSA_AMD_QUEUE_PRIORITY_HIGH;
+                break;
+            case priority_normal:
+                h_priority = HSA_AMD_QUEUE_PRIORITY_NORMAL;
+                break;
+            default:
+                {
+                    std::stringstream msg;
+                    msg << "Unknown priority value " << p;
+                    throw Kalmar::runtime_exception(msg.str().c_str(), -1);
+                }
+                break;
+        }
+        _priority = p;
+        // Set queue priority
+        status = hsa_amd_queue_set_priority(_hwQueue, h_priority);
+        DBOUT(DB_QUEUE, "Set priority for HSA command queue: " << _hwQueue << " to " << h_priority << "\n");
+    }
+    return status;
+}
+
 hsa_status_t RocrQueue::setCuMask(HSAQueue *hccQueue) {
     hsa_status_t status = HSA_STATUS_SUCCESS;
 
@@ -2253,33 +2264,45 @@ public:
                     }
                 }
             }
-
             // Second pass, try steal from a ROCR queue associated with an HCC queue, but with no active tasks
             {
                 std::lock_guard<std::mutex> lg(rocrQueuesMutex);
-                for (auto rq : rocrQueues[priority]) {
+                for (int p = priority_low; priority >= priority_high; --p) {
+                    auto& rqueues = rocrQueues[p];
+                    for (auto it = rqueues.begin(); it != rqueues.end(); ++it) {
+                        auto rq = *it;
 
-                    if (rq->_hccQueue == nullptr) {
-                        DBOUT(DB_QUEUE, "Found unused rocrQueue=" << rq << " for thief=" << thief << ".  hwQueue=" << rq->_hwQueue << "\n")
-                        // update the queue pointers to indicate the theft
-                        rq->assignHccQueue(thief);
-                        return;
-                    } else if (rq->_hccQueue != thief)  {
-                        auto victimHccQueue = rq->_hccQueue;
-                        std::lock_guard<std::recursive_mutex> l(victimHccQueue->qmutex);
-                        if (victimHccQueue->isEmpty()) {
-                            DBOUT(DB_LOCK, " ptr:" << this << " lock_guard...\n");
-                            assert (victimHccQueue->rocrQueue == rq);  // ensure the link is consistent.
-                            victimHccQueue->rocrQueue = nullptr;
-
-                            // update the queue pointers to indicate the theft:
+                        auto is_free = [thief](RocrQueue* rq) {
+                            if (rq->_hccQueue == nullptr) {
+                                DBOUT(DB_QUEUE, "Found unused rocrQueue=" << rq << "\n")
+                                return true;
+                            } else if (rq->_hccQueue != thief)  {
+                                auto victimHccQueue = rq->_hccQueue;
+                                std::lock_guard<std::recursive_mutex> l(victimHccQueue->qmutex);
+                                if (victimHccQueue->isEmpty()) {
+                                    assert (victimHccQueue->rocrQueue == rq);  // ensure the link is consistent.
+                                    victimHccQueue->rocrQueue = nullptr;
+                                    DBOUT(DB_QUEUE, "Stole existing rocrQueue=" << rq << " from victimHccQueue=" << victimHccQueue << "\n")
+                                    return true;
+                                }
+                            }
+                            return false;
+                        };
+                        
+                        if (is_free(rq)) {
+                            DBOUT(DB_QUEUE, "Assign rocrQueue=" << rq << " to thief=" << thief << ".  hwQueue=" << rq->_hwQueue << "\n");
                             rq->assignHccQueue(thief);
-                            DBOUT(DB_QUEUE, "Stole existing rocrQueue=" << rq << " from victimHccQueue=" << victimHccQueue << " to hccQueue=" << thief << "\n")
-                            return; // for
+                            if (p != priority) {
+                                auto status = rq->setPriority(priority);
+                                STATUS_CHECK(status, __LINE__);
+                                rocrQueues[priority].push_back(rq);
+                                rqueues.erase(it);
+                            }
+                            return;
                         }
                     }
                 }
-            }
+            }  // Second pass
         }
     };
 
@@ -2498,9 +2521,6 @@ public:
         STATUS_CHECK(err, __LINE__);
         return access;
     }
-
-
-
 
 
     HSADevice(hsa_agent_t a, hsa_agent_t host, int x_accSeqNum);

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -2234,7 +2234,7 @@ public:
     UnpinnedCopyEngine::CopyMode  copy_mode;
 
     // Creates or steals a rocrQueue and returns it in theif->rocrQueue
-    void createOrstealRocrQueue(Kalmar::HSAQueue *thief, queue_priority priority = priority_normal) {
+    void createOrstealRocrQueue(Kalmar::HSAQueue *thief, queue_priority priority) {
         RocrQueue *foundRQ = nullptr;
 
         // Allocate a new queue when we are below the HCC_MAX_QUEUES limit
@@ -4071,7 +4071,7 @@ void *HSAQueue::acquireLockedHsaQueue() {
     this->qmutex.lock();
     if (this->rocrQueue == nullptr) {
         auto device = static_cast<Kalmar::HSADevice*>(this->getDev());
-        device->createOrstealRocrQueue(this);
+        device->createOrstealRocrQueue(this, priority);
     }
 
     DBOUT (DB_QUEUE, "acquireLockedHsaQueue returned hwQueue=" << this->rocrQueue->_hwQueue << "\n");


### PR DESCRIPTION
This fixes an issue in queue stealing that got exposed indirectly by lazy initialization.  For a given priority level, when there's no queue created yet for this particular level and that the maximum number of queues have been reached, queue stealing will get stuck.  The fix is to look for an available queue from a different priority level, adjust the priority level and reassign.