### PR TITLE
Dont hardcode path for clang-offload-bundler

### DIFF
--- a/lib/extractkernel.in
+++ b/lib/extractkernel.in
@@ -25,10 +25,10 @@ if (!%options || defined $options{h}) {
   usage();
 }
 
-my $rocm_path = "@ROCM_ROOT@";
+my $install_prefix = "@CMAKE_INSTALL_PREFIX@";
 # set the default to rocm path
-my $llvm_objdump = "$rocm_path/hcc/bin/llvm-objdump";
-my $clang_offload_bundler = "$rocm_path/hcc/bin/clang-offload-bundler";
+my $llvm_objdump = "$install_prefix/bin/llvm-objdump";
+my $clang_offload_bundler = "$install_prefix/bin/clang-offload-bundler";
 if (defined $ENV{'HCC_HOME'}) {
   $llvm_objdump = "$ENV{'HCC_HOME'}/bin/llvm-objdump";
   $clang_offload_bundler = "$ENV{'HCC_HOME'}/bin/clang-offload-bundler";


### PR DESCRIPTION
This will use the installation path to find the clang-offload-bundler instead.