### PR TITLE
Dont make the imported hsa-runtime64 target global

### DIFF
--- a/lib/hcc-config.cmake.in
+++ b/lib/hcc-config.cmake.in
@@ -14,7 +14,7 @@ find_library(HSA_LIBRARY hsa-runtime64
     /opt/rocm/lib
 )
 
-add_library(hsa-runtime64 SHARED IMPORTED GLOBAL)
+add_library(hsa-runtime64 SHARED IMPORTED)
 
 set_target_properties(hsa-runtime64 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"


### PR DESCRIPTION
This causes problems if `find_package(hcc)` gets called twice.