### PR TITLE
Introduce KMHACKISA environment variable for ISA-level code injection.

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -34,6 +34,9 @@ KMOPTLLC="${KMOPTLLC:="-O2"}"
 # enable LLVM hijacking
 KMHACKLLVM="${KMHACKLLVM:=0}"
 
+# enable ISA hijacking
+KMHACKISA="${KMHACKISA:=0}"
+
 # enable ThinLTO
 KMTHINLTO="${KMTHINLTO:=0}"
 
@@ -68,6 +71,7 @@ LLC=$BINDIR/llc
 LINK=$BINDIR/llvm-link
 LIB=$BINDIR/../lib
 LLD=$BINDIR/ld.lld
+MC=$BINDIR/llvm-mc
 
 
 ################
@@ -126,6 +130,10 @@ do
     ;;
     --dump-dir=*)
     KMDUMPDIR="${ARG#*=}"
+    continue
+    ;;
+    --input-filename=*)
+    INPUT_FILENAME="${ARG#*=}"
     continue
     ;;
   esac
@@ -230,34 +238,56 @@ if [ $KMDUMPLLVM == "1" ]; then
   cp $2.opt.bc ${KMDUMPDIR}/dump-$AMDGPU_TARGET.opt.bc
 fi
 
-
 # Disable code object v3, generate code object v2 for now
 CODE_OBJECT_FORMAT="-mattr=-code-object-v3"
 
-if [ $KMTHINLTO == "1" ]; then
-  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
-    $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2 $2.opt.bc
-else
-  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
-    $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2.isabin $2.opt.bc
-fi
-
-# error handling for llc
-RETVAL=$?
-if [ $RETVAL != 0 ]; then
-  echo "Generating AMD GCN kernel failed in llc for target: $AMDGPU_TARGET"
-  exit $RETVAL
-fi
-
-if [ $KMDUMPISA == "1" ]; then
+if [[ $KMHACKISA == "1" && -e ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa ]]; then
+  # hijack ISA
   if [ $KMTHINLTO == "1" ]; then
-    cp $2 ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    echo "Use ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa to hijack $2"
+    $MC --triple=amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+      -filetype=obj -o $2 ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa
   else
-    cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    echo "Use ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa to hijack $2.isabin"
+    $MC --triple=amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+      -filetype=obj -o $2.isabin ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa
   fi
-  $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
-     $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=asm -o $2.isa $2.opt.bc
-  mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
+
+  if [ $KMDUMPISA == "1" ]; then
+    if [ $KMTHINLTO == "1" ]; then
+      cp $2 ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    else
+      cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    fi
+    cp ./hack-$INPUT_FILENAME-$AMDGPU_TARGET.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
+  fi
+else
+  if [ $KMTHINLTO == "1" ]; then
+    $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+      $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2 $2.opt.bc
+  else
+    $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+      $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=obj -o $2.isabin $2.opt.bc
+  fi
+  
+  # error handling for llc
+  RETVAL=$?
+  if [ $RETVAL != 0 ]; then
+    echo "Generating AMD GCN kernel failed in llc for target: $AMDGPU_TARGET"
+    exit $RETVAL
+  fi
+
+  if [ $KMDUMPISA == "1" ]; then
+    if [ $KMTHINLTO == "1" ]; then
+      cp $2 ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    else
+      cp $2.isabin ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isabin
+    fi
+  
+    $LLC -mtriple amdgcn-amd-amdhsa -mcpu=$AMDGPU_TARGET $CODE_OBJECT_FORMAT \
+       $KMOPTLLC -amdgpu-function-calls=$AMDGPU_FUNC_CALLS -filetype=asm -o $2.isa $2.opt.bc
+    mv $2.isa ${KMDUMPDIR}/dump-$AMDGPU_TARGET.isa
+  fi
 fi
 
 # ThinLTO does not performs LLD here inside clamp-device.in.

--- a/lib/hc-kernel-assemble.in
+++ b/lib/hc-kernel-assemble.in
@@ -146,9 +146,9 @@ if [ $AMDGPU_OBJ_CODEGEN == 1 ]; then
   # for each GPU target, lower to GCN ISA in HSACO format
   for AMDGPU_TARGET in ${AMDGPU_TARGET_ARRAY[@]}; do
     if [ $AMDGPU_FUNC_CALLS == "1" ]; then
-      { $CLAMP_DEVICE "$KERNEL_INPUT" "$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco" --amdgpu-target=$AMDGPU_TARGET --early-finalize --amdgpu-func-calls; } &
+      { $CLAMP_DEVICE "$KERNEL_INPUT" "$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco" --amdgpu-target=$AMDGPU_TARGET --early-finalize --amdgpu-func-calls --input-filename=`basename -s .o $2`; } &
     else
-      { $CLAMP_DEVICE "$KERNEL_INPUT" "$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco" --amdgpu-target=$AMDGPU_TARGET --early-finalize ; } &
+      { $CLAMP_DEVICE "$KERNEL_INPUT" "$TEMP_DIR/kernel-$AMDGPU_TARGET.hsaco" --amdgpu-target=$AMDGPU_TARGET --early-finalize --input-filename=`basename -s .o $2`; } &
     fi
 
     # error handling


### PR DESCRIPTION
When used with `-fno-gpu-rdc`, this allows applications to inject ISA into
object files. This flag is used for kernel developers to tweak ISA before an
optimization can be devised in the compiler.

The feature is developed for @asroy and @zjing14 . Need verification from their applications first.