### PR TITLE
use a smaller async ops vector size to reduce the number of signals

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -77,7 +77,7 @@
 #define MAX_INFLIGHT_COMMANDS_PER_QUEUE  (2*8192)
 
 // threshold to clean up finished kernel in HSAQueue.asyncOps
-int HCC_ASYNCOPS_SIZE = (2*8192);
+int HCC_ASYNCOPS_SIZE = 128;
 
 
 //---


### PR DESCRIPTION
replacing https://github.com/RadeonOpenCompute/hcc/pull/1256 since it couldn't be reopened for some reason 