### PR TITLE
hcc-config.cmake.in: avoid redundant hsa-runtime64 targets

### DIFF
--- a/lib/hcc-config.cmake.in
+++ b/lib/hcc-config.cmake.in
@@ -14,13 +14,16 @@ find_library(HSA_LIBRARY hsa-runtime64
     /opt/rocm/lib
 )
 
-add_library(hsa-runtime64 SHARED IMPORTED)
+if (NOT HSA_FOUND)
+  add_library(hsa-runtime64 SHARED IMPORTED)
 
-set_target_properties(hsa-runtime64 PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"
-  IMPORTED_LOCATION "${HSA_LIBRARY}"
-  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HSA_HEADER}"
-)
+  set_target_properties(hsa-runtime64 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+    IMPORTED_LOCATION "${HSA_LIBRARY}"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HSA_HEADER}"
+  )
+  set(HSA_FOUND YES)
+endif()
 
 include( "${CMAKE_CURRENT_LIST_DIR}/ImportedTargets.cmake" )
 include( "${CMAKE_CURRENT_LIST_DIR}/hcc-targets.cmake" )


### PR DESCRIPTION
When `hcc-config.cmake` is included multiple times, the `hsa-runtime64` target can be created multiple times, leading to errors reported by `cmake`.

Fixes https://github.com/ROCm-Developer-Tools/HIP/issues/1521