### PR TITLE
SWDEV-204509: re-enable printf on all platforms (including CentOS)

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3333,89 +3333,106 @@ private:
 
 namespace hc {
 
-#ifdef HC_PRINTF_SUPPORT_ENABLE
+static void printArgument(const std::string &spec, const PrintfPacket *ptr) {
+    switch (spec.back()) {
+    case 'c':
+    case 'd':
+    case 'i':
+      std::printf(spec.c_str(), ptr->data.li);
+      return;
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X':
+      std::printf(spec.c_str(), ptr->data.uli);
+      return;
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'g':
+    case 'G':
+    case 'a':
+    case 'A':
+      std::printf(spec.c_str(), ptr->data.d);
+      return;
+    case 's':
+    case 'p':
+      std::printf(spec.c_str(), ptr->data.cptr);
+      return;
+    }
+}
 
-// regex for finding format string specifiers
-static const std::regex specifierPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([hl]*)([diuoxXfFeEgGaAcsp]){1}");
-static const std::regex signedIntegerPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([hl]*)([cdi]){1}");
-static const std::regex unsignedIntegerPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([hl]*)([uoxX]){1}");
-static const std::regex floatPattern("(%){1}[-+#0]*[0-9]*((.)[0-9]+){0,1}([fFeEgGaA]){1}");
-static const std::regex pointerPattern("(%){1}[ps]");
-static const std::regex doubleAmpersandPattern("(%){2}");
-static const std::string ampersand("%");
+void format(const std::string &fmt, const PrintfPacket *ptr, const PrintfPacket *end) {
+  const char conv_specifiers[] = "diuoxXfFeEgGaAcsp";
+
+  size_t point = 0;
+
+  while (true) {
+    // Each segment of the format string delineated by [mark, point)
+    // is handled seprately.
+    auto mark = point;
+    point = fmt.find('%', point);
+
+    // Two different cases where a literal segment is printed out.
+    // 1. When the point reaches the end of the format string.
+    // 2. When the point is at the start of a format specifier.
+    if (point == std::string::npos) {
+      std::printf("%s", &fmt[mark]);
+      return;
+    }
+
+    std::printf("%.*s", (int)(point - mark), &fmt[mark]);
+
+    mark = point;
+    ++point;
+
+    // Handle the simplest specifier, '%%'.
+    if (fmt[point] == '%') {
+      std::printf("%%");
+      ++point;
+      continue;
+    }
+
+    // If we have run out of arguments, bail out.
+    if (ptr == end) {
+      return;
+    }
+
+    // Undefined behaviour if we don't see a conversion specifier.
+    point = fmt.find_first_of(conv_specifiers, point);
+    if (point == std::string::npos) {
+      return;
+    }
+    ++point;
+
+    // [mark,point) now contains a complete specifier.
+    const std::string spec(fmt, mark, point - mark);
+    printArgument(spec, ptr);
+    ++ptr;
+  }
+}
 
 static inline void processPrintfPackets(PrintfPacket* packets, const unsigned int numPackets) {
+  auto pkt = packets;
+  auto end = pkt + numPackets;
 
-  for (unsigned int i = 0; i < numPackets; ) {
-
-    unsigned int numPrintfArgs = packets[i++].data.ui;
+  while (pkt != end) {
+    unsigned int numPrintfArgs = pkt->data.uli;
+    ++pkt;
     if (numPrintfArgs == 0)
       continue;
 
     // get the format
-    unsigned int formatStringIndex = i++;
-    assert(packets[formatStringIndex].type == PRINTF_CHAR_PTR
-           || packets[formatStringIndex].type == PRINTF_CONST_CHAR_PTR);
-    std::string formatString((const char*)packets[formatStringIndex].data.cptr);
-    std::smatch specifierMatches;
+    assert(pkt->type == PRINTF_CHAR_PKT || pkt->type == PRINTF_CONST_CHAR_PKT);
+    const std::string formatString((const char*)pkt->data.cptr);
+    ++pkt;
 
-#if HC_PRINTF_DEBUG
-    std::printf("%s:%d \t number of matches = %d\n", __FUNCTION__, __LINE__, (int)specifierMatches.size());
-#endif
-
-    for (unsigned int j = 1; j < numPrintfArgs; ++j, ++i) {
-
-      if (!std::regex_search(formatString, specifierMatches, specifierPattern)) {
-        // More printf argument than format specifier??
-        // Just skip to the next printf request
-        i+=(numPrintfArgs - j);
-        break;
-      }
-
-      std::string specifier = specifierMatches.str();
-#if HC_PRINTF_DEBUG
-      std::cout << " (specifier found: " << specifier << ") ";
-#endif
-
-      // print the substring before the specifier
-      // clean up all the double ampersands
-      std::string prefix = specifierMatches.prefix();
-      prefix = std::regex_replace(prefix,doubleAmpersandPattern,ampersand);
-      std::printf("%s",prefix.c_str());
-
-      std::smatch specifierTypeMatch;
-      if (std::regex_search(specifier, specifierTypeMatch, unsignedIntegerPattern)) {
-        std::printf(specifier.c_str(), packets[i].data.ui);
-      } else if (std::regex_search(specifier, specifierTypeMatch, signedIntegerPattern)) {
-        std::printf(specifier.c_str(), packets[i].data.i);
-      } else if (std::regex_search(specifier, specifierTypeMatch, floatPattern)) {
-        if (packets[i].type == PRINTF_HALF)
-          std::cout << static_cast<float>(packets[i].data.h);
-        else if (packets[i].type == PRINTF_FLOAT)
-          std::printf(specifier.c_str(), packets[i].data.f);
-        else
-          std::printf(specifier.c_str(), packets[i].data.d);
-      } else if (std::regex_search(specifier, specifierTypeMatch, pointerPattern)) {
-        std::printf(specifier.c_str(), packets[i].data.cptr);
-      }
-      else {
-        assert(false);
-      }
-      formatString = specifierMatches.suffix();
-    }
-    // print the substring after the last specifier
-    // clean up all the double ampersands before printing
-    formatString = std::regex_replace(formatString,doubleAmpersandPattern,ampersand);
-    std::printf("%s",formatString.c_str());
+    format(formatString, pkt, end);
+    pkt += numPrintfArgs - 1;
   }
   std::flush(std::cout);
 }
-
-#else
-
-static inline void processPrintfPackets(PrintfPacket* packets, const unsigned int numPackets) { }
-
-#endif  // #ifdef HC_PRINTF_SUPPORT_ENABLE
 
 static inline void processPrintfBuffer(PrintfPacket* gpuBuffer) {
 
@@ -3425,7 +3442,7 @@ static inline void processPrintfBuffer(PrintfPacket* gpuBuffer) {
 
   // check whether the printf buffer is non-empty
   if (cursor !=  PRINTF_HEADER_SIZE) {
-    unsigned int bufferSize = gpuBuffer[PRINTF_BUFFER_SIZE].data.ui;
+    unsigned int bufferSize = gpuBuffer[PRINTF_BUFFER_SIZE].data.uli;
     unsigned int numPackets = ((bufferSize<cursor)?bufferSize:cursor) - PRINTF_HEADER_SIZE;
 
     processPrintfPackets(gpuBuffer+PRINTF_HEADER_SIZE, numPackets);
@@ -3623,7 +3640,6 @@ public:
         }
         def = Devices[first_gpu_index + HCC_DEFAULT_GPU];
 
-#ifdef HC_PRINTF_SUPPORT_ENABLE
         // pinned hc::printf_buffer so that the GPUs could access it
         if (hc::printf_buffer_locked_va == nullptr) {
           hsa_status_t status = HSA_STATUS_SUCCESS;
@@ -3632,7 +3648,6 @@ public:
                                        hsa_agents, agents.size(), (void**)&hc::printf_buffer_locked_va);
           STATUS_CHECK(status, __LINE__);
         }
-#endif
 
         init_success = true;
     }
@@ -3659,7 +3674,6 @@ public:
         if (!init_success)
           return;
 
-#if HC_PRINTF_SUPPORT_ENABLE
         // deallocate the printf buffer
         if (HCC_ENABLE_PRINTF &&
             hc::printf_buffer != nullptr) {
@@ -3671,7 +3685,6 @@ public:
         status = hsa_amd_memory_unlock(&hc::printf_buffer);
         STATUS_CHECK(status, __LINE__);
         hc::printf_buffer_locked_va = nullptr;
-#endif
 
         // destroy all KalmarDevices associated with this context
         for (auto dev : Devices)
@@ -5827,8 +5840,6 @@ HSACopy::syncCopy() {
 // ----------------------------------------------------------------------
 
 extern "C" void *GetContextImpl() {
-
-#ifdef HC_PRINTF_SUPPORT_ENABLE
   // If hc::printf is enabled, it must be initialized *after* the Kalmar::ctx is created.
   // We only want to do this once, but the call to initPrintfBuffer will recurse back
   // into this getter. We use TLS to make sure the same thread is the one recursing.
@@ -5842,8 +5853,6 @@ extern "C" void *GetContextImpl() {
       });
     }
   }
-#endif
-
   return Kalmar::ctx;
 }
 

--- a/scripts/cmake/MCWAMP.cmake
+++ b/scripts/cmake/MCWAMP.cmake
@@ -25,10 +25,6 @@ macro(amp_target name )
   add_definitions(-DHCC_MAJOR_VERSION=${HCC_VERSION_MAJOR})
   add_definitions(-DHCC_MINOR_VERSION=${HCC_VERSION_MINOR})
 
-  # printf has to be disable on RHEL/CentOS 7.x due to unstable support of std::regex
-  # Disabling experimental hc::printf on all platforms due to breakage and lack of maintance
-  # target_compile_definitions(${name} PRIVATE HC_PRINTF_SUPPORT_ENABLE)
-
   target_compile_definitions(${name} PRIVATE "GTEST_HAS_TR1_TUPLE=0")
   target_include_directories(${name} SYSTEM PRIVATE ${GTEST_INC_DIR} ${LIBCXX_INC_DIR})
   target_include_directories(${name} PRIVATE ${MCWAMP_INC_DIR})

--- a/tests/Unit/HSA/printf.cpp
+++ b/tests/Unit/HSA/printf.cpp
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_error_check.cpp
+++ b/tests/Unit/HSA/printf_error_check.cpp
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -DCHECK_PRINTF_ERROR -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_excess_args.cpp
+++ b/tests/Unit/HSA/printf_excess_args.cpp
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <cassert>

--- a/tests/Unit/HSA/printf_minimal.cpp
+++ b/tests/Unit/HSA/printf_minimal.cpp
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <hc.hpp>

--- a/tests/Unit/HSA/printf_ptr_addr.cpp
+++ b/tests/Unit/HSA/printf_ptr_addr.cpp
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: %hc %s -DHCC_ENABLE_ACCELERATOR_PRINTF -lhc_am -o %t.out && %t.out | %FileCheck %s
 
 #include <hc.hpp>


### PR DESCRIPTION
printf was because std::regex is broken on CentOS. The dependence on
std::regex is now removed.