### PR TITLE
remove __attribute__((used)) from math instrinsic wrappers

### DIFF
--- a/include/kalmar_math.h
+++ b/include/kalmar_math.h
@@ -290,7 +290,7 @@ extern "C" _Float16 __ocml_trunc_f16(_Float16 x) [[hc]];
 extern "C" float __ocml_trunc_f32(float x) [[hc]];
 extern "C" double __ocml_trunc_f64(double x) [[hc]];
 
-#define HCC_MATH_LIB_FN inline __attribute__((used, hc))
+#define HCC_MATH_LIB_FN inline __attribute__((hc))
 namespace Kalmar
 {
     namespace fast_math


### PR DESCRIPTION
an upstream clang commit: 8f089f2099d39021bbfb76a2cd575612382a7cf6 exposes this issue, where because we have __attribute__((used)) on our intrinsic wrappers, we end with superfluous calls to (actually) unused intrinsics.

https://github.com/llvm/llvm-project/commit/8f089f2099d39021bbfb76a2cd575612382a7cf6