### PR TITLE
Work around ppc64[le] lack of Float16 native hardware support

### DIFF
--- a/include/kalmar_math.h
+++ b/include/kalmar_math.h
@@ -10,6 +10,10 @@
 #include <cmath>
 #include <stdexcept>
 
+#ifdef __PPC64__
+#define _Float16 __fp16
+#endif
+
 extern "C" _Float16 __ocml_acos_f16(_Float16 x) [[hc]];
 extern "C" float __ocml_acos_f32(float x) [[hc]];
 extern "C" double __ocml_acos_f64(double x) [[hc]];


### PR DESCRIPTION
This fixes the failure to build on POWER platforms.  Some additional information on Float16 and how it can reduce portability is available here:

https://reviews.llvm.org/D35295