### PR TITLE
Enable frame pointer elimination

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -29,7 +29,9 @@ KMOPTOPT="${KMOPTOPT:="-O3"}"
 # pass extra options to LLC
 # KMOPTLLC can be used to pass last-minute options to llc in the backend
 # if not set, then "-O2" will be passed to llc
-KMOPTLLC="${KMOPTLLC:="-O2"}"
+# add "--frame-pointer=none" as a default option to lllc to enable
+# frame pointer elimination thus saving a few registers for SGPR spill
+KMOPTLLC="${KMOPTLLC:="-O2 --frame-pointer=none"}"
 
 # enable LLVM hijacking
 KMHACKLLVM="${KMHACKLLVM:=0}"

--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -29,7 +29,9 @@ KMOPTOPT="${KMOPTOPT:="-O3"}"
 # pass extra options to LLC
 # KMOPTLLC can be used to pass last-minute options to llc in the backend
 # if not set, then "-O2" will be passed to llc
-KMOPTLLC="${KMOPTLLC:="-O2"}"
+# add "--frame-pointer=none" as a default option to llc to enable
+# frame pointer elimination thus saving a few registers for SGPR spill
+KMOPTLLC="${KMOPTLLC:="-O2 --frame-pointer=none"}"
 
 # enable LLVM hijacking
 KMHACKLLVM="${KMHACKLLVM:=0}"


### PR DESCRIPTION
Enabling frame pointer elimination as default option will allow to save a few registers, which can now be used for SGPR spill.