### PR TITLE
[CMake] workaround installation problem SLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,8 +600,10 @@ set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${PROJECT_BINARY_DIR}/packaging/debian/
 # disable automatic shared libraries dependency detection
 set(CPACK_RPM_PACKAGE_AUTOREQ 0)
 
-if( "${DISTRO_ID}" MATCHES "sles" )
-   set(HCC_GENERAL_RPM_DEP "coreutils, findutils, libelf-devel, pciutils, file, perl-File-BaseDir, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")
+if("${DISTRO_ID}" MATCHES "opensuse" OR
+   "${DISTRO_ID}" MATCHES "suse" OR
+   "${DISTRO_ID}" MATCHES "sles" )
+   set(HCC_GENERAL_RPM_DEP "coreutils, findutils, libelf-devel, pciutils, file, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")
 else()
    set(HCC_GENERAL_RPM_DEP "coreutils, findutils, elfutils-libelf, pciutils-libs, file, pth, perl-File-BaseDir, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")
 endif ()


### PR DESCRIPTION
The extractkernel depends on dirname() from perl-File-BaseDir.
The package is shown to be available by zypper; however it couldn't
be installed properly.  However, it seems that dirname() is still
available even if that package is not installed on SLES so removing
perl-File-BaseDir as dependency for the SLES installer package.