### PR TITLE
Re-enable flushing of printf buffer at application exit

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -3683,12 +3683,6 @@ public:
         if (!init_success)
           return;
 
-#if 0
-        // For reasons that we don't understand, the printf buffer
-        // occasionally disappears before this point. As a workaround,
-        // we avoid accessing the printf buffer here.
-        //
-        // deallocate the printf buffer
         if (HCC_ENABLE_PRINTF &&
             hc::printf_buffer != nullptr) {
            // do a final flush
@@ -3696,7 +3690,7 @@ public:
 
            hc::deletePrintfBuffer(hc::printf_buffer);
         }
-#endif
+
         status = hsa_amd_memory_unlock(&hc::printf_buffer);
         STATUS_CHECK(status, __LINE__);
         hc::printf_buffer_locked_va = nullptr;


### PR DESCRIPTION
This is potential fix for SWDEV-216718.

PR #1290 had worked around a crash in printf by disabling the final
access to the printf buffer when the application exits. This may have
resulted in cases where printf produces no result. After PR #1296 it
might be possible to re-enable this final flush without crashing.

Change-Id: Ic61074a3d56148e98cf1e23c688fc570ad994544