### PR TITLE
increase KERNARG_BUFFER_SIZE from 512 to 4k

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -61,7 +61,10 @@
 // kernel dispatch speed optimization flags
 /////////////////////////////////////////////////
 
-// size of default kernarg buffer in the kernarg pool in HSAContext
+// Size of default kernarg buffer in the kernarg pool in HSAContext, in bytes.
+// Increased from 512 to 4k to match CUDA default. See
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#function-parameters
+// When this size is exceeded, on-demand allocation of the kernarg buffer is slow.
 #define KERNARG_BUFFER_SIZE (4096)
 
 // number of pre-allocated kernarg buffers in HSAContext
@@ -75,7 +78,9 @@
 // MUST be a power of 2.
 #define MAX_INFLIGHT_COMMANDS_PER_QUEUE  (2*8192)
 
-// threshold to clean up finished kernel in HSAQueue.asyncOps
+// Threshold to clean up finished kernel in HSAQueue.asyncOps.
+// Reduced from 16k to 1k at the same time when the HCC_KERNARG_BUFFER_SIZE
+// was increased, in order to offset the increase in memory pressure.
 int HCC_ASYNCOPS_SIZE = (1024);
 
 

--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -62,7 +62,7 @@
 /////////////////////////////////////////////////
 
 // size of default kernarg buffer in the kernarg pool in HSAContext
-#define KERNARG_BUFFER_SIZE (512)
+#define KERNARG_BUFFER_SIZE (4096)
 
 // number of pre-allocated kernarg buffers in HSAContext
 // (some kernels don't allocate signals but nearly all need kernargs)
@@ -76,7 +76,7 @@
 #define MAX_INFLIGHT_COMMANDS_PER_QUEUE  (2*8192)
 
 // threshold to clean up finished kernel in HSAQueue.asyncOps
-int HCC_ASYNCOPS_SIZE = (2*8192);
+int HCC_ASYNCOPS_SIZE = (1024);
 
 
 //---


### PR DESCRIPTION
Decrease HCC_ASYNCOPS_SIZE from 16k to 1k.
HCC_KERNARG_BUFFER_SIZE is now an environment variable.
HCC_KERNARG_POOL_SIZE is now an environment variable.