### PR TITLE
add nullptr check to isEmpty()

### DIFF
--- a/lib/hsa/mcwamp_hsa.cpp
+++ b/lib/hsa/mcwamp_hsa.cpp
@@ -1585,7 +1585,11 @@ public:
     bool isEmptyNoLock() {
         if (!has_been_used) return true;
 
-        hsa_signal_t signal = *(static_cast <hsa_signal_t*> (back()->getNativeHandle()));
+        auto lastOp = back();
+
+        if (lastOp.get() == nullptr) return true;
+
+        hsa_signal_t signal = *(static_cast <hsa_signal_t*> (lastOp->getNativeHandle()));
         if (signal.handle) {
             hsa_signal_value_t v = hsa_signal_load_scacquire(signal);
             if (v != 0) {


### PR DESCRIPTION
This fixes a corner case where `has_been_used` can be true and yet `back()` returns a `nullptr`, resulting in seg fault.  This can happen if the HSA queue is acquired before any HSAOp is created. 