### PR TITLE
restore error return for 2D SDMA copy, fix completion_future valid()

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -1280,7 +1280,15 @@ public:
      * completion_future is associated with an asynchronous operation.
      */
     bool valid() const {
-        return __amp_future.valid();
+        if (__amp_future.valid()) {
+            if (__asyncOp != nullptr) throw runtime_exception("completion_future expected amp, had async op", 0);
+            return true;
+        }
+        if (__asyncOp != nullptr) {
+            if (__amp_future.valid()) throw runtime_exception("completion_future expected async op, had amp", 0);
+            return true;
+        }
+        return false;
     }
 
     /** @{ */
@@ -1629,7 +1637,10 @@ accelerator_view::copy2d_async_ext(const void *src, void *dst, size_t width, siz
                              const hc::AmPointerInfo &srcInfo, const hc::AmPointerInfo &dstInfo,
                              const hc::accelerator *copyAcc)
 {
-    return completion_future(pQueue->EnqueueAsyncCopy2dExt(src, dst, width, height, srcPitch, dstPitch, copyDir, srcInfo, dstInfo, copyAcc ? copyAcc->pDev : nullptr));
+    const auto& asyncOp = pQueue->EnqueueAsyncCopy2dExt(src, dst, width, height, srcPitch, dstPitch, copyDir, srcInfo, dstInfo, copyAcc ? copyAcc->pDev : nullptr);
+    if (asyncOp == nullptr)
+        return completion_future();
+    return completion_future(asyncOp);
 };
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
PR #1317 inadvertently backed out changes to add reporting of a failed 2D SDMA copy,
originally added in PR #1061. This commit restores those changes.

Further, the implementation of hc::completion_future valid() was incorrect after #1317.
valid() should also check if an asyncOp is present, since we no longer construct a shared_future.