### PR TITLE
remove chmod 777 /opt/rocm from docker files

### DIFF
--- a/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
+++ b/docker/dockerfile-auto-upstream-merge-ubuntu-16.04
@@ -29,8 +29,6 @@ ENV PATH="$HCC_HOME/bin:$HIP_PATH/bin:${PATH}"
 ENV PATH="$ROCM_PATH/bin:${PATH}"
 ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 
-RUN chmod 777 $(find /opt/rocm -type d)
-
 RUN wget https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-386-2.3.0-pre10.tgz
 RUN tar -xf hub-linux-386-2.3.0-pre10.tgz
 RUN hub-linux-386-2.3.0-pre10/install

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -42,5 +42,3 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     hsa-rocr-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-RUN chmod 777 $(find /opt/rocm -type d)


### PR DESCRIPTION
This RUN command is no longer needed; and is interfering with image/container creation since rocm 3.1