### PR TITLE
add hsa-ext-rocr-dev to docker build file

### DIFF
--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -39,7 +39,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libnuma-dev \
     rocm-utils \
     rocminfo \
-    hsa-rocr-dev && \
+    hsa-rocr-dev \
+    hsa-ext-rocr-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
adding hsa-ext-rocr-dev to the base HCC docker file resolves the failing testcases that can't find "libhsa-runtime64.so.1".