### PR TITLE
add accelerator_view::create_marker(hsa_barrier_and_packet_t)

### DIFF
--- a/include/hc.hpp
+++ b/include/hc.hpp
@@ -268,6 +268,24 @@ public:
 
     /**
      * This command inserts a marker event into the accelerator_view's command
+     * queue. This marker is returned as a completion_future object. When all
+     * commands that were submitted prior to the marker event creation have
+     * completed, the future is ready.
+     *
+     * Regardless of the accelerator_view's execute_order (execute_any_order, execute_in_order),
+     * the marker always ensures older commands complete before the returned completion_future
+     * is marked ready.   Thus, markers provide a mechanism to enforce order between
+     * commands in an execute_any_order accelerator_view.
+     *
+     * Memory acquire and release fences are inferred from the AQL packet header, as well as any possible completion_signal.
+     *
+     * @return A future which can be waited on, and will block until the
+     *         current batch of commands has completed.
+     */
+    completion_future create_marker(const hsa_barrier_and_packet_t *aql) const;
+
+    /**
+     * This command inserts a marker event into the accelerator_view's command
      * queue with a prior dependent asynchronous event.
      *
      * This marker is returned as a completion_future object. When its
@@ -1555,6 +1573,21 @@ accelerator_view::create_marker(memory_scope scope) const {
     }
 
     return completion_future(pQueue->EnqueueMarkerWithDependency(cnt, deps, scope));
+}
+
+inline completion_future
+accelerator_view::create_marker(const hsa_barrier_and_packet_t *aql) const {
+    std::shared_ptr<Kalmar::KalmarAsyncOp> deps[1];
+    // If necessary create an explicit dependency on previous command
+    // This is necessary for example if copy command is followed by marker - we need the marker to wait for the copy to complete.
+    std::shared_ptr<Kalmar::KalmarAsyncOp> depOp = pQueue->detectStreamDeps(hcCommandMarker, nullptr);
+
+    int cnt = 0;
+    if (depOp) {
+        deps[cnt++] = depOp; // retrieve async op associated with completion_future
+    }
+
+    return completion_future(pQueue->EnqueueMarkerWithDependency(cnt, deps, aql));
 }
 
 inline unsigned int accelerator_view::get_version() const { return get_accelerator().get_version(); }

--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -10,6 +10,7 @@ class completion_future;
 }; // end namespace hc
 
 typedef struct hsa_kernel_dispatch_packet_s hsa_kernel_dispatch_packet_t;
+typedef struct hsa_barrier_and_packet_s hsa_barrier_and_packet_t;
 
 namespace Kalmar {
 namespace enums {
@@ -287,6 +288,9 @@ public:
 
   /// enqueue marker with prior dependency
   virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(int count, std::shared_ptr <KalmarAsyncOp> *depOps, memory_scope scope) { return nullptr; }
+
+  /// enqueue marker with prior dependency
+  virtual std::shared_ptr<KalmarAsyncOp> EnqueueMarkerWithDependency(int count, std::shared_ptr <KalmarAsyncOp> *depOps, const hsa_barrier_and_packet_t *aql) { return nullptr; }
 
   virtual std::shared_ptr<KalmarAsyncOp> detectStreamDeps(hcCommandKind commandKind, KalmarAsyncOp *newCopyOp) { return nullptr; };
 


### PR DESCRIPTION
Similar to how `hc::accelerator_view::dispatch_hsa_kernel` allows the caller to pass their own `hsa_kernel_dispatch_packet_t`, add a new function `accelerator_view::create_marker(hsa_barrier_and_packet_t)`.  It behaves nearly identically to `accelerator_view::create_marker(hc::memory_scope)`, but now the caller can specify a nearly complete aql packet.  This could be used to indicate both acq and rel scope as well as an associated hsa signal with a non-default starting value.