### PR TITLE
SWDEV-225038: disable relaxed uniform regions in structurizer

### DIFF
--- a/lib/clamp-device.in
+++ b/lib/clamp-device.in
@@ -30,7 +30,7 @@ KMOPTOPT="${KMOPTOPT:="-O3"}"
 # KMOPTLLC can be used to pass last-minute options to llc in the backend
 # add "--frame-pointer=none" as deafult option to llc to enable frame
 # pointer elimination, so saved registers can be used for SGPR spill
-KMOPTLLC="${KMOPTLLC:="--frame-pointer=none"}"
+KMOPTLLC="${KMOPTLLC:="--frame-pointer=none --structurizecfg-relaxed-uniform-regions=false"}"
 
 # enable LLVM hijacking
 KMHACKLLVM="${KMHACKLLVM:=0}"


### PR DESCRIPTION
The LLVM structurizer includes a local relaxation on the criteria that
define uniform regions, that was introduced in [1] and eventually
enabled by default in [2].

[1] https://reviews.llvm.org/D62198
[2] https://reviews.llvm.org/D63198

But this relaxation is affecting correctness. For example, in
SWDEV-225038, for different combinations of compiler version and app
version, it is possible to either make the app hang or produce
incorrect results.

For now, we disable this relaxation in HCC until we have a complete
resolution in LLVM itself.