### PR TITLE
fix creation of /opt/rocm soft link

### DIFF
--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -38,10 +38,15 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     cmake \
     libnuma-dev \
     rocm-utils \
-    rocminfo \
-    hsa-rocr-dev \
-    hsa-ext-rocr-dev && \
+    rocminfo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -sd `realpath /opt/rocm-*` /opt/rocm
+RUN chmod -R 777 /opt/rocm
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
+    curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main | tee /etc/apt/sources.list.d/rocm.list && \
+    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    hsa-rocr-dev hsa-ext-rocr-dev

--- a/packaging/debian/postinst.in
+++ b/packaging/debian/postinst.in
@@ -30,9 +30,12 @@ SOFTLINKS=(
 
 do_softlinks() {
 
+  ln -sd `realpath /opt/rocm-*` $ROCM_PATH
+ 
   mkdir -p "$ROCM_PATH/lib"
   mkdir -p "$ROCM_PATH/lib/cmake"
   mkdir -p "$ROCM_PATH/bin"
+  mkdir -p "$ROCM_PATH/include"
 
   if [ -L "$ROCM_PATH/hcc" ] ; then
     rm -f "$ROCM_PATH/hcc" 


### PR DESCRIPTION
We need to install ROCr (HSA RT) after we create the soft link, otherwise the symlinks in the HSA lib do not get created properly on the ROCr install.