### PR TITLE
An optimization to the function of findGlobalPool

### DIFF
--- a/include/kalmar_runtime.h
+++ b/include/kalmar_runtime.h
@@ -421,13 +421,18 @@ public:
         });
         return def;
 #else
+        std::shared_ptr<KalmarQueue> result;
         std::thread::id tid = std::this_thread::get_id();
-        tlsDefaultQueueMap_mutex.lock();
-        if (tlsDefaultQueueMap.find(tid) == tlsDefaultQueueMap.end()) {
-            tlsDefaultQueueMap[tid] = createQueue();
+        if (tlsDefaultQueueMap.find(tid) != tlsDefaultQueueMap.end()) {
+            result = tlsDefaultQueueMap[tid];
+        } else {
+            tlsDefaultQueueMap_mutex.lock();
+            if (tlsDefaultQueueMap.find(tid) == tlsDefaultQueueMap.end()) {
+                tlsDefaultQueueMap[tid] = createQueue();
+            }
+            result = tlsDefaultQueueMap[tid];
+            tlsDefaultQueueMap_mutex.unlock();
         }
-        std::shared_ptr<KalmarQueue> result = tlsDefaultQueueMap[tid];
-        tlsDefaultQueueMap_mutex.unlock();
         return result;
 #endif
     }

--- a/lib/hsa/unpinned_copy_engine.cpp
+++ b/lib/hsa/unpinned_copy_engine.cpp
@@ -52,6 +52,7 @@ static hsa_status_t findGlobalPool(hsa_amd_memory_pool_t pool, void* data)
     if ((HSA_AMD_SEGMENT_GLOBAL == segment) &&
         (flag & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED)) {
         *((hsa_amd_memory_pool_t*)data) = pool;
+        return HSA_STATUS_INFO_BREAK;
     }
     return HSA_STATUS_SUCCESS;
 }
@@ -96,6 +97,7 @@ UnpinnedCopyEngine::UnpinnedCopyEngine(hsa_agent_t hsaAgent, hsa_agent_t cpuAgen
 {
     hsa_amd_memory_pool_t sys_pool;
     hsa_status_t err = hsa_amd_agent_iterate_memory_pools(_cpuAgent, findGlobalPool, &sys_pool);
+    ErrorCheck(err);
 
     // Generate a packed C-style array of agents, for use below with hsa_amd_agents_allow_access
     // TODO - should this include the CPU agents as well?


### PR DESCRIPTION
In findGlobalPool, return HSA_STATUS_INFO_BREAK instead of HSA_STATUS_SUCCESS when a fine grained global pool is found, so as to avoid useless iterations when called in the constructor of UnpinnedCopyEngine. Also add an ErrorCheck after this call.