### PR TITLE
correct HCC package requirements for centos 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,9 +605,9 @@ if("${DISTRO_ID}" MATCHES "opensuse" OR
    "${DISTRO_ID}" MATCHES "suse" OR
    "${DISTRO_ID}" MATCHES "sles" )
    set(HCC_GENERAL_RPM_DEP "coreutils, findutils, libelf-devel, pciutils, file, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")
-elseif( "${DISTRO_ID}" MATCHES "centos" OR 
-        "${DISTRO_ID}" MATCHES "redhatenterpriseserver" AND 
-        "${DISTRO_RELEASE}" MATCHES "^7")
+elseif( ("${DISTRO_ID}" MATCHES "centos" OR
+        "${DISTRO_ID}" MATCHES "redhatenterpriseserver") AND
+        "${DISTRO_RELEASE}" MATCHES "7")
     set(HCC_GENERAL_RPM_DEP "coreutils, findutils, elfutils-libelf, pciutils-libs, file, pth, perl-File-BaseDir, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")
 else()
    set(HCC_GENERAL_RPM_DEP "coreutils, findutils, elfutils-libelf, pciutils-libs, file, npth, perl-File-BaseDir, perl-File-Copy-Recursive, perl-File-Listing, perl-File-Which")


### PR DESCRIPTION
My original fix got the order of conditional expressions backwards, OR is evaluated last.