### PR TITLE
Remove strict /opt/rocm references from tests

### DIFF
--- a/tests/Unit/AcceleratorViewCopy/avcopy_classic.cpp
+++ b/tests/Unit/AcceleratorViewCopy/avcopy_classic.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -o %t.out -lhc_am -L/opt/rocm/lib -lhsa-runtime64 && %t.out
+// RUN: %hc %s -I%hsa_header_path -lhc_am -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 //
 // Test "classic" GPU pattern of H2D copies, followed by Kernels, followed by
 // D2H.
@@ -7,7 +7,7 @@
 #include <hc.hpp>
 #include <hc_am.hpp>
 
-#include "/opt/rocm/include/hsa/hsa.h"
+#include <hsa/hsa.h>
 
 #include <algorithm>
 #include <cassert>

--- a/tests/Unit/AcceleratorViewCopy/copy_coherency.cpp
+++ b/tests/Unit/AcceleratorViewCopy/copy_coherency.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -o %t.out -lhc_am -L/opt/rocm/lib -lhsa-runtime64 && %t.out
+// RUN: %hc %s -I%hsa_header_path -lhc_am -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 //
 // Test coherency and flushes.  Need to flush GPU caches before H2D copy
 

--- a/tests/Unit/AcceleratorViewCopy/copy_coherency2.cpp
+++ b/tests/Unit/AcceleratorViewCopy/copy_coherency2.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -o %t.out -lhc_am -L/opt/rocm/lib -lhsa-runtime64 && %t.out
+// RUN: %hc %s -I%hsa_header_path -lhc_am -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 //
 // Test coherency and flushes.  Need to flush GPU caches before H2D copy
 

--- a/tests/Unit/DispatchAql/dispatch_hsa_kernel.cpp
+++ b/tests/Unit/DispatchAql/dispatch_hsa_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s %S/hsacodelib.CPP -I/opt/rocm/include -L/opt/rocm/lib -lhsa-runtime64 -lhc_am -o %t.out && %t.out %S/vcpy_isa.hsaco
+// RUN: %hc %s %S/hsacodelib.CPP -I%hsa_header_path -L%hsa_library_path -lhsa-runtime64 -lhc_am -o %t.out && %t.out %S/vcpy_isa.hsaco
 
 #include <hc.hpp>
 

--- a/tests/Unit/HC/create_blocking_marker.cpp
+++ b/tests/Unit/HC/create_blocking_marker.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -I/opt/rocm/hsa/include -L/opt/rocm/lib -lhsa-runtime64 -o %t.out && %t.out
+// RUN: %hc %s -I%hsa_header_path -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 
 #include <hc.hpp>
 

--- a/tests/Unit/HC/create_blocking_marker2.cpp
+++ b/tests/Unit/HC/create_blocking_marker2.cpp
@@ -1,4 +1,4 @@
-// RUN: %hc %s -I/opt/rocm/hsa/include -L/opt/rocm/lib -lhsa-runtime64 -o %t.out && %t.out
+// RUN: %hc %s -I%hsa_header_path -L%hsa_library_path -lhsa-runtime64 -o %t.out && %t.out
 
 #include <hc.hpp>
 


### PR DESCRIPTION
HCC tests contain some strict references to /opt/rocm that cause test failures if the HSA library is located elsewhere.